### PR TITLE
mGPU support for DirectX Tool Kit

### DIFF
--- a/Inc/GeometricPrimitive.h
+++ b/Inc/GeometricPrimitive.h
@@ -30,19 +30,19 @@ namespace DirectX
         using VertexType = VertexPositionNormalTexture;
 
         // Factory methods.
-        static std::unique_ptr<GeometricPrimitive> __cdecl CreateCube(float size = 1, bool rhcoords = true);
-        static std::unique_ptr<GeometricPrimitive> __cdecl CreateBox(const XMFLOAT3& size, bool rhcoords = true, bool invertn = false);
-        static std::unique_ptr<GeometricPrimitive> __cdecl CreateSphere(float diameter = 1, size_t tessellation = 16, bool rhcoords = true, bool invertn = false);
-        static std::unique_ptr<GeometricPrimitive> __cdecl CreateGeoSphere(float diameter = 1, size_t tessellation = 3, bool rhcoords = true);
-        static std::unique_ptr<GeometricPrimitive> __cdecl CreateCylinder(float height = 1, float diameter = 1, size_t tessellation = 32, bool rhcoords = true);
-        static std::unique_ptr<GeometricPrimitive> __cdecl CreateCone(float diameter = 1, float height = 1, size_t tessellation = 32, bool rhcoords = true);
-        static std::unique_ptr<GeometricPrimitive> __cdecl CreateTorus(float diameter = 1, float thickness = 0.333f, size_t tessellation = 32, bool rhcoords = true);
-        static std::unique_ptr<GeometricPrimitive> __cdecl CreateTetrahedron(float size = 1, bool rhcoords = true);
-        static std::unique_ptr<GeometricPrimitive> __cdecl CreateOctahedron(float size = 1, bool rhcoords = true);
-        static std::unique_ptr<GeometricPrimitive> __cdecl CreateDodecahedron(float size = 1, bool rhcoords = true);
-        static std::unique_ptr<GeometricPrimitive> __cdecl CreateIcosahedron(float size = 1, bool rhcoords = true);
-        static std::unique_ptr<GeometricPrimitive> __cdecl CreateTeapot(float size = 1, size_t tessellation = 8, bool rhcoords = true);
-        static std::unique_ptr<GeometricPrimitive> __cdecl CreateCustom(const std::vector<VertexType>& vertices, const std::vector<uint16_t>& indices);
+        static std::unique_ptr<GeometricPrimitive> __cdecl CreateCube(float size = 1, bool rhcoords = true, _In_opt_ ID3D12Device* device = nullptr);
+        static std::unique_ptr<GeometricPrimitive> __cdecl CreateBox(const XMFLOAT3& size, bool rhcoords = true, bool invertn = false, _In_opt_ ID3D12Device* device = nullptr);
+        static std::unique_ptr<GeometricPrimitive> __cdecl CreateSphere(float diameter = 1, size_t tessellation = 16, bool rhcoords = true, bool invertn = false, _In_opt_ ID3D12Device* device = nullptr);
+        static std::unique_ptr<GeometricPrimitive> __cdecl CreateGeoSphere(float diameter = 1, size_t tessellation = 3, bool rhcoords = true, _In_opt_ ID3D12Device* device = nullptr);
+        static std::unique_ptr<GeometricPrimitive> __cdecl CreateCylinder(float height = 1, float diameter = 1, size_t tessellation = 32, bool rhcoords = true, _In_opt_ ID3D12Device* device = nullptr);
+        static std::unique_ptr<GeometricPrimitive> __cdecl CreateCone(float diameter = 1, float height = 1, size_t tessellation = 32, bool rhcoords = true, _In_opt_ ID3D12Device* device = nullptr);
+        static std::unique_ptr<GeometricPrimitive> __cdecl CreateTorus(float diameter = 1, float thickness = 0.333f, size_t tessellation = 32, bool rhcoords = true, _In_opt_ ID3D12Device* device = nullptr);
+        static std::unique_ptr<GeometricPrimitive> __cdecl CreateTetrahedron(float size = 1, bool rhcoords = true, _In_opt_ ID3D12Device* device = nullptr);
+        static std::unique_ptr<GeometricPrimitive> __cdecl CreateOctahedron(float size = 1, bool rhcoords = true, _In_opt_ ID3D12Device* device = nullptr);
+        static std::unique_ptr<GeometricPrimitive> __cdecl CreateDodecahedron(float size = 1, bool rhcoords = true, _In_opt_ ID3D12Device* device = nullptr);
+        static std::unique_ptr<GeometricPrimitive> __cdecl CreateIcosahedron(float size = 1, bool rhcoords = true, _In_opt_ ID3D12Device* device = nullptr);
+        static std::unique_ptr<GeometricPrimitive> __cdecl CreateTeapot(float size = 1, size_t tessellation = 8, bool rhcoords = true, _In_opt_ ID3D12Device* device = nullptr);
+        static std::unique_ptr<GeometricPrimitive> __cdecl CreateCustom(const std::vector<VertexType>& vertices, const std::vector<uint16_t>& indices, _In_opt_ ID3D12Device* device = nullptr);
 
         static void __cdecl CreateCube(std::vector<VertexType>& vertices, std::vector<uint16_t>& indices, float size = 1, bool rhcoords = true);
         static void __cdecl CreateBox(std::vector<VertexType>& vertices, std::vector<uint16_t>& indices, const XMFLOAT3& size, bool rhcoords = true, bool invertn = false);

