### PR TITLE
Fix compiler errors (Clang 6)

### DIFF
--- a/Audio/WAVFileReader.cpp
+++ b/Audio/WAVFileReader.cpp
@@ -16,15 +16,9 @@
 
 using namespace DirectX;
 
-#ifndef MAKEFOURCC
-#define MAKEFOURCC(ch0, ch1, ch2, ch3)                              \
-                ((uint32_t)(uint8_t)(ch0) | ((uint32_t)(uint8_t)(ch1) << 8) |       \
-                ((uint32_t)(uint8_t)(ch2) << 16) | ((uint32_t)(uint8_t)(ch3) << 24 ))
-#endif /* defined(MAKEFOURCC) */
 
 namespace
 {
-
     //---------------------------------------------------------------------------------
     // .WAV files
     //---------------------------------------------------------------------------------

--- a/Audio/WaveBankReader.cpp
+++ b/Audio/WaveBankReader.cpp
@@ -19,11 +19,6 @@
 #include <apu.h>
 #endif
 
-#ifndef MAKEFOURCC
-#define MAKEFOURCC(ch0, ch1, ch2, ch3)                              \
-                ((uint32_t)(uint8_t)(ch0) | ((uint32_t)(uint8_t)(ch1) << 8) |       \
-                ((uint32_t)(uint8_t)(ch2) << 16) | ((uint32_t)(uint8_t)(ch3) << 24 ))
-#endif /* defined(MAKEFOURCC) */
 
 namespace
 {

--- a/Audio/WaveBankReader.cpp
+++ b/Audio/WaveBankReader.cpp
@@ -224,7 +224,7 @@ namespace
         DWORD AdpcmSamplesPerBlock() const
         {
             uint32_t nBlockAlign = (wBlockAlign + ADPCM_BLOCKALIGN_CONVERSION_OFFSET) * nChannels;
-            return nBlockAlign * 2 / (uint32_t)nChannels - 12;
+            return nBlockAlign * 2 / uint32_t(nChannels) - 12;
         }
 
         void AdpcmFillCoefficientTable(ADPCMWAVEFORMAT *fmt) const
@@ -968,7 +968,7 @@ HRESULT WaveBankReader::Impl::GetFormat(uint32_t index, WAVEFORMATEX* pFormat, s
             pFormat->cbSize = 32 /*MSADPCM_FORMAT_EXTRA_BYTES*/;
             {
                 auto adpcmFmt = reinterpret_cast<ADPCMWAVEFORMAT*>(pFormat);
-                adpcmFmt->wSamplesPerBlock = (WORD)miniFmt.AdpcmSamplesPerBlock();
+                adpcmFmt->wSamplesPerBlock = static_cast<WORD>(miniFmt.AdpcmSamplesPerBlock());
                 miniFmt.AdpcmFillCoefficientTable(adpcmFmt);
             }
             break;
@@ -1061,7 +1061,7 @@ HRESULT WaveBankReader::Impl::GetFormat(uint32_t index, WAVEFORMATEX* pFormat, s
 
     pFormat->nChannels = miniFmt.nChannels;
     pFormat->wBitsPerSample = miniFmt.BitsPerSample();
-    pFormat->nBlockAlign = (WORD)miniFmt.BlockAlign();
+    pFormat->nBlockAlign = static_cast<WORD>(miniFmt.BlockAlign());
     pFormat->nSamplesPerSec = miniFmt.nSamplesPerSec;
     pFormat->nAvgBytesPerSec = miniFmt.AvgBytesPerSec();
 

--- a/Inc/Audio.h
+++ b/Inc/Audio.h
@@ -473,8 +473,9 @@ namespace DirectX
             {
                 XMVECTOR lastPos = XMLoadFloat3(reinterpret_cast<const XMFLOAT3*>(&Position));
 
-                XMVECTOR vDelta = (newPos - lastPos);
-                XMVECTOR v = vDelta / dt;
+                XMVECTOR vDelta = XMVectorSubtract(newPos, lastPos);
+                XMVECTOR vt = XMVectorReplicate(dt);
+                XMVECTOR v = XMVectorDivide(vDelta, vt);
                 XMStoreFloat3(reinterpret_cast<XMFLOAT3*>(&Velocity), v);
 
                 vDelta = XMVector3Normalize(vDelta);
@@ -566,8 +567,9 @@ namespace DirectX
             {
                 XMVECTOR lastPos = XMLoadFloat3(reinterpret_cast<const XMFLOAT3*>(&Position));
 
-                XMVECTOR vDelta = (newPos - lastPos);
-                XMVECTOR v = vDelta / dt;
+                XMVECTOR vDelta = XMVectorSubtract(newPos, lastPos);
+                XMVECTOR vt = XMVectorReplicate(dt);
+                XMVECTOR v = XMVectorDivide(vDelta, vt);
                 XMStoreFloat3(reinterpret_cast<XMFLOAT3*>(&Velocity), v);
 
                 vDelta = XMVector3Normalize(vDelta);

--- a/Inc/Model.h
+++ b/Inc/Model.h
@@ -255,7 +255,7 @@ namespace DirectX
                 return handle;
 
             handle = heap->GetGPUDescriptorHandleForHeapStart();
-            handle.ptr += descriptorSize * ((size_t)textureIndex + descriptorOffset);
+            handle.ptr += static_cast<UINT64>(descriptorSize * (static_cast<size_t>(textureIndex) + descriptorOffset));
 
             return handle;
         }

--- a/Src/AlphaTestEffect.cpp
+++ b/Src/AlphaTestEffect.cpp
@@ -260,7 +260,7 @@ void AlphaTestEffect::Impl::Apply(_In_ ID3D12GraphicsCommandList* commandList)
     if (dirtyFlags & EffectDirtyFlags::AlphaTest)
     {
         // Convert reference alpha from 8 bit integer to 0-1 float format.
-        float reference = (float)referenceAlpha / 255.0f;
+        auto reference = static_cast<float>(referenceAlpha) / 255.0f;
                 
         // Comparison tolerance of half the 8 bit integer precision.
         const float threshold = 0.5f / 255.0f;

--- a/Src/BasicPostProcess.cpp
+++ b/Src/BasicPostProcess.cpp
@@ -462,10 +462,12 @@ void BasicPostProcess::Impl::GaussianBlur5x5(float multiplier)
     // blur kernels add to 1.0f to ensure that the intensity of the image isn't
     // changed when the blur occurs. An optional multiplier variable is used to
     // add or remove image intensity during the blur.
+    XMVECTOR vtw = XMVectorReplicate(totalWeight);
+    XMVECTOR vm = XMVectorReplicate(multiplier);
     for (size_t i = 0; i < index; ++i)
     {
-        weights[i] /= totalWeight;
-        weights[i] *= multiplier;
+        XMVECTOR w = XMVectorDivide(weights[i], vtw);
+        weights[i] = XMVectorMultiply(w, vm);
     }
 }
 

--- a/Src/Bezier.h
+++ b/Src/Bezier.h
@@ -89,11 +89,11 @@ namespace Bezier
 
         for (size_t i = 0; i <= tessellation; i++)
         {
-            float u = (float)i / tessellation;
+            float u = float(i) / tessellation;
 
             for (size_t j = 0; j <= tessellation; j++)
             {
-                float v = (float)j / tessellation;
+                float v = float(j) / tessellation;
 
                 // Perform four horizontal bezier interpolations
                 // between the control points of this patch.

--- a/Src/Bezier.h
+++ b/Src/Bezier.h
@@ -19,25 +19,37 @@ namespace Bezier
 {
     // Performs a cubic bezier interpolation between four control points,
     // returning the value at the specified time (t ranges 0 to 1).
-    // This template implementation can be used to interpolate XMVECTOR,
-    // float, or any other types that define suitable * and + operators.
     template<typename T>
-    T CubicInterpolate(T const& p1, T const& p2, T const& p3, T const& p4, float t)
+    inline T CubicInterpolate(T const& p1, T const& p2, T const& p3, T const& p4, float t)
     {
-        using DirectX::operator*;
-        using DirectX::operator+;
-
         return p1 * (1 - t) * (1 - t) * (1 - t) +
             p2 * 3 * t * (1 - t) * (1 - t) +
             p3 * 3 * t * t * (1 - t) +
             p4 * t * t * t;
     }
 
+     template<>
+     inline DirectX::XMVECTOR CubicInterpolate(DirectX::XMVECTOR const& p1, DirectX::XMVECTOR const& p2, DirectX::XMVECTOR const& p3, DirectX::XMVECTOR const& p4, float t)
+    {
+        using namespace DirectX;
+
+        XMVECTOR T0 = XMVectorReplicate((1 - t) * (1 - t) * (1 - t));
+        XMVECTOR T1 = XMVectorReplicate(3 * t * (1 - t) * (1 - t));
+        XMVECTOR T2 = XMVectorReplicate(3 * t * t * (1 - t));
+        XMVECTOR T3 = XMVectorReplicate(t * t * t);
+
+        XMVECTOR Result = XMVectorMultiply(p1, T0);
+        Result = XMVectorMultiplyAdd(p2, T1, Result);
+        Result = XMVectorMultiplyAdd(p3, T2, Result);
+        Result = XMVectorMultiplyAdd(p4, T3, Result);
+
+        return Result;
+    }
+
 
     // Computes the tangent of a cubic bezier curve at the specified time.
-    // Template supports XMVECTOR, float, or any other types with * and + operators.
     template<typename T>
-    T CubicTangent(T const& p1, T const& p2, T const& p3, T const& p4, float t)
+    inline T CubicTangent(T const& p1, T const& p2, T const& p3, T const& p4, float t)
     {
         using DirectX::operator*;
         using DirectX::operator+;
@@ -46,6 +58,24 @@ namespace Bezier
             p2 * (1 - 4 * t + 3 * t * t) +
             p3 * (2 * t - 3 * t * t) +
             p4 * (t * t);
+    }
+
+    template<>
+    inline DirectX::XMVECTOR CubicTangent(DirectX::XMVECTOR const& p1, DirectX::XMVECTOR const& p2, DirectX::XMVECTOR const& p3, DirectX::XMVECTOR const& p4, float t)
+    {
+        using namespace DirectX;
+
+        XMVECTOR T0 = XMVectorReplicate(-1 + 2 * t - t * t);
+        XMVECTOR T1 = XMVectorReplicate(1 - 4 * t + 3 * t * t);
+        XMVECTOR T2 = XMVectorReplicate(2 * t - 3 * t * t);
+        XMVECTOR T3 = XMVectorReplicate(t * t);
+
+        XMVECTOR Result = XMVectorMultiply(p1, T0);
+        Result = XMVectorMultiplyAdd(p2, T1, Result);
+        Result = XMVectorMultiplyAdd(p3, T2, Result);
+        Result = XMVectorMultiplyAdd(p4, T3, Result);
+
+        return Result;
     }
 
 
@@ -97,7 +127,7 @@ namespace Bezier
                     // If this patch is mirrored, we must invert the normal.
                     if (isMirrored)
                     {
-                        normal = -normal;
+                        normal = XMVectorNegate(normal);
                     }
                 }
                 else

--- a/Src/CommonStates.cpp
+++ b/Src/CommonStates.cpp
@@ -391,7 +391,7 @@ public:
     static const D3D12_SAMPLER_DESC SamplerDescs[static_cast<int>(SamplerIndex::Count)];
 
     Impl(_In_ ID3D12Device* device)
-        : mDescriptors(device, D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE, (int)SamplerIndex::Count)
+        : mDescriptors(device, D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE, static_cast<size_t>(SamplerIndex::Count))
     {
         SetDebugObjectName(mDescriptors.Heap(), L"CommonStates");
 
@@ -403,7 +403,7 @@ public:
 
     D3D12_GPU_DESCRIPTOR_HANDLE Get(SamplerIndex i) const
     {
-        return mDescriptors.GetGpuHandle((int)i);
+        return mDescriptors.GetGpuHandle(static_cast<size_t>(i));
     }
 
     ID3D12DescriptorHeap* Heap() const

--- a/Src/DDSTextureLoader.cpp
+++ b/Src/DDSTextureLoader.cpp
@@ -17,9 +17,9 @@
 
 #include "DDSTextureLoader.h"
 
+#include "PlatformHelpers.h"
 #include "dds.h"
 #include "DirectXHelpers.h"
-#include "PlatformHelpers.h"
 #include "LoaderHelpers.h"
 #include "ResourceUploadBatch.h"
 

--- a/Src/DDSTextureLoader.cpp
+++ b/Src/DDSTextureLoader.cpp
@@ -308,7 +308,7 @@ namespace
         if ((header->ddspf.flags & DDS_FOURCC) &&
             (MAKEFOURCC('D', 'X', '1', '0') == header->ddspf.fourCC))
         {
-            auto d3d10ext = reinterpret_cast<const DDS_HEADER_DXT10*>((const char*)header + sizeof(DDS_HEADER));
+            auto d3d10ext = reinterpret_cast<const DDS_HEADER_DXT10*>(reinterpret_cast<const char*>(header) + sizeof(DDS_HEADER));
 
             arraySize = d3d10ext->arraySize;
             if (arraySize == 0)
@@ -595,7 +595,7 @@ HRESULT DirectX::LoadDDSTextureFromMemoryEx(
         return E_FAIL;
     }
 
-    const uint32_t dwMagicNumber = *reinterpret_cast<const uint32_t*>(ddsData);
+    auto dwMagicNumber = *reinterpret_cast<const uint32_t*>(ddsData);
     if (dwMagicNumber != DDS_MAGIC)
     {
         return E_FAIL;

--- a/Src/DemandCreate.h
+++ b/Src/DemandCreate.h
@@ -17,7 +17,7 @@ namespace DirectX
 {
     // Helper for lazily creating a D3D resource.
     template<typename T, typename TCreateFunc>
-    static T* DemandCreate(Microsoft::WRL::ComPtr<T>& comPtr, std::mutex& mutex, TCreateFunc createFunc)
+    inline T* DemandCreate(Microsoft::WRL::ComPtr<T>& comPtr, std::mutex& mutex, TCreateFunc createFunc)
     {
         T* result = comPtr.Get();
 

--- a/Src/EffectCommon.cpp
+++ b/Src/EffectCommon.cpp
@@ -89,7 +89,8 @@ void XM_CALLCONV EffectFog::SetConstants(int& dirtyFlags, FXMMATRIX worldView, X
                 // 0, 0, 0, fogStart
                 XMVECTOR wOffset = XMVectorSwizzle<1, 2, 3, 0>(XMLoadFloat(&start));
 
-                fogVectorConstant = (worldViewZ + wOffset) / (start - end);
+                // (worldViewZ + wOffset) / (start - end);
+                fogVectorConstant = XMVectorDivide(XMVectorAdd(worldViewZ, wOffset), XMVectorReplicate(start - end));
             }
 
             dirtyFlags &= ~(EffectDirtyFlags::FogVector | EffectDirtyFlags::FogEnable);
@@ -126,7 +127,7 @@ void EffectColor::SetConstants(_Inout_ int& dirtyFlags, _Inout_ XMVECTOR& diffus
         XMVECTOR alphaVector = XMVectorReplicate(alpha);
 
         // xyz = diffuse * alpha, w = alpha.
-        diffuseColorConstant = XMVectorSelect(alphaVector, diffuseColor * alphaVector, g_XMSelect1110);
+        diffuseColorConstant = XMVectorSelect(alphaVector, XMVectorMultiply(diffuseColor, alphaVector), g_XMSelect1110);
 
         dirtyFlags &= ~EffectDirtyFlags::MaterialColor;
         dirtyFlags |= EffectDirtyFlags::ConstantBuffer;
@@ -239,16 +240,17 @@ void EffectLights::SetConstants(int& dirtyFlags, EffectMatrices const& matrices,
         if (lightingEnabled)
         {
             // Merge emissive and ambient light contributions.
-            emissiveColorConstant = (emissiveColor + ambientLightColor * diffuse) * alphaVector;
+            // (emissiveColor + ambientLightColor * diffuse) * alphaVector;
+            emissiveColorConstant = XMVectorMultiply(XMVectorMultiplyAdd(ambientLightColor, diffuse, emissiveColor), alphaVector);
         }
         else
         {
             // Merge diffuse and emissive light contributions.
-            diffuse += emissiveColor;
+            diffuse = XMVectorAdd(diffuse, emissiveColor);
         }
 
         // xyz = diffuse * alpha, w = alpha.
-        diffuseColorConstant = XMVectorSelect(alphaVector, diffuse * alphaVector, g_XMSelect1110);
+        diffuseColorConstant = XMVectorSelect(alphaVector, XMVectorMultiply(diffuse, alphaVector), g_XMSelect1110);
 
         dirtyFlags &= ~EffectDirtyFlags::MaterialColor;
         dirtyFlags |= EffectDirtyFlags::ConstantBuffer;

--- a/Src/GamePad.cpp
+++ b/Src/GamePad.cpp
@@ -1163,14 +1163,14 @@ private:
         if (mConnected[player])
             return false;
 
-        for (size_t j = 0; j < XUSER_MAX_COUNT; ++j)
+        for (int j = 0; j < XUSER_MAX_COUNT; ++j)
         {
             if (!mConnected[j])
             {
                 LONGLONG delta = time - mLastReadTime[j];
 
                 LONGLONG interval = 1000;
-                if ((int)j != player)
+                if (j != player)
                     interval /= 4;
 
                 if ((delta >= 0) && (delta < interval))

--- a/Src/Geometry.cpp
+++ b/Src/Geometry.cpp
@@ -32,7 +32,7 @@ namespace
     inline void index_push_back(IndexCollection& indices, size_t value)
     {
         CheckIndexOverflow(value);
-        indices.push_back((uint16_t)value);
+        indices.push_back(static_cast<uint16_t>(value));
     }
 
 
@@ -160,7 +160,7 @@ void DirectX::ComputeSphere(VertexCollection& vertices, IndexCollection& indices
     // Create rings of vertices at progressively higher latitudes.
     for (size_t i = 0; i <= verticalSegments; i++)
     {
-        float v = 1 - (float)i / verticalSegments;
+        float v = 1 - float(i) / verticalSegments;
 
         float latitude = (i * XM_PI / verticalSegments) - XM_PIDIV2;
         float dy, dxz;
@@ -170,7 +170,7 @@ void DirectX::ComputeSphere(VertexCollection& vertices, IndexCollection& indices
         // Create a single ring of vertices at this latitude.
         for (size_t j = 0; j <= horizontalSegments; j++)
         {
-            float u = (float)j / horizontalSegments;
+            float u = float(j) / horizontalSegments;
 
             float longitude = j * XM_2PI / horizontalSegments;
             float dx, dz;
@@ -633,7 +633,7 @@ void DirectX::ComputeCylinder(VertexCollection& vertices, IndexCollection& indic
 
         XMVECTOR sideOffset = XMVectorScale(normal, radius);
 
-        float u = (float)i / tessellation;
+        float u = float(i) / tessellation;
 
         XMVECTOR textureCoordinate = XMLoadFloat(&u);
 
@@ -682,7 +682,7 @@ void DirectX::ComputeCone(VertexCollection& vertices, IndexCollection& indices, 
 
         XMVECTOR sideOffset = XMVectorScale(circlevec, radius);
 
-        float u = (float)i / tessellation;
+        float u = float(i) / tessellation;
 
         XMVECTOR textureCoordinate = XMLoadFloat(&u);
 
@@ -727,7 +727,7 @@ void DirectX::ComputeTorus(VertexCollection& vertices, IndexCollection& indices,
     // First we loop around the main ring of the torus.
     for (size_t i = 0; i <= tessellation; i++)
     {
-        float u = (float)i / tessellation;
+        float u = float(i) / tessellation;
 
         float outerAngle = i * XM_2PI / tessellation - XM_PIDIV2;
 
@@ -738,7 +738,7 @@ void DirectX::ComputeTorus(VertexCollection& vertices, IndexCollection& indices,
         // Now we loop along the other axis, around the side of the tube.
         for (size_t j = 0; j <= tessellation; j++)
         {
-            float v = 1 - (float)j / tessellation;
+            float v = 1 - float(j) / tessellation;
 
             float innerAngle = j * XM_2PI / tessellation + XM_PI;
             float dx, dy;

--- a/Src/GraphicsMemory.cpp
+++ b/Src/GraphicsMemory.cpp
@@ -59,7 +59,7 @@ namespace
 #ifdef _WIN64
         return _BitScanForward64(&bitIndex, allocatorPageSize) ? bitIndex + 1 : 0;
 #else
-        return _BitScanForward(&bitIndex, (DWORD)allocatorPageSize) ? bitIndex + 1 : 0;
+        return _BitScanForward(&bitIndex, static_cast<DWORD>(allocatorPageSize)) ? bitIndex + 1 : 0;
 #endif
     }
 

--- a/Src/LoaderHelpers.h
+++ b/Src/LoaderHelpers.h
@@ -794,7 +794,7 @@ namespace DirectX
             {
                 if (MAKEFOURCC('D', 'X', '1', '0') == header->ddspf.fourCC)
                 {
-                    auto d3d10ext = reinterpret_cast<const DDS_HEADER_DXT10*>((const char*)header + sizeof(DDS_HEADER));
+                    auto d3d10ext = reinterpret_cast<const DDS_HEADER_DXT10*>(reinterpret_cast<const uint8_t*>(header) + sizeof(DDS_HEADER));
                     auto mode = static_cast<DDS_ALPHA_MODE>(d3d10ext->miscFlags2 & DDS_MISC_FLAGS2_ALPHA_MODE_MASK);
                     switch (mode)
                     {

--- a/Src/Model.cpp
+++ b/Src/Model.cpp
@@ -320,7 +320,7 @@ void XM_CALLCONV Model::UpdateEffectMatrices(
 {
     for (auto& fx : effectList)
     {
-        IEffectMatrices* matFx = dynamic_cast<IEffectMatrices*>(fx.get());
+        auto matFx = dynamic_cast<IEffectMatrices*>(fx.get());
         if (matFx)
         {
             matFx->SetMatrices(world, view, proj);

--- a/Src/Model.cpp
+++ b/Src/Model.cpp
@@ -291,7 +291,7 @@ std::shared_ptr<IEffect> Model::CreateEffectForMeshPart(
     const auto& m = materials[part->materialIndex];
 
     D3D12_INPUT_LAYOUT_DESC il = {};
-    il.NumElements = (uint32_t)part->vbDecl->size();
+    il.NumElements = static_cast<UINT>(part->vbDecl->size());
     il.pInputElementDescs = part->vbDecl->data();
 
     return fxFactory.CreateEffect(m, opaquePipelineState, alphaPipelineState, il, textureDescriptorOffset, samplerDescriptorOffset);

--- a/Src/PlatformHelpers.h
+++ b/Src/PlatformHelpers.h
@@ -15,6 +15,13 @@
 #include <exception>
 #include <memory>
 
+#ifndef MAKEFOURCC
+    #define MAKEFOURCC(ch0, ch1, ch2, ch3) \
+                (static_cast<uint32_t>(static_cast<uint8_t>(ch0)) \
+                | (static_cast<uint32_t>(static_cast<uint8_t>(ch1)) << 8) \
+                | (static_cast<uint32_t>(static_cast<uint8_t>(ch2)) << 16) \
+                | (static_cast<uint32_t>(static_cast<uint8_t>(ch3)) << 24))
+#endif /* defined(MAKEFOURCC) */
 
 namespace DirectX
 {

--- a/Src/PrimitiveBatch.cpp
+++ b/Src/PrimitiveBatch.cpp
@@ -177,18 +177,18 @@ void PrimitiveBatchBase::Impl::Draw(D3D_PRIMITIVE_TOPOLOGY topology, bool isInde
     // Copy over the index data.
     if (isIndexed)
     {
-        uint16_t* outputIndices = (uint16_t*)mIndexSegment.Memory() + mIndexCount;
+        auto outputIndices = static_cast<uint16_t*>(mIndexSegment.Memory()) + mIndexCount;
 
         for (size_t i = 0; i < indexCount; i++)
         {
-            outputIndices[i] = (uint16_t)(indices[i] + mVertexCount - mBaseIndex);
+            outputIndices[i] = static_cast<uint16_t>(indices[i] + mVertexCount - mBaseIndex);
         }
 
         mIndexCount += indexCount;
     }
 
     // Return the output vertex data location.
-    *pMappedVertices = (uint8_t*)mVertexSegment.Memory() + mVertexSize * mVertexCount;
+    *pMappedVertices = static_cast<uint8_t*>(mVertexSegment.Memory()) + mVertexSize * mVertexCount;
 
     mVertexCount += vertexCount;
 }

--- a/Src/ResourceUploadBatch.cpp
+++ b/Src/ResourceUploadBatch.cpp
@@ -149,7 +149,7 @@ namespace
         };
 #pragma pack(pop)
 
-        static const uint32_t Num32BitConstants = (uint32_t)(sizeof(ConstantData) / sizeof(uint32_t));
+        static const uint32_t Num32BitConstants = static_cast<uint32_t>(sizeof(ConstantData) / sizeof(uint32_t));
         static const uint32_t ThreadGroupSize = 8;
 
         ComPtr<ID3D12RootSignature> rootSignature;
@@ -544,7 +544,7 @@ private:
             descriptorSize); // offset by 1 descriptor
 
         // Process each mip
-        uint32_t mipWidth = (uint32_t)desc.Width;
+        auto mipWidth = static_cast<uint32_t>(desc.Width);
         uint32_t mipHeight = desc.Height;
         for (uint32_t mip = 1; mip < desc.MipLevels; ++mip)
         {
@@ -561,7 +561,7 @@ private:
             // Set constants
             GenerateMipsResources::ConstantData constants;
             constants.SrcMipIndex = mip - 1;
-            constants.InvOutTexelSize = XMFLOAT2(1 / (float)mipWidth, 1 / (float)mipHeight);
+            constants.InvOutTexelSize = XMFLOAT2(1 / float(mipWidth), 1 / float(mipHeight));
             mList->SetComputeRoot32BitConstants(
                 GenerateMipsResources::Constants,
                 GenerateMipsResources::Num32BitConstants,

--- a/Src/ResourceUploadBatch.cpp
+++ b/Src/ResourceUploadBatch.cpp
@@ -378,7 +378,7 @@ public:
         ThrowIfFailed(mList->Close());
 
         // Submit the job to the GPU
-        commandQueue->ExecuteCommandLists(1, (ID3D12CommandList**)mList.GetAddressOf());
+        commandQueue->ExecuteCommandLists(1, CommandListCast(mList.GetAddressOf()));
 
         // Set an event so we get notified when the GPU has completed all its work
         ComPtr<ID3D12Fence> fence;

--- a/Src/ScreenGrab.cpp
+++ b/Src/ScreenGrab.cpp
@@ -25,8 +25,8 @@
 #include "ScreenGrab.h"
 #include "DirectXHelpers.h"
 
-#include "dds.h"
 #include "PlatformHelpers.h"
+#include "dds.h"
 #include "LoaderHelpers.h"
 
 using Microsoft::WRL::ComPtr;
@@ -196,7 +196,7 @@ namespace
             return hr;
 
         // Execute the command list
-        pCommandQ->ExecuteCommandLists(1, (ID3D12CommandList**)commandList.GetAddressOf());
+        pCommandQ->ExecuteCommandLists(1, CommandListCast(commandList.GetAddressOf()));
 
         // Signal the fence
         hr = pCommandQ->Signal(fence.Get(), 1);

--- a/Src/ScreenGrab.cpp
+++ b/Src/ScreenGrab.cpp
@@ -275,7 +275,7 @@ HRESULT DirectX::SaveDDSTextureToFile(
     header->size = sizeof(DDS_HEADER);
     header->flags = DDS_HEADER_FLAGS_TEXTURE | DDS_HEADER_FLAGS_MIPMAP;
     header->height = desc.Height;
-    header->width = (uint32_t)desc.Width;
+    header->width = static_cast<uint32_t>(desc.Width);
     header->mipMapCount = 1;
     header->caps = DDS_SURFACE_FLAGS_TEXTURE;
 
@@ -337,7 +337,7 @@ HRESULT DirectX::SaveDDSTextureToFile(
     }
 
     size_t rowPitch, slicePitch, rowCount;
-    GetSurfaceInfo((size_t)desc.Width, desc.Height, desc.Format, &slicePitch, &rowPitch, &rowCount);
+    GetSurfaceInfo(static_cast<size_t>(desc.Width), desc.Height, desc.Format, &slicePitch, &rowPitch, &rowCount);
 
     if (IsCompressed(desc.Format))
     {

--- a/Src/SpriteFont.cpp
+++ b/Src/SpriteFont.cpp
@@ -120,7 +120,7 @@ SpriteFont::Impl::Impl(
     // Read font properties.
     lineSpacing = reader->Read<float>();
 
-    SetDefaultCharacter((wchar_t)reader->Read<uint32_t>());
+    SetDefaultCharacter(static_cast<wchar_t>(reader->Read<uint32_t>()));
 
     // Read the texture data.
     auto textureWidth = reader->Read<uint32_t>();
@@ -432,8 +432,8 @@ XMVECTOR XM_CALLCONV SpriteFont::MeasureString(_In_z_ wchar_t const* text) const
     {
         UNREFERENCED_PARAMETER(advance);
 
-        float w = (float)(glyph->Subrect.right - glyph->Subrect.left);
-        float h = (float)(glyph->Subrect.bottom - glyph->Subrect.top) + glyph->YOffset;
+        auto w = static_cast<float>(glyph->Subrect.right - glyph->Subrect.left);
+        auto h = static_cast<float>(glyph->Subrect.bottom - glyph->Subrect.top) + glyph->YOffset;
 
         h = std::max(h, pImpl->lineSpacing);
 
@@ -450,8 +450,8 @@ RECT SpriteFont::MeasureDrawBounds(_In_z_ wchar_t const* text, XMFLOAT2 const& p
 
     pImpl->ForEachGlyph(text, [&](Glyph const* glyph, float x, float y, float advance)
     {
-        float w = (float)(glyph->Subrect.right - glyph->Subrect.left);
-        float h = (float)(glyph->Subrect.bottom - glyph->Subrect.top);
+        auto w = static_cast<float>(glyph->Subrect.right - glyph->Subrect.left);
+        auto h = static_cast<float>(glyph->Subrect.bottom - glyph->Subrect.top);
 
         float minX = position.x + x;
         float minY = position.y + y + glyph->YOffset;
@@ -507,7 +507,7 @@ void SpriteFont::SetLineSpacing(float spacing)
 // Font properties
 wchar_t SpriteFont::GetDefaultCharacter() const
 {
-    return pImpl->defaultGlyph ? (wchar_t)pImpl->defaultGlyph->Character : 0;
+    return static_cast<wchar_t>(pImpl->defaultGlyph ? pImpl->defaultGlyph->Character : 0);
 }
 
 

--- a/Src/SpriteFont.cpp
+++ b/Src/SpriteFont.cpp
@@ -395,7 +395,10 @@ void XM_CALLCONV SpriteFont::DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ wc
     // If the text is mirrored, offset the start position accordingly.
     if (effects)
     {
-        baseOffset -= MeasureString(text) * axisIsMirroredTable[effects & 3];
+        baseOffset = XMVectorNegativeMultiplySubtract(
+            MeasureString(text),
+            axisIsMirroredTable[effects & 3],
+            baseOffset);
     }
 
     // Draw each character in turn.
@@ -411,7 +414,7 @@ void XM_CALLCONV SpriteFont::DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ wc
             XMVECTOR glyphRect = XMConvertVectorIntToFloat(XMLoadInt4(reinterpret_cast<uint32_t const*>(&glyph->Subrect)), 0);
 
             // xy = glyph width/height.
-            glyphRect = XMVectorSwizzle<2, 3, 0, 1>(glyphRect) - glyphRect;
+            glyphRect = XMVectorSubtract(XMVectorSwizzle<2, 3, 0, 1>(glyphRect), glyphRect);
 
             offset = XMVectorMultiplyAdd(glyphRect, axisIsMirroredTable[effects & 3], offset);
         }

--- a/Src/WICTextureLoader.cpp
+++ b/Src/WICTextureLoader.cpp
@@ -145,7 +145,7 @@ namespace
         // We don't support n-channel formats
     };
 
-    BOOL WINAPI InitializeWICFactory(PINIT_ONCE, PVOID, PVOID *ifactory)
+    BOOL WINAPI InitializeWICFactory(PINIT_ONCE, PVOID, PVOID *ifactory) noexcept
     {
         return SUCCEEDED(CoCreateInstance(
             CLSID_WICImagingFactory2,

--- a/Src/WICTextureLoader.cpp
+++ b/Src/WICTextureLoader.cpp
@@ -463,7 +463,7 @@ namespace
         D3D12_RESOURCE_DESC desc = {};
         desc.Width = twidth;
         desc.Height = theight;
-        desc.MipLevels = (uint16_t)mipCount;
+        desc.MipLevels = static_cast<UINT16>(mipCount);
         desc.DepthOrArraySize = 1;
         desc.Format = format;
         desc.SampleDesc.Count = 1;

--- a/Src/WICTextureLoader.cpp
+++ b/Src/WICTextureLoader.cpp
@@ -144,6 +144,16 @@ namespace
 
         // We don't support n-channel formats
     };
+
+    BOOL WINAPI InitializeWICFactory(PINIT_ONCE, PVOID, PVOID *ifactory)
+    {
+        return SUCCEEDED(CoCreateInstance(
+            CLSID_WICImagingFactory2,
+            nullptr,
+            CLSCTX_INPROC_SERVER,
+            __uuidof(IWICImagingFactory2),
+            ifactory)) ? TRUE : FALSE;
+    }
 }
 
 //--------------------------------------------------------------------------------------
@@ -154,16 +164,11 @@ namespace DirectX
         static INIT_ONCE s_initOnce = INIT_ONCE_STATIC_INIT;
 
         IWICImagingFactory2* factory = nullptr;
-        (void)InitOnceExecuteOnce(&s_initOnce,
-            [](PINIT_ONCE, PVOID, PVOID *ifactory) -> BOOL
-        {
-            return SUCCEEDED(CoCreateInstance(
-                CLSID_WICImagingFactory2,
-                nullptr,
-                CLSCTX_INPROC_SERVER,
-                __uuidof(IWICImagingFactory2),
-                ifactory)) ? TRUE : FALSE;
-        }, nullptr, reinterpret_cast<LPVOID*>(&factory));
+        (void)InitOnceExecuteOnce(
+            &s_initOnce,
+            InitializeWICFactory,
+            nullptr,
+            reinterpret_cast<LPVOID*>(&factory));
 
         return factory;
     }

--- a/Src/XboxDDSTextureLoader.cpp
+++ b/Src/XboxDDSTextureLoader.cpp
@@ -18,9 +18,9 @@
 
 #include "XboxDDSTextureLoader.h"
 
+#include "PlatformHelpers.h"
 #include "dds.h"
 #include "DirectXHelpers.h"
-#include "PlatformHelpers.h"
 
 #include <xdk.h>
 

--- a/Src/dds.h
+++ b/Src/dds.h
@@ -49,12 +49,6 @@ struct DDS_PIXELFORMAT
 #define DDS_PAL8A       0x00000021  // DDPF_PALETTEINDEXED8 | DDPF_ALPHAPIXELS
 #define DDS_BUMPDUDV    0x00080000  // DDPF_BUMPDUDV
 
-#ifndef MAKEFOURCC
-    #define MAKEFOURCC(ch0, ch1, ch2, ch3)                              \
-                ((uint32_t)(uint8_t)(ch0) | ((uint32_t)(uint8_t)(ch1) << 8) |       \
-                ((uint32_t)(uint8_t)(ch2) << 16) | ((uint32_t)(uint8_t)(ch3) << 24 ))
-#endif /* defined(MAKEFOURCC) */
-
 extern __declspec(selectany) const DDS_PIXELFORMAT DDSPF_DXT1 =
     { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('D','X','T','1'), 0, 0, 0, 0, 0 };
 

--- a/Src/pch.h
+++ b/Src/pch.h
@@ -89,6 +89,8 @@
 #pragma warning(pop)
 #endif
 
+#define _XM_NO_XMVECTOR_OVERLOADS_
+
 #include <DirectXMath.h>
 #include <DirectXPackedVector.h>
 #include <DirectXCollision.h>


### PR DESCRIPTION
The change here is to make the _DirectX Tool Kit_ math code build correctly with DirectXMath 3.12 or later when using ``_XM_NO_XMVECTOR_OVERLOADS_``.