### PR TITLE
Model::LoadStaticBuffers to use static VB/IB instead of dynamic

### DIFF
--- a/Inc/Effects.h
+++ b/Inc/Effects.h
@@ -622,12 +622,12 @@ namespace DirectX
     public:
         EffectTextureFactory(
             _In_ ID3D12Device* device,
-            _Inout_ ResourceUploadBatch& resourceUploadBatch,
+            ResourceUploadBatch& resourceUploadBatch,
             _In_ ID3D12DescriptorHeap* descriptorHeap);
 
         EffectTextureFactory(
             _In_ ID3D12Device* device,
-            _Inout_ ResourceUploadBatch& resourceUploadBatch,
+            ResourceUploadBatch& resourceUploadBatch,
             _In_ size_t numDescriptors,
             _In_ D3D12_DESCRIPTOR_HEAP_FLAGS descriptorHeapFlags);
 

--- a/Inc/GraphicsMemory.h
+++ b/Inc/GraphicsMemory.h
@@ -92,6 +92,9 @@ namespace DirectX
         
         explicit operator bool () const { return mSharedResource != nullptr; }
 
+        bool operator == (const SharedGraphicsResource& other) const { return mSharedResource.get() == other.mSharedResource.get(); }
+        bool operator != (const SharedGraphicsResource& other) const { return mSharedResource.get() != other.mSharedResource.get(); }
+
         // Clear the pointer. Using operator -> will produce bad results.
         void __cdecl Reset();
         void __cdecl Reset(GraphicsResource&&);

--- a/Inc/Model.h
+++ b/Inc/Model.h
@@ -53,10 +53,14 @@ namespace DirectX
         uint32_t                                                vertexOffset;
         uint32_t                                                vertexStride;
         uint32_t                                                vertexCount;
+        uint32_t                                                indexBufferSize;
+        uint32_t                                                vertexBufferSize;
         D3D_PRIMITIVE_TOPOLOGY                                  primitiveType;
         DXGI_FORMAT                                             indexFormat;
         SharedGraphicsResource                                  indexBuffer;
         SharedGraphicsResource                                  vertexBuffer;
+        Microsoft::WRL::ComPtr<ID3D12Resource>                  staticIndexBuffer;
+        Microsoft::WRL::ComPtr<ID3D12Resource>                  staticVertexBuffer;
         std::shared_ptr<std::vector<D3D12_INPUT_ELEMENT_DESC>>  vbDecl;
 
         using Collection = std::vector<std::unique_ptr<ModelMeshPart>>;
@@ -212,9 +216,15 @@ namespace DirectX
         // Load texture resources into a new Effect Texture Factory
         std::unique_ptr<EffectTextureFactory> __cdecl LoadTextures(
             _In_ ID3D12Device* device,
-            _Inout_ ResourceUploadBatch& resourceUploadBatch,
+            ResourceUploadBatch& resourceUploadBatch,
             _In_opt_z_ const wchar_t* texturesPath = nullptr,
             D3D12_DESCRIPTOR_HEAP_FLAGS flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE) const;
+
+        // Load VB/IB resources for static geometry
+        void __cdecl LoadBuffers(
+            _In_ ID3D12Device* device,
+            ResourceUploadBatch& resourceUploadBatch,
+            bool keepMemory = false);
 
         // Create effects using the default effect factory
         std::vector<std::shared_ptr<IEffect>> __cdecl CreateEffects(

--- a/Inc/Model.h
+++ b/Inc/Model.h
@@ -221,7 +221,7 @@ namespace DirectX
             D3D12_DESCRIPTOR_HEAP_FLAGS flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE) const;
 
         // Load VB/IB resources for static geometry