--- a/Inc/GraphicsMemory.h
+++ b/Inc/GraphicsMemory.h
@@ -145,7 +145,8 @@ namespace DirectX
         void __cdecl GarbageCollect();
 
         // Singleton
-        static GraphicsMemory& __cdecl Get();
+        // Should only use nullptr for single GPU scenarios; mGPU requires a specific device
+        static GraphicsMemory& __cdecl Get(_In_opt_ ID3D12Device* device = nullptr);
 
     private:
         // Private implementation.

--- a/Inc/Model.h
+++ b/Inc/Model.h
@@ -234,12 +234,12 @@ namespace DirectX
             int samplerDescriptorOffset = 0) const;
 
         // Loads a model from a DirectX SDK .SDKMESH file
-        static std::unique_ptr<Model> __cdecl CreateFromSDKMESH(_In_reads_bytes_(dataSize) const uint8_t* meshData, _In_ size_t dataSize);
-        static std::unique_ptr<Model> __cdecl CreateFromSDKMESH(_In_z_ const wchar_t* szFileName);
+        static std::unique_ptr<Model> __cdecl CreateFromSDKMESH(_In_reads_bytes_(dataSize) const uint8_t* meshData, _In_ size_t dataSize, _In_opt_ ID3D12Device* device = nullptr);
+        static std::unique_ptr<Model> __cdecl CreateFromSDKMESH(_In_z_ const wchar_t* szFileName, _In_opt_ ID3D12Device* device = nullptr);
 
         // Loads a model from a .VBO file
-        static std::unique_ptr<Model> __cdecl CreateFromVBO(_In_reads_bytes_(dataSize) const uint8_t* meshData, _In_ size_t dataSize);
-        static std::unique_ptr<Model> __cdecl CreateFromVBO(_In_z_ const wchar_t* szFileName);
+        static std::unique_ptr<Model> __cdecl CreateFromVBO(_In_reads_bytes_(dataSize) const uint8_t* meshData, _In_ size_t dataSize, _In_opt_ ID3D12Device* device = nullptr);
+        static std::unique_ptr<Model> __cdecl CreateFromVBO(_In_z_ const wchar_t* szFileName, _In_opt_ ID3D12Device* device = nullptr);
 
         // Utility function for getting a GPU descriptor for a mesh part/material index. If there is no texture the 
         // descriptor will be zero.

--- a/Src/BasicPostProcess.cpp
+++ b/Src/BasicPostProcess.cpp
@@ -123,6 +123,8 @@ namespace
             });
         }
 
+        ID3D12Device* GetDevice() const { return mDevice.Get(); }
+
     protected:
         ComPtr<ID3D12Device>                        mDevice;
         Microsoft::WRL::ComPtr<ID3D12RootSignature> mRootSignature[RootSignatureCount];
