### PR TITLE
Individually define albedo/normal/RMA textures

### DIFF
--- a/Inc/Effects.h
+++ b/Inc/Effects.h
@@ -537,6 +537,9 @@ namespace DirectX
             D3D12_GPU_DESCRIPTOR_HANDLE sampler);
 
         void __cdecl SetEmissiveTexture(D3D12_GPU_DESCRIPTOR_HANDLE emissive);
+        void __cdecl SetAlbedoTexture(D3D12_GPU_DESCRIPTOR_HANDLE albedo);
+        void __cdecl SetNormalTexture(D3D12_GPU_DESCRIPTOR_HANDLE normal);
+        void __cdecl SetRMATexture(D3D12_GPU_DESCRIPTOR_HANDLE roughnessMetallicAmbientOcclusion);
 
         // Render target size, required for velocity buffer output.
         void __cdecl SetRenderTargetSizeInPixels(int width, int height);

--- a/Src/PBREffect.cpp
+++ b/Src/PBREffect.cpp
@@ -652,6 +652,21 @@ void PBREffect::SetEmissiveTexture(D3D12_GPU_DESCRIPTOR_HANDLE emissive)
     pImpl->descriptors[Impl::RootParameterIndex::EmissiveTexture] = emissive;
 }
 
+void PBREffect::SetAlbedoTexture(D3D12_GPU_DESCRIPTOR_HANDLE albedo)
+{
+    pImpl->descriptors[Impl::RootParameterIndex::AlbedoTexture] = albedo;
+}
+
+void PBREffect::SetNormalTexture(D3D12_GPU_DESCRIPTOR_HANDLE normal)
+{
+    pImpl->descriptors[Impl::RootParameterIndex::NormalTexture] = normal;
+}
+
+void PBREffect::SetRMATexture(D3D12_GPU_DESCRIPTOR_HANDLE roughnessMetallicAmbientOcclusion)
+{
+    pImpl->descriptors[Impl::RootParameterIndex::RMATexture] = roughnessMetallicAmbientOcclusion;
+}
+
 
 // Additional settings.
 void PBREffect::SetRenderTargetSizeInPixels(int width, int height)


### PR DESCRIPTION
Only a small addition, but allows for the useful ability to individually define new textures for albedo, normal, and RMA.