-        void __cdecl LoadBuffers(
+        void __cdecl LoadStaticBuffers(
             _In_ ID3D12Device* device,
             ResourceUploadBatch& resourceUploadBatch,
             bool keepMemory = false);

--- a/Inc/ResourceUploadBatch.h
+++ b/Inc/ResourceUploadBatch.h
@@ -18,6 +18,8 @@
 #include <future>
 #include <memory>
 
+#include "GraphicsMemory.h"
+
 
 namespace DirectX
 {
@@ -41,9 +43,14 @@ namespace DirectX
         // The resource must be in the COPY_DEST state.
         void __cdecl Upload(
             _In_ ID3D12Resource* resource,
-            _In_ uint32_t subresourceIndexStart,
+            uint32_t subresourceIndexStart,
             _In_reads_(numSubresources) D3D12_SUBRESOURCE_DATA* subRes,
-            _In_ uint32_t numSubresources);
+            uint32_t numSubresources);
+
+        void __cdecl Upload(
+            _In_ ID3D12Resource* resource,
+            SharedGraphicsResource& buffer
+            );
 
         // Asynchronously generate mips from a resource.
         // Resource must be in the PIXEL_SHADER_RESOURCE state
@@ -52,8 +59,8 @@ namespace DirectX
         // Transition a resource once you're done with it
         void __cdecl Transition(
             _In_ ID3D12Resource* resource,
-            _In_ D3D12_RESOURCE_STATES stateBefore,
-            _In_ D3D12_RESOURCE_STATES stateAfter);
+            D3D12_RESOURCE_STATES stateBefore,
+            D3D12_RESOURCE_STATES stateAfter);
 
         // Submits all the uploads to the driver.
         // No more uploads can happen after this call until Begin is called again.
@@ -68,4 +75,3 @@ namespace DirectX
         std::unique_ptr<Impl> pImpl;
     };
 }
-

--- a/Inc/ResourceUploadBatch.h
+++ b/Inc/ResourceUploadBatch.h
@@ -49,7 +49,7 @@ namespace DirectX
 
         void __cdecl Upload(
             _In_ ID3D12Resource* resource,
-            SharedGraphicsResource& buffer
+            const SharedGraphicsResource& buffer
             );
 
         // Asynchronously generate mips from a resource.

--- a/Src/EffectTextureFactory.cpp
+++ b/Src/EffectTextureFactory.cpp
@@ -8,13 +8,14 @@
 //--------------------------------------------------------------------------------------
 
 #include "pch.h"
+
 #include "Effects.h"
 #include "DirectXHelpers.h"
 #include "DDSTextureLoader.h"
 #include "DescriptorHeap.h"
+#include "PlatformHelpers.h"
 #include "ResourceUploadBatch.h"
 #include "WICTextureLoader.h"
-#include "PlatformHelpers.h"
 
 #include <mutex>
 
@@ -36,7 +37,7 @@ public:
 
     Impl(
         _In_ ID3D12Device* device,
-        _Inout_ ResourceUploadBatch& resourceUploadBatch,
+        ResourceUploadBatch& resourceUploadBatch,
         _In_ ID3D12DescriptorHeap* descriptorHeap)
         : mPath{}
         , mTextureDescriptorHeap(descriptorHeap)
@@ -51,7 +52,7 @@ public:
 
     Impl(
         _In_ ID3D12Device* device,
-        _Inout_ ResourceUploadBatch& resourceUploadBatch,
+        ResourceUploadBatch& resourceUploadBatch,
         _In_ size_t numDescriptors,
         _In_ D3D12_DESCRIPTOR_HEAP_FLAGS descriptorHeapFlags)
         : mPath{}
@@ -202,19 +203,21 @@ void EffectTextureFactory::Impl::ReleaseCache()
 // EffectTextureFactory
 //--------------------------------------------------------------------------------------
 
+_Use_decl_annotations_
 EffectTextureFactory::EffectTextureFactory(
-    _In_ ID3D12Device* device,
-    _Inout_ ResourceUploadBatch& resourceUploadBatch,
-    _In_ ID3D12DescriptorHeap* descriptorHeap)
+    ID3D12Device* device,
+    ResourceUploadBatch& resourceUploadBatch,
+    ID3D12DescriptorHeap* descriptorHeap)
 {
     pImpl = std::make_unique<Impl>(device, resourceUploadBatch, descriptorHeap);
 }
 