@@ -342,7 +344,7 @@ void BasicPostProcess::Impl::Process(_In_ ID3D12GraphicsCommandList* commandList
         if (mDirtyFlags & Dirty_ConstantBuffer)
         {
             mDirtyFlags &= ~Dirty_ConstantBuffer;
-            mConstantBuffer = GraphicsMemory::Get().AllocateConstant(constants);
+            mConstantBuffer = GraphicsMemory::Get(mDeviceResources->GetDevice()).AllocateConstant(constants);
         }
 
         commandList->SetGraphicsRootConstantBufferView(RootParameterIndex::ConstantBuffer, mConstantBuffer.GpuAddress());

--- a/Src/DualPostProcess.cpp
+++ b/Src/DualPostProcess.cpp
@@ -89,6 +89,8 @@ namespace
             });
         }
 
+        ID3D12Device* GetDevice() const { return mDevice.Get(); }
+
     protected:
         ComPtr<ID3D12Device>                        mDevice;
         Microsoft::WRL::ComPtr<ID3D12RootSignature> mRootSignature;
@@ -271,7 +273,7 @@ void DualPostProcess::Impl::Process(_In_ ID3D12GraphicsCommandList* commandList)
     if (mDirtyFlags & Dirty_ConstantBuffer)
     {
         mDirtyFlags &= ~Dirty_ConstantBuffer;
-        mConstantBuffer = GraphicsMemory::Get().AllocateConstant(constants);
+        mConstantBuffer = GraphicsMemory::Get(mDeviceResources->GetDevice()).AllocateConstant(constants);
     }
 
     commandList->SetGraphicsRootConstantBufferView(RootParameterIndex::ConstantBuffer, mConstantBuffer.GpuAddress());

--- a/Src/EffectCommon.h
+++ b/Src/EffectCommon.h
@@ -148,7 +148,7 @@ namespace DirectX
             mDeviceResources(deviceResourcesPool.DemandCreate(device))
         {
             // Initialize the constant buffer data
-            mConstantBuffer = GraphicsMemory::Get().AllocateConstant(constants);
+            mConstantBuffer = GraphicsMemory::Get(device).AllocateConstant(constants);
         }
 
         // Commits constants to the constant buffer memory
@@ -157,7 +157,7 @@ namespace DirectX
             // Make sure the constant buffer is up to date.
             if (dirtyFlags & EffectDirtyFlags::ConstantBuffer)
             {
-                mConstantBuffer = GraphicsMemory::Get().AllocateConstant(constants);
+                mConstantBuffer = GraphicsMemory::Get(mDeviceResources->GetDevice()).AllocateConstant(constants);
 
                 dirtyFlags &= ~EffectDirtyFlags::ConstantBuffer;
             }
@@ -214,6 +214,8 @@ namespace DirectX
 
                 return DemandCreateRootSig(mRootSignature[slot], desc);
             }
+
+            ID3D12Device* GetDevice() const { return mDevice.Get(); }
 
         private:
             Microsoft::WRL::ComPtr<ID3D12RootSignature> mRootSignature[Traits::RootSignatureCount];

--- a/Src/GeometricPrimitive.cpp
+++ b/Src/GeometricPrimitive.cpp
@@ -25,7 +25,7 @@ class GeometricPrimitive::Impl
 public:
     Impl() noexcept : mIndexCount(0), mVertexBufferView{}, mIndexBufferView{} {}
 
-    void Initialize(const VertexCollection& vertices, const IndexCollection& indices);
+    void Initialize(const VertexCollection& vertices, const IndexCollection& indices, _In_opt_ ID3D12Device* device);
 
     void Draw(_In_ ID3D12GraphicsCommandList* commandList) const;
     
@@ -39,7 +39,10 @@ public:
 
 
 // Initializes a geometric primitive instance that will draw the specified vertex and index data.
-void GeometricPrimitive::Impl::Initialize(const VertexCollection& vertices, const IndexCollection& indices)
+void GeometricPrimitive::Impl::Initialize(
+    const VertexCollection& vertices,
+    const IndexCollection& indices,
+    _In_opt_ ID3D12Device* device)
 {
     if (vertices.size() >= USHRT_MAX)
         throw std::exception("Too many vertices for 16-bit index buffer");
@@ -48,14 +51,14 @@ void GeometricPrimitive::Impl::Initialize(const VertexCollection& vertices, cons
     auto verts = reinterpret_cast<const uint8_t*>(vertices.data());
     size_t vertSizeBytes = vertices.size() * sizeof(vertices[0]);
     
-    mVertexBuffer = GraphicsMemory::Get().Allocate(vertSizeBytes);
+    mVertexBuffer = GraphicsMemory::Get(device).Allocate(vertSizeBytes);
     memcpy(mVertexBuffer.Memory(), verts, vertSizeBytes);
 
     // Index data
     auto ind = reinterpret_cast<const uint8_t*>(indices.data());
     size_t indSizeBytes = indices.size() * sizeof(indices[0]);
 
-    mIndexBuffer = GraphicsMemory::Get().Allocate(indSizeBytes);
+    mIndexBuffer = GraphicsMemory::Get(device).Allocate(indSizeBytes);
     memcpy(mIndexBuffer.Memory(), ind, indSizeBytes);
 
     // Record index count for draw
@@ -113,7 +116,10 @@ void GeometricPrimitive::Draw(ID3D12GraphicsCommandList* commandList) const
 //--------------------------------------------------------------------------------------
 
 // Creates a cube primitive.
-std::unique_ptr<GeometricPrimitive> GeometricPrimitive::CreateCube(float size, bool rhcoords)
+std::unique_ptr<GeometricPrimitive> GeometricPrimitive::CreateCube(
+    float size,
+    bool rhcoords,
+    _In_opt_ ID3D12Device* device)
 {
     VertexCollection vertices;
     IndexCollection indices;
@@ -122,7 +128,7 @@ std::unique_ptr<GeometricPrimitive> GeometricPrimitive::CreateCube(float size, b
     // Create the primitive object.
     std::unique_ptr<GeometricPrimitive> primitive(new GeometricPrimitive());
 
-    primitive->pImpl->Initialize(vertices, indices);
+    primitive->pImpl->Initialize(vertices, indices, device);
 
     return primitive;
 }
@@ -138,7 +144,11 @@ void GeometricPrimitive::CreateCube(
 
 
 // Creates a box primitive.
-std::unique_ptr<GeometricPrimitive> GeometricPrimitive::CreateBox(const XMFLOAT3& size, bool rhcoords, bool invertn)
+std::unique_ptr<GeometricPrimitive> GeometricPrimitive::CreateBox(
+    const XMFLOAT3& size,
+    bool rhcoords,
+    bool invertn,
+    _In_opt_ ID3D12Device* device)
 {
     VertexCollection vertices;
     IndexCollection indices;
@@ -147,7 +157,7 @@ std::unique_ptr<GeometricPrimitive> GeometricPrimitive::CreateBox(const XMFLOAT3
     // Create the primitive object.
     std::unique_ptr<GeometricPrimitive> primitive(new GeometricPrimitive());
 
-    primitive->pImpl->Initialize(vertices, indices);
+    primitive->pImpl->Initialize(vertices, indices, device);
 
     return primitive;
 }
@@ -172,7 +182,8 @@ std::unique_ptr<GeometricPrimitive> GeometricPrimitive::CreateSphere(
     float diameter,
     size_t tessellation,
     bool rhcoords,
-    bool invertn)
+    bool invertn,
+    _In_opt_ ID3D12Device* device)
 {
     // Create the primitive object.
     std::unique_ptr<GeometricPrimitive> primitive(new GeometricPrimitive());
@@ -182,7 +193,7 @@ std::unique_ptr<GeometricPrimitive> GeometricPrimitive::CreateSphere(
 
     ComputeSphere(vertices, indices, diameter, tessellation, rhcoords, invertn);
 
-    primitive->pImpl->Initialize(vertices, indices);
+    primitive->pImpl->Initialize(vertices, indices, device);
 
     return primitive;
 }
@@ -204,7 +215,11 @@ void GeometricPrimitive::CreateSphere(
 //--------------------------------------------------------------------------------------
 
 // Creates a geosphere primitive.
-std::unique_ptr<GeometricPrimitive> GeometricPrimitive::CreateGeoSphere(float diameter, size_t tessellation, bool rhcoords)
+std::unique_ptr<GeometricPrimitive> GeometricPrimitive::CreateGeoSphere(
+    float diameter,
+    size_t tessellation,
+    bool rhcoords,
+    _In_opt_ ID3D12Device* device)
 {
     // Create the primitive object.
     std::unique_ptr<GeometricPrimitive> primitive(new GeometricPrimitive());
@@ -213,7 +228,7 @@ std::unique_ptr<GeometricPrimitive> GeometricPrimitive::CreateGeoSphere(float di
     IndexCollection indices;
     ComputeGeoSphere(vertices, indices, diameter, tessellation, rhcoords);
 
-    primitive->pImpl->Initialize(vertices, indices);
+    primitive->pImpl->Initialize(vertices, indices, device);
 
     return primitive;
 }
@@ -238,7 +253,8 @@ std::unique_ptr<GeometricPrimitive> GeometricPrimitive::CreateCylinder(
     float height,
     float diameter,
     size_t tessellation,
-    bool rhcoords)
+    bool rhcoords,
+    _In_opt_ ID3D12Device* device)
 {
     // Create the primitive object.
     std::unique_ptr<GeometricPrimitive> primitive(new GeometricPrimitive());
@@ -247,7 +263,7 @@ std::unique_ptr<GeometricPrimitive> GeometricPrimitive::CreateCylinder(
     IndexCollection indices;
     ComputeCylinder(vertices, indices, height, diameter, tessellation, rhcoords);
 
-    primitive->pImpl->Initialize(vertices, indices);
+    primitive->pImpl->Initialize(vertices, indices, device);
 
     return primitive;
 }
@@ -268,7 +284,8 @@ std::unique_ptr<GeometricPrimitive> GeometricPrimitive::CreateCone(
     float diameter,
     float height,
     size_t tessellation,
-    bool rhcoords)
+    bool rhcoords,
+    _In_opt_ ID3D12Device* device)
 {
     // Create the primitive object.
     std::unique_ptr<GeometricPrimitive> primitive(new GeometricPrimitive());
@@ -277,7 +294,7 @@ std::unique_ptr<GeometricPrimitive> GeometricPrimitive::CreateCone(
     IndexCollection indices;
     ComputeCone(vertices, indices, diameter, height, tessellation, rhcoords);
 
-    primitive->pImpl->Initialize(vertices, indices);
+    primitive->pImpl->Initialize(vertices, indices, device);
 
     return primitive;
 }
@@ -303,7 +320,8 @@ std::unique_ptr<GeometricPrimitive> GeometricPrimitive::CreateTorus(
     float diameter,
     float thickness,
     size_t tessellation,
-    bool rhcoords)
+    bool rhcoords,
+    _In_opt_ ID3D12Device* device)
 {	
     // Create the primitive object.
     std::unique_ptr<GeometricPrimitive> primitive(new GeometricPrimitive());
@@ -312,7 +330,7 @@ std::unique_ptr<GeometricPrimitive> GeometricPrimitive::CreateTorus(
     IndexCollection indices;
     ComputeTorus(vertices, indices, diameter, thickness, tessellation, rhcoords);
 
-    primitive->pImpl->Initialize(vertices, indices);
+    primitive->pImpl->Initialize(vertices, indices, device);
 
     return primitive;
 }
@@ -333,7 +351,10 @@ void GeometricPrimitive::CreateTorus(
 // Tetrahedron
 //--------------------------------------------------------------------------------------
 
-std::unique_ptr<GeometricPrimitive> GeometricPrimitive::CreateTetrahedron(float size, bool rhcoords)
+std::unique_ptr<GeometricPrimitive> GeometricPrimitive::CreateTetrahedron(
+    float size,
+    bool rhcoords,
+    _In_opt_ ID3D12Device* device)
 {
     // Create the primitive object.
     std::unique_ptr<GeometricPrimitive> primitive(new GeometricPrimitive());
@@ -342,7 +363,7 @@ std::unique_ptr<GeometricPrimitive> GeometricPrimitive::CreateTetrahedron(float 
     IndexCollection indices;
     ComputeTetrahedron(vertices, indices, size, rhcoords);
 
-    primitive->pImpl->Initialize(vertices, indices);
+    primitive->pImpl->Initialize(vertices, indices, device);
 
     return primitive;
 }
@@ -361,7 +382,10 @@ void GeometricPrimitive::CreateTetrahedron(
 // Octahedron
 //--------------------------------------------------------------------------------------
 
-std::unique_ptr<GeometricPrimitive> GeometricPrimitive::CreateOctahedron(float size, bool rhcoords)
+std::unique_ptr<GeometricPrimitive> GeometricPrimitive::CreateOctahedron(
+    float size,
+    bool rhcoords,
+    _In_opt_ ID3D12Device* device)
 {
     // Create the primitive object.
     std::unique_ptr<GeometricPrimitive> primitive(new GeometricPrimitive());
@@ -370,7 +394,7 @@ std::unique_ptr<GeometricPrimitive> GeometricPrimitive::CreateOctahedron(float s
     IndexCollection indices;
     ComputeOctahedron(vertices, indices, size, rhcoords);
 
-    primitive->pImpl->Initialize(vertices, indices);
+    primitive->pImpl->Initialize(vertices, indices, device);
 
     return primitive;
 }
@@ -389,7 +413,10 @@ void GeometricPrimitive::CreateOctahedron(
 // Dodecahedron
 //--------------------------------------------------------------------------------------
 
-std::unique_ptr<GeometricPrimitive> GeometricPrimitive::CreateDodecahedron(float size, bool rhcoords)
+std::unique_ptr<GeometricPrimitive> GeometricPrimitive::CreateDodecahedron(
+    float size,
+    bool rhcoords,
+    _In_opt_ ID3D12Device* device)
 {
     // Create the primitive object.
     std::unique_ptr<GeometricPrimitive> primitive(new GeometricPrimitive());
@@ -398,7 +425,7 @@ std::unique_ptr<GeometricPrimitive> GeometricPrimitive::CreateDodecahedron(float
     IndexCollection indices;
     ComputeDodecahedron(vertices, indices, size, rhcoords);
 
-    primitive->pImpl->Initialize(vertices, indices);
+    primitive->pImpl->Initialize(vertices, indices, device);
 
     return primitive;
 }
@@ -417,7 +444,10 @@ void GeometricPrimitive::CreateDodecahedron(
 // Icosahedron
 //--------------------------------------------------------------------------------------
 
-std::unique_ptr<GeometricPrimitive> GeometricPrimitive::CreateIcosahedron(float size, bool rhcoords)
+std::unique_ptr<GeometricPrimitive> GeometricPrimitive::CreateIcosahedron(
+    float size,
+    bool rhcoords,
+    _In_opt_ ID3D12Device* device)
 {
     // Create the primitive object.
     std::unique_ptr<GeometricPrimitive> primitive(new GeometricPrimitive());
@@ -426,7 +456,7 @@ std::unique_ptr<GeometricPrimitive> GeometricPrimitive::CreateIcosahedron(float 
     IndexCollection indices;
     ComputeIcosahedron(vertices, indices, size, rhcoords);
 
-    primitive->pImpl->Initialize(vertices, indices);
+    primitive->pImpl->Initialize(vertices, indices, device);
 
     return primitive;
 }
@@ -446,7 +476,11 @@ void GeometricPrimitive::CreateIcosahedron(
 //--------------------------------------------------------------------------------------
 
 // Creates a teapot primitive.
-std::unique_ptr<GeometricPrimitive> GeometricPrimitive::CreateTeapot(float size, size_t tessellation, bool rhcoords)
+std::unique_ptr<GeometricPrimitive> GeometricPrimitive::CreateTeapot(
+    float size,
+    size_t tessellation,
+    bool rhcoords,
+    _In_opt_ ID3D12Device* device)
 {
     // Create the primitive object.
     std::unique_ptr<GeometricPrimitive> primitive(new GeometricPrimitive());
@@ -455,7 +489,7 @@ std::unique_ptr<GeometricPrimitive> GeometricPrimitive::CreateTeapot(float size,
     IndexCollection indices;
     ComputeTeapot(vertices, indices, size, tessellation, rhcoords);
 
-    primitive->pImpl->Initialize(vertices, indices);
+    primitive->pImpl->Initialize(vertices, indices, device);
 
     return primitive;
 }
@@ -476,7 +510,8 @@ void GeometricPrimitive::CreateTeapot(
 
 std::unique_ptr<GeometricPrimitive> GeometricPrimitive::CreateCustom(
     const std::vector<VertexType>& vertices,
-    const std::vector<uint16_t>& indices)
+    const std::vector<uint16_t>& indices,
+    _In_opt_ ID3D12Device* device)
 {
     // Extra validation
     if (vertices.empty() || indices.empty())
@@ -500,7 +535,7 @@ std::unique_ptr<GeometricPrimitive> GeometricPrimitive::CreateCustom(
     std::unique_ptr<GeometricPrimitive> primitive(new GeometricPrimitive());
 
     // copy geometry
-    primitive->pImpl->Initialize(vertices, indices);
+    primitive->pImpl->Initialize(vertices, indices, device);
 
     return primitive;
 }

--- a/Src/ModelLoadSDKMESH.cpp
+++ b/Src/ModelLoadSDKMESH.cpp
@@ -322,7 +322,7 @@ namespace
 //======================================================================================
 
 _Use_decl_annotations_
-std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(const uint8_t* meshData, size_t dataSize)
+std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(const uint8_t* meshData, size_t dataSize, ID3D12Device* device)
 {
     if (!meshData)
         throw std::exception("meshData cannot be null");
@@ -548,13 +548,15 @@ std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(const uint8_t* meshData
 
             // Vertex data
             auto verts = bufferData + (vh.DataOffset - bufferDataOffset);
-            part->vertexBuffer = GraphicsMemory::Get().Allocate((size_t)vh.SizeBytes);
-            memcpy(part->vertexBuffer.Memory(), verts, (size_t)vh.SizeBytes);
+            auto vbytes = static_cast<size_t>(vh.SizeBytes);
+            part->vertexBuffer = GraphicsMemory::Get(device).Allocate(vbytes);
+            memcpy(part->vertexBuffer.Memory(), verts, vbytes);
 
             // Index data
             auto indices = bufferData + (ih.DataOffset - bufferDataOffset);
-            part->indexBuffer = GraphicsMemory::Get().Allocate((size_t)ih.SizeBytes);
-            memcpy(part->indexBuffer.Memory(), indices, (size_t)ih.SizeBytes);
+            auto ibytes = static_cast<size_t>(ih.SizeBytes);
+            part->indexBuffer = GraphicsMemory::Get(device).Allocate(ibytes);
+            memcpy(part->indexBuffer.Memory(), indices, ibytes);
 
             part->materialIndex = subset.MaterialID;
             part->vbDecl = vbDecls[mh.VertexBuffers[0]];
@@ -582,7 +584,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(const uint8_t* meshData
 
 //--------------------------------------------------------------------------------------
 _Use_decl_annotations_
-std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(const wchar_t* szFileName)
+std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(const wchar_t* szFileName, ID3D12Device* device)
 {
     size_t dataSize = 0;
     std::unique_ptr<uint8_t[]> data;
@@ -593,7 +595,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(const wchar_t* szFileNa
         throw std::exception("CreateFromSDKMESH");
     }
 
-    auto model = CreateFromSDKMESH(data.get(), dataSize);
+    auto model = CreateFromSDKMESH(data.get(), dataSize, device);
 
     model->name = szFileName;
 

--- a/Src/ModelLoadVBO.cpp
+++ b/Src/ModelLoadVBO.cpp
@@ -47,7 +47,7 @@ namespace
 
 //--------------------------------------------------------------------------------------
 _Use_decl_annotations_
-std::unique_ptr<Model> DirectX::Model::CreateFromVBO(const uint8_t* meshData, size_t dataSize)
+std::unique_ptr<Model> DirectX::Model::CreateFromVBO(const uint8_t* meshData, size_t dataSize, ID3D12Device* device)
 {
     if (!InitOnceExecuteOnce(&g_InitOnce, InitializeDecl, nullptr, nullptr))
         throw std::exception("One-time initialization failed");
@@ -76,11 +76,11 @@ std::unique_ptr<Model> DirectX::Model::CreateFromVBO(const uint8_t* meshData, si
     auto indices = reinterpret_cast<const uint16_t*>(meshData + sizeof(VBO::header_t) + vertSize);
 
     // Create vertex buffer
-    auto vb = GraphicsMemory::Get().Allocate(vertSize);
+    auto vb = GraphicsMemory::Get(device).Allocate(vertSize);
     memcpy(vb.Memory(), verts, vertSize);
 
     // Create index buffer
-    auto ib = GraphicsMemory::Get().Allocate(indexSize);
+    auto ib = GraphicsMemory::Get(device).Allocate(indexSize);
     memcpy(ib.Memory(), indices, indexSize);
 
     auto part = new ModelMeshPart(0);
@@ -107,7 +107,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromVBO(const uint8_t* meshData, si
 
 //--------------------------------------------------------------------------------------
 _Use_decl_annotations_
-std::unique_ptr<Model> DirectX::Model::CreateFromVBO(const wchar_t* szFileName)
+std::unique_ptr<Model> DirectX::Model::CreateFromVBO(const wchar_t* szFileName, ID3D12Device* device)
 {
     size_t dataSize = 0;
     std::unique_ptr<uint8_t[]> data;
@@ -118,7 +118,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromVBO(const wchar_t* szFileName)
         throw std::exception("CreateFromVBO");
     }
 
-    auto model = CreateFromVBO(data.get(), dataSize);
+    auto model = CreateFromVBO(data.get(), dataSize, device);
 
     model->name = szFileName;
 

--- a/Src/PrimitiveBatch.cpp
+++ b/Src/PrimitiveBatch.cpp
@@ -169,9 +169,9 @@ void PrimitiveBatchBase::Impl::Draw(D3D_PRIMITIVE_TOPOLOGY topology, bool isInde
 
         // Allocate a page for the primitive data
         if (isIndexed)
-            mIndexSegment = GraphicsMemory::Get().Allocate(mIndexPageSize);
+            mIndexSegment = GraphicsMemory::Get(mDevice.Get()).Allocate(mIndexPageSize);
 
-        mVertexSegment = GraphicsMemory::Get().Allocate(mVertexPageSize);
+        mVertexSegment = GraphicsMemory::Get(mDevice.Get()).Allocate(mVertexPageSize);
     }
 
     // Copy over the index data.

--- a/Src/ToneMapPostProcess.cpp
+++ b/Src/ToneMapPostProcess.cpp
@@ -176,6 +176,8 @@ namespace
             });
         }
 
+        ID3D12Device* GetDevice() const { return mDevice.Get(); }
+
     protected:
         ComPtr<ID3D12Device>                        mDevice;
         Microsoft::WRL::ComPtr<ID3D12RootSignature> mRootSignature;
@@ -347,7 +349,7 @@ void ToneMapPostProcess::Impl::Process(_In_ ID3D12GraphicsCommandList* commandLi
     if (mDirtyFlags & Dirty_ConstantBuffer)
     {
         mDirtyFlags &= ~Dirty_ConstantBuffer;
-        mConstantBuffer = GraphicsMemory::Get().AllocateConstant(constants);
+        mConstantBuffer = GraphicsMemory::Get(mDeviceResources->GetDevice()).AllocateConstant(constants);
     }
 
     commandList->SetGraphicsRootConstantBufferView(RootParameterIndex::ConstantBuffer, mConstantBuffer.GpuAddress());


### PR DESCRIPTION
This adds basic multi-GPU support to DirectX Tool Kit. It primary requires a per-device ``GraphicsMemory`` singleton, and passing an explicit device to ``GeometricPrimitive`` and ``Model``.