+_Use_decl_annotations_
 EffectTextureFactory::EffectTextureFactory(
-    _In_ ID3D12Device* device,
-    _Inout_ ResourceUploadBatch& resourceUploadBatch,
-    _In_ size_t numDescriptors,
-    _In_ D3D12_DESCRIPTOR_HEAP_FLAGS descriptorHeapFlags)
+    ID3D12Device* device,
+    ResourceUploadBatch& resourceUploadBatch,
+    size_t numDescriptors,
+    D3D12_DESCRIPTOR_HEAP_FLAGS descriptorHeapFlags)
 {
     pImpl = std::make_unique<Impl>(device, resourceUploadBatch, numDescriptors, descriptorHeapFlags);
 }

--- a/Src/Model.cpp
+++ b/Src/Model.cpp
@@ -280,7 +280,8 @@ void Model::LoadBuffers(
 
             resourceUploadBatch.Upload(part->staticVertexBuffer.Get(), part->vertexBuffer);
 
-            resourceUploadBatch.Transition(part->staticVertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER);
+            resourceUploadBatch.Transition(part->staticVertexBuffer.Get(),
+                D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER);
 
             // Scan for any other part with the same vertex buffer for sharing
             for (auto sit = std::next(it); sit != uniqueParts.cend(); ++sit)
@@ -333,7 +334,8 @@ void Model::LoadBuffers(
 
             resourceUploadBatch.Upload(part->staticIndexBuffer.Get(), part->indexBuffer);
 
-            resourceUploadBatch.Transition(part->staticIndexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_INDEX_BUFFER);
+            resourceUploadBatch.Transition(part->staticIndexBuffer.Get(),
+                D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_INDEX_BUFFER);
 
             // Scan for any other part with the same index buffer for sharing
             for (auto sit = std::next(it); sit != uniqueParts.cend(); ++sit)

--- a/Src/Model.cpp
+++ b/Src/Model.cpp
@@ -231,7 +231,7 @@ std::unique_ptr<EffectTextureFactory> Model::LoadTextures(
 
 // Load VB/IB resources for static geometry
 _Use_decl_annotations_
-void Model::LoadBuffers(
+void Model::LoadStaticBuffers(
     ID3D12Device* device,
     ResourceUploadBatch& resourceUploadBatch,
     bool keepMemory)

--- a/Src/Model.cpp
+++ b/Src/Model.cpp
@@ -281,7 +281,22 @@ void Model::LoadBuffers(
             resourceUploadBatch.Transition(part->staticVertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER);
 
             // Scan for any other part with the same vertex buffer for sharing
-            // TODO -
+            for (auto sharePart : uniqueParts)
+            {
+                if (sharePart == part || sharePart->staticVertexBuffer)
+                    continue;
+
+                if (sharePart->vertexBuffer == part->vertexBuffer)
+                {
+                    sharePart->vertexBufferSize = part->vertexBufferSize;
+                    sharePart->staticVertexBuffer = part->staticVertexBuffer;
+
+                    if (!keepMemory)
+                    {
+                        sharePart->vertexBuffer.Reset();
+                    }
+                }
+            }
 
             if (!keepMemory)
             {
@@ -316,7 +331,22 @@ void Model::LoadBuffers(
             resourceUploadBatch.Transition(part->staticIndexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_INDEX_BUFFER);
 
             // Scan for any other part with the same index buffer for sharing
-            // TODO -
+            for (auto sharePart : uniqueParts)
+            {
+                if (sharePart == part || sharePart->staticIndexBuffer)
+                    continue;
+
+                if (sharePart->indexBuffer == part->indexBuffer)
+                {
+                    sharePart->indexBufferSize = part->indexBufferSize;
+                    sharePart->staticIndexBuffer = part->staticIndexBuffer;
+
+                    if (!keepMemory)
+                    {
+                        sharePart->indexBuffer.Reset();
+                    }
+                }
+            }
 
             if (!keepMemory)
             {

--- a/Src/Model.cpp
+++ b/Src/Model.cpp
@@ -252,8 +252,10 @@ void Model::LoadBuffers(
 
     CD3DX12_HEAP_PROPERTIES heapProperties(D3D12_HEAP_TYPE_DEFAULT);
 
-    for (auto part : uniqueParts)
+    for(auto it = uniqueParts.cbegin(); it != uniqueParts.cend(); ++it)
     {
+        auto part = *it;
+
         // Convert dynamic VB to static VB
         if (!part->staticVertexBuffer)
         {
@@ -281,9 +283,12 @@ void Model::LoadBuffers(
             resourceUploadBatch.Transition(part->staticVertexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER);
 
             // Scan for any other part with the same vertex buffer for sharing
-            for (auto sharePart : uniqueParts)
+            for (auto sit = std::next(it); sit != uniqueParts.cend(); ++sit)
             {
-                if (sharePart == part || sharePart->staticVertexBuffer)
+                auto sharePart = *sit;
+                assert(sharePart != part);
+
+                if (sharePart->staticVertexBuffer)
                     continue;
 
                 if (sharePart->vertexBuffer == part->vertexBuffer)
@@ -331,9 +336,12 @@ void Model::LoadBuffers(
             resourceUploadBatch.Transition(part->staticIndexBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_INDEX_BUFFER);
 
             // Scan for any other part with the same index buffer for sharing
-            for (auto sharePart : uniqueParts)
+            for (auto sit = std::next(it); sit != uniqueParts.cend(); ++sit)
             {
-                if (sharePart == part || sharePart->staticIndexBuffer)
+                auto sharePart = *sit;
+                assert(sharePart != part);
+
+                if (sharePart->staticIndexBuffer)
                     continue;
 
                 if (sharePart->indexBuffer == part->indexBuffer)
@@ -355,7 +363,6 @@ void Model::LoadBuffers(
         }
     }
 }
-
 
 
 // Create effects for each mesh piece

--- a/Src/ModelLoadSDKMESH.cpp
+++ b/Src/ModelLoadSDKMESH.cpp
@@ -549,12 +549,14 @@ std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(const uint8_t* meshData
             // Vertex data
             auto verts = bufferData + (vh.DataOffset - bufferDataOffset);
             auto vbytes = static_cast<size_t>(vh.SizeBytes);
+            part->vertexBufferSize = static_cast<uint32_t>(vh.SizeBytes);
             part->vertexBuffer = GraphicsMemory::Get(device).Allocate(vbytes);
             memcpy(part->vertexBuffer.Memory(), verts, vbytes);
 
             // Index data
             auto indices = bufferData + (ih.DataOffset - bufferDataOffset);
             auto ibytes = static_cast<size_t>(ih.SizeBytes);
+            part->indexBufferSize = static_cast<uint32_t>(ih.SizeBytes);
             part->indexBuffer = GraphicsMemory::Get(device).Allocate(ibytes);
             memcpy(part->indexBuffer.Memory(), indices, ibytes);
 

--- a/Src/ModelLoadVBO.cpp
+++ b/Src/ModelLoadVBO.cpp
@@ -87,8 +87,10 @@ std::unique_ptr<Model> DirectX::Model::CreateFromVBO(const uint8_t* meshData, si
     part->materialIndex = 0;
     part->indexCount = header->numIndices;
     part->startIndex = 0;
-    part->vertexStride = static_cast<UINT>(sizeof(VertexPositionNormalTexture));
+    part->vertexStride = static_cast<uint32_t>(sizeof(VertexPositionNormalTexture));
     part->vertexCount = header->numVertices;
+    part->indexBufferSize = static_cast<uint32_t>(indexSize);
+    part->vertexBufferSize = static_cast<uint32_t>(vertSize);
     part->indexBuffer = std::move(ib);
     part->vertexBuffer = std::move(vb);
     part->vbDecl = g_vbdecl;

--- a/Src/ResourceUploadBatch.cpp
+++ b/Src/ResourceUploadBatch.cpp
@@ -256,9 +256,9 @@ public:
     // The resource must be in the COPY_DEST state.
     void Upload(
         _In_ ID3D12Resource* resource,
-        _In_ uint32_t subresourceIndexStart,
+        uint32_t subresourceIndexStart,
         _In_reads_(numSubresources) D3D12_SUBRESOURCE_DATA* subRes,
-        _In_ uint32_t numSubresources)
+        uint32_t numSubresources)
     {
         if (!mInBeginEndBlock)
             throw std::exception("Can't call Upload on a closed ResourceUploadBatch.");
@@ -296,7 +296,7 @@ public:
 
     void Upload(
         _In_ ID3D12Resource* resource,
-        SharedGraphicsResource& buffer)
+        const SharedGraphicsResource& buffer)
     {
         if (!mInBeginEndBlock)
             throw std::exception("Can't call Upload on a closed ResourceUploadBatch.");
@@ -438,8 +438,8 @@ public:
             }
 
             // Delete the batch
-            // Because the vector contains ComPtrs, their destructors will fire and the
-            // resources will be Released.
+            // Because the vectors contain smart-pointers, their destructors will
+            // fire and the resources will be released.
             delete uploadBatch;
         });
 
@@ -447,6 +447,10 @@ public:
         mInBeginEndBlock = false;
         mList.Reset();
         mCmdAlloc.Reset();
+
+        // Swap above should have cleared these
+        assert(mTrackedObjects.empty());
+        assert(mTrackedMemoryResources.empty());
 
         return future;
     }
@@ -826,7 +830,7 @@ void ResourceUploadBatch::Upload(
 _Use_decl_annotations_
 void ResourceUploadBatch::Upload(
     ID3D12Resource* resource,
-    SharedGraphicsResource& buffer
+    const SharedGraphicsResource& buffer
 )
 {
     pImpl->Upload(resource, buffer);

--- a/Src/ResourceUploadBatch.cpp
+++ b/Src/ResourceUploadBatch.cpp
@@ -285,11 +285,29 @@ public:
 
         SetDebugObjectName(scratchResource.Get(), L"ResourceUploadBatch Temporary");
 
-        // Transition the resource to a copy target, copy and transition back
+        // Submit resource copy to command list
         UpdateSubresources(mList.Get(), resource, scratchResource.Get(), 0, subresourceIndexStart, numSubresources, subRes);
 
         // Remember this upload object for delayed release
         mTrackedObjects.push_back(scratchResource);
+
+        PIXEndEvent(mList.Get());
+    }
+
+    void Upload(
+        _In_ ID3D12Resource* resource,
+        SharedGraphicsResource& buffer)
+    {
+        if (!mInBeginEndBlock)
+            throw std::exception("Can't call Upload on a closed ResourceUploadBatch.");
+
+        PIXBeginEvent(mList.Get(), 0, __FUNCTIONW__);
+
+        // Submit resource copy to command list
+        mList->CopyBufferRegion(resource, 0, buffer.Resource(), buffer.ResourceOffset(), buffer.Size());
+
+        // Remember this upload resource for delayed release
+        mTrackedMemoryResources.push_back(buffer);
 
         PIXEndEvent(mList.Get());
     }
@@ -394,11 +412,12 @@ public:
         ThrowIfFailed(fence->SetEventOnCompletion(1ULL, gpuCompletedEvent));
 
         // Create a packet of data that'll be passed to our waiting upload thread
-        UploadBatch* uploadBatch = new UploadBatch();
+        auto uploadBatch = new UploadBatch();
         uploadBatch->CommandList = mList;
         uploadBatch->Fence = fence;
         uploadBatch->GpuCompleteEvent = gpuCompletedEvent;
-        uploadBatch->TrackedObjects.insert(std::end(uploadBatch->TrackedObjects), std::begin(mTrackedObjects), std::end(mTrackedObjects));
+        std::swap(mTrackedObjects, uploadBatch->TrackedObjects);
+        std::swap(mTrackedMemoryResources, uploadBatch->TrackedMemoryResources);
 
         // Kick off a thread that waits for the upload to complete on the GPU timeline.
         // Let the thread run autonomously, but provide a future the user can wait on.
@@ -426,7 +445,6 @@ public:
 
         // Reset our state
         mInBeginEndBlock = false;
-        mTrackedObjects.resize(0);
         mList.Reset();
         mCmdAlloc.Reset();
 
@@ -740,6 +758,7 @@ private:
     struct UploadBatch
     {
         std::vector<ComPtr<ID3D12DeviceChild>>  TrackedObjects;
+        std::vector<SharedGraphicsResource>     TrackedMemoryResources;
         ComPtr<ID3D12GraphicsCommandList>       CommandList;
         ComPtr<ID3D12Fence>  			        Fence;
         HANDLE                                  GpuCompleteEvent;
@@ -753,6 +772,7 @@ private:
     std::unique_ptr<GenerateMipsResources>      mGenMipsResources;
 
     std::vector<ComPtr<ID3D12DeviceChild>>      mTrackedObjects;
+    std::vector<SharedGraphicsResource>         mTrackedMemoryResources;
     bool                                        mInBeginEndBlock;
 };
 
@@ -792,14 +812,26 @@ void ResourceUploadBatch::Begin()
 }
 
 
+_Use_decl_annotations_
 void ResourceUploadBatch::Upload(
-    _In_ ID3D12Resource* resource,
-    _In_ uint32_t subresourceIndexStart,
-    _In_reads_(numSubresources) D3D12_SUBRESOURCE_DATA* subRes,
-    _In_ uint32_t numSubresources)
+    ID3D12Resource* resource,
+    uint32_t subresourceIndexStart,
+    D3D12_SUBRESOURCE_DATA* subRes,
+    uint32_t numSubresources)
 {
     pImpl->Upload(resource, subresourceIndexStart, subRes, numSubresources);
 }
+
+
+_Use_decl_annotations_
+void ResourceUploadBatch::Upload(
+    ID3D12Resource* resource,
+    SharedGraphicsResource& buffer
+)
+{
+    pImpl->Upload(resource, buffer);
+}
+
 
 
 void ResourceUploadBatch::GenerateMips(_In_ ID3D12Resource* resource)
@@ -808,10 +840,11 @@ void ResourceUploadBatch::GenerateMips(_In_ ID3D12Resource* resource)
 }
 
 
+_Use_decl_annotations_
 void ResourceUploadBatch::Transition(
-    _In_ ID3D12Resource* resource,
-    _In_ D3D12_RESOURCE_STATES stateBefore,
-    _In_ D3D12_RESOURCE_STATES stateAfter)
+    ID3D12Resource* resource,
+    D3D12_RESOURCE_STATES stateBefore,
+    D3D12_RESOURCE_STATES stateAfter)
 {
     pImpl->Transition(resource, stateBefore, stateAfter);
 }
@@ -821,4 +854,3 @@ std::future<void> ResourceUploadBatch::End(_In_ ID3D12CommandQueue* commandQueue
 {
     return pImpl->End(commandQueue);
 }
-


### PR DESCRIPTION
In the original implementation, all Model vertex buffers and index buffers are allocated by ``GraphicsMemory``. This means that they are in a upload heap which is accessible to both the CPU and GPU, equivalent to the Direct3D 11 version of ``USAGE_DYNAMIC``. This is simple and easy to use, but has performance impacts--which on Xbox One can be quite noticeable due to the caching behavior.

This change adds an optional call to ``LoadStaticBuffers`` which uses a ``ResourceUploadBatch`` to create static VB/IBs for rendering copying the data from the loaded ``GraphicsMemory`` resources. This is equivalent to ``USAGE_DEFAULT`` in Direct3D 11.

The ``ModelMeshPart`` now contains four new members:

* ``staticVertexBuffer``: If set, then this vertex buffer is used for rendering as the VB in the view. Otherwise it uses ``vertexBuffer``.
* ``staticIndexBuffer``: If set, then this index buffer is used for rendering as the IB in the view. Otherwise it uses ``indexBuffer``.
* ``vertexBufferSize``: The size of the VB for rendering set in the view.
* ``indexBufferSize``: The size of the IB for rendering set in the view.

There is a small breaking change here in that all custom Model loaders must populate the new ``vertexBufferSize`` and ``indexBufferSize`` members of ``ModelMeshPart``.

Custom Model renderers should be updated for all four new member variables.

To support this I added a new ``Upload`` method overload for ``ResourceUploadBatch``. The existing ``Upload`` method copies the data into a staging upload heap resource for use in the copy to the GPU, but here the data is already in an upload heap managed by ``GraphicsMemory`` which we can use directly.

> Also did a little SAL annotation cleanup in a few places, and added comparison operators for ``SharedGraphicsResource``
