### PR TITLE
Additional debugging output for GraphicsMemory

### DIFF
--- a/Inc/GraphicsMemory.h
+++ b/Inc/GraphicsMemory.h
@@ -22,9 +22,8 @@ namespace DirectX
 {
     class LinearAllocatorPage;
 
-    //----------------------------------------------------------------------------------
-    // These work like smart-pointers. The memory will only be fenced by the GPU
-    // once the pointer has been invalidated or the user explicitly marks it for fencing.
+    // Works a little like a smart pointer. The memory will only be fenced by the GPU once the pointer
+    // has been invalidated or the user explicitly marks it for fencing.
     class GraphicsResource
     {
     public:
@@ -106,14 +105,6 @@ namespace DirectX
         std::shared_ptr<GraphicsResource> mSharedResource;
     };
 
-    //----------------------------------------------------------------------------------
-    struct GraphicsMemoryStatistics
-    {
-        size_t pendingMemoryBytes;
-        size_t totalMemoryBytes;
-    };
-
-    //----------------------------------------------------------------------------------
     class GraphicsMemory
     {
     public:
@@ -155,9 +146,6 @@ namespace DirectX
         // It is not recommended that you call this unless absolutely necessary (e.g. your
         // memory budget changes at run-time, or perhaps you're changing levels in your game.)
         void __cdecl GarbageCollect();
-
-        // This returns memory statistics for the graphics memory manager.
-        void __cdecl GetStatistics(GraphicsMemoryStatistics& stats) const;
 
         // Singleton
         // Should only use nullptr for single GPU scenarios; mGPU requires a specific device

--- a/Inc/GraphicsMemory.h
+++ b/Inc/GraphicsMemory.h
@@ -22,8 +22,9 @@ namespace DirectX
 {
     class LinearAllocatorPage;
 
-    // Works a little like a smart pointer. The memory will only be fenced by the GPU once the pointer
-    // has been invalidated or the user explicitly marks it for fencing.
+    //----------------------------------------------------------------------------------
+    // These work like smart-pointers. The memory will only be fenced by the GPU
+    // once the pointer has been invalidated or the user explicitly marks it for fencing.
     class GraphicsResource
     {
     public:
@@ -105,6 +106,14 @@ namespace DirectX
         std::shared_ptr<GraphicsResource> mSharedResource;
     };
 
+    //----------------------------------------------------------------------------------
+    struct GraphicsMemoryStatistics
+    {
+        size_t pendingMemoryBytes;
+        size_t totalMemoryBytes;
+    };
+
+    //----------------------------------------------------------------------------------
     class GraphicsMemory
     {
     public:
@@ -146,6 +155,9 @@ namespace DirectX
         // It is not recommended that you call this unless absolutely necessary (e.g. your
         // memory budget changes at run-time, or perhaps you're changing levels in your game.)
         void __cdecl GarbageCollect();
+
+        // This returns memory statistics for the graphics memory manager.
+        void __cdecl GetStatistics(GraphicsMemoryStatistics& stats) const;
 
         // Singleton
         // Should only use nullptr for single GPU scenarios; mGPU requires a specific device

--- a/Src/GraphicsMemory.cpp
+++ b/Src/GraphicsMemory.cpp
@@ -388,6 +388,7 @@ GraphicsResource::~GraphicsResource()
     if (mPage)
     {
         mPage->Release();
+        mPage = nullptr;
     }
 }
 
@@ -402,9 +403,9 @@ void GraphicsResource::Reset()
     if (mPage)
     {
         mPage->Release();
+        mPage = nullptr;
     }
 
-    mPage = nullptr;
     mGpuAddress = {};
     mResource = nullptr;
     mMemory = nullptr;
@@ -417,6 +418,7 @@ void GraphicsResource::Reset(GraphicsResource&& alloc)
     if (mPage)
     {
         mPage->Release();
+        mPage = nullptr;
     }
 
     mGpuAddress = alloc.GpuAddress();

--- a/Src/GraphicsMemory.cpp
+++ b/Src/GraphicsMemory.cpp
@@ -162,22 +162,6 @@ namespace
             }
         }
 
-        void GetStatistics(GraphicsMemoryStatistics& stats) const
-        {
-            ScopedLock lock(mMutex);
-
-            memset(&stats, 0, sizeof(stats));
-
-            for (auto& i : mPools)
-            {
-                if (i != nullptr)
-                {
-                    stats.pendingMemoryBytes += i->CommittedMemoryUsage();
-                    stats.totalMemoryBytes += i->TotalMemoryUsage();
-                }
-            }
-        }
-
         ID3D12Device* GetDevice() const { return mDevice.Get(); }
 
     private:
@@ -247,11 +231,6 @@ public:
     void GarbageCollect()
     {
         mDeviceAllocator->GarbageCollect();
-    }
-
-    void GetStatistics(GraphicsMemoryStatistics& stats) const
-    {
-        mDeviceAllocator->GetStatistics(stats);
     }
 
     GraphicsMemory* mOwner;
@@ -325,10 +304,6 @@ void GraphicsMemory::GarbageCollect()
     pImpl->GarbageCollect();
 }
 
-void GraphicsMemory::GetStatistics(GraphicsMemoryStatistics& stats) const
-{
-    pImpl->GetStatistics(stats);
-}
 
 
 #if defined(_XBOX_ONE) && defined(_TITLE)

--- a/Src/GraphicsMemory.cpp
+++ b/Src/GraphicsMemory.cpp
@@ -115,7 +115,7 @@ namespace
             assert(allocator != nullptr);
             assert(poolSize < MinPageSize || poolSize == allocator->PageSize());
 
-            LinearAllocatorPage* page = allocator->FindPageForAlloc(size, alignment);
+            auto page = allocator->FindPageForAlloc(size, alignment);
             if (!page)
             {
                 DebugTrace("GraphicsMemory failed to allocate page (%zu requested bytes, %zu alignment)\n", size, alignment);
@@ -141,7 +141,7 @@ namespace
 
             for (auto& i : mPools)
             {
-                if (i != nullptr)
+                if (i)
                 {
                     i->RetirePendingPages();
                     i->FenceCommittedPages(commandQueue);
@@ -155,7 +155,7 @@ namespace
 
             for (auto& i : mPools)
             {
-                if (i != nullptr)
+                if (i)
                 {
                     i->Shrink();
                 }
@@ -368,6 +368,7 @@ GraphicsResource::GraphicsResource(
     , mBufferOffset(offset)
     , mSize(size)
 {
+    assert(mPage != nullptr);
     mPage->AddRef();
 }
 
@@ -384,7 +385,7 @@ GraphicsResource::GraphicsResource(GraphicsResource&& other) noexcept
 
 GraphicsResource::~GraphicsResource()
 {
-    if (mPage != nullptr)
+    if (mPage)
     {
         mPage->Release();
     }
@@ -398,7 +399,7 @@ GraphicsResource&& GraphicsResource::operator= (GraphicsResource&& other) noexce
 
 void GraphicsResource::Reset()
 {
-    if (mPage != nullptr)
+    if (mPage)
     {
         mPage->Release();
     }
@@ -413,7 +414,7 @@ void GraphicsResource::Reset()
 
 void GraphicsResource::Reset(GraphicsResource&& alloc)
 {
-    if (mPage != nullptr)
+    if (mPage)
     {
         mPage->Release();
     }

--- a/Src/GraphicsMemory.cpp
+++ b/Src/GraphicsMemory.cpp
@@ -305,7 +305,6 @@ void GraphicsMemory::GarbageCollect()
 }
 
 
-
 #if defined(_XBOX_ONE) && defined(_TITLE)
 GraphicsMemory& GraphicsMemory::Get(_In_opt_ ID3D12Device*)
 {

--- a/Src/LinearAllocator.cpp
+++ b/Src/LinearAllocator.cpp
@@ -12,6 +12,7 @@
 #include "PlatformHelpers.h"
 #include "LinearAllocator.h"
 
+// Set this to 1 to enable some additional debug validation
 #define VALIDATE_LISTS 0
 
 #if VALIDATE_LISTS
@@ -26,7 +27,7 @@ LinearAllocatorPage::LinearAllocatorPage() noexcept
     , pNextPage(nullptr)
     , mMemory(nullptr)
     , mPendingFence(0)
-    , mGpuAddress {}
+    , mGpuAddress{}
     , mOffset(0)
     , mSize(0)
     , mRefCount(1)
@@ -36,10 +37,12 @@ LinearAllocatorPage::LinearAllocatorPage() noexcept
 size_t LinearAllocatorPage::Suballocate(_In_ size_t size, _In_ size_t alignment)
 {
     size_t offset = AlignUp(mOffset, alignment);
-#ifdef _DEBUG
     if (offset + size > mSize)
-        throw std::exception("Out of free memory in page suballoc");
-#endif
+    {
+        // Use of suballocate should be limited to pages with free space,
+        // so really shouldn't happen.
+        throw std::exception("LinearAllocatorPage::Suballocate");
+    }
     mOffset = offset + size;
     return offset;
 }
@@ -55,6 +58,8 @@ void LinearAllocatorPage::Release()
     }
 }
 
+
+//--------------------------------------------------------------------------------------
 LinearAllocator::LinearAllocator(
     _In_ ID3D12Device* pDevice,
     _In_ size_t pageSize,
@@ -76,7 +81,9 @@ LinearAllocator::LinearAllocator(
     {
         if (GetNewPage() == nullptr)
         {
-            throw std::exception("Out of memory.");
+            DebugTrace("LinearAllocator failed to preallocate pages (%zu required bytes, %zu pages)\n",
+                preallocatePageCount * m_increment, preallocatePageCount);
+            throw std::bad_alloc();
         }
     }
 }
@@ -112,10 +119,10 @@ LinearAllocatorPage* LinearAllocator::FindPageForAlloc(_In_ size_t size, _In_ si
         throw std::exception("Cannot honor zero size allocation request.");
 #endif
 
-    LinearAllocatorPage* page = GetPageForAlloc(size, alignment);
-    if (page == nullptr)
+    auto page = GetPageForAlloc(size, alignment);
+    if (!page)
     {
-        throw std::exception("Out of memory.");
+        return nullptr;
     }
 
     return page;
@@ -133,7 +140,7 @@ void LinearAllocator::FenceCommittedPages(_In_ ID3D12CommandQueue* commandQueue)
     LinearAllocatorPage* readyPages = nullptr;
     LinearAllocatorPage* unreadyPages = nullptr;
     LinearAllocatorPage* nextPage = nullptr;
-    for (LinearAllocatorPage* page = m_usedPages; page != nullptr; page = nextPage)
+    for (auto page = m_usedPages; page != nullptr; page = nextPage)
     {
         nextPage = page->pNextPage;
 
@@ -182,7 +189,7 @@ void LinearAllocator::RetirePendingPages()
 {
     // For each page that we know has a fence pending, check it. If the fence has passed,
     // we can mark the page for re-use.
-    LinearAllocatorPage* page = m_pendingPages;
+    auto page = m_pendingPages;
     while (page != nullptr)
     {
         LinearAllocatorPage* nextPage = page->pNextPage;
@@ -212,14 +219,13 @@ void LinearAllocator::Shrink()
 LinearAllocatorPage* LinearAllocator::GetCleanPageForAlloc()
 {
     // Grab the first unused page, if one exists. Else, allocate a new page.
-    LinearAllocatorPage* page = m_unusedPages;
-    if (page == nullptr)
+    auto page = m_unusedPages;
+    if (!page)
     {
         // Allocate a new page
         page = GetNewPage();
-        if (page == nullptr)
+        if (!page)
         {
-            // OOM.
             return nullptr;
         }
     }
@@ -244,8 +250,8 @@ LinearAllocatorPage* LinearAllocator::GetPageForAlloc(
     }
 
     // Find a page in the pending pages list that has space.
-    LinearAllocatorPage* page = FindPageForAlloc(m_usedPages, sizeBytes, alignment);
-    if (page == nullptr)
+    auto page = FindPageForAlloc(m_usedPages, sizeBytes, alignment);
+    if (!page)
     {
         page = GetCleanPageForAlloc();
     }
@@ -258,7 +264,7 @@ LinearAllocatorPage* LinearAllocator::FindPageForAlloc(
     size_t sizeBytes,
     size_t alignment)
 {
-    for (LinearAllocatorPage* page = list; page != nullptr; page = page->pNextPage)
+    for (auto page = list; page != nullptr; page = page->pNextPage)
     {
         size_t offset = AlignUp(page->mOffset, alignment);
         if (offset + sizeBytes <= m_increment)
@@ -269,20 +275,24 @@ LinearAllocatorPage* LinearAllocator::FindPageForAlloc(
 
 LinearAllocatorPage* LinearAllocator::GetNewPage()
 {
-    ComPtr<ID3D12Resource> spResource;
-
     CD3DX12_HEAP_PROPERTIES uploadHeapProperties(D3D12_HEAP_TYPE_UPLOAD);
     CD3DX12_RESOURCE_DESC bufferDesc = CD3DX12_RESOURCE_DESC::Buffer(m_increment);
 
     // Allocate the upload heap
-    if (FAILED(m_device->CreateCommittedResource(
+    ComPtr<ID3D12Resource> spResource;
+    HRESULT hr = m_device->CreateCommittedResource(
         &uploadHeapProperties,
         D3D12_HEAP_FLAG_NONE,
         &bufferDesc,
         D3D12_RESOURCE_STATE_GENERIC_READ,
         nullptr,
-        IID_GRAPHICS_PPV_ARGS(spResource.ReleaseAndGetAddressOf()))))
+        IID_GRAPHICS_PPV_ARGS(spResource.ReleaseAndGetAddressOf()));
+    if (FAILED(hr))
     {
+        if (hr != E_OUTOFMEMORY)
+        {
+            DebugTrace("LinearAllocator::GetNewPage resource allocation failed due with unexpected error %08X\n", hr);
+        }
         return nullptr;
     }
 
@@ -297,18 +307,20 @@ LinearAllocatorPage* LinearAllocator::GetNewPage()
 
     // Create a fence
     ComPtr<ID3D12Fence> spFence;
-    if (FAILED(m_device->CreateFence(
+    hr = m_device->CreateFence(
         0,
         D3D12_FENCE_FLAG_NONE,
-        IID_GRAPHICS_PPV_ARGS(spFence.ReleaseAndGetAddressOf()))))
+        IID_GRAPHICS_PPV_ARGS(spFence.ReleaseAndGetAddressOf()));
+    if (FAILED(hr))
     {
+        DebugTrace("LinearAllocator::GetNewPage failed to allocate fence with error %08X\n", hr);
         return nullptr;
     }
 
     SetDebugObjectName(spFence.Get(), L"LinearAllocator");
 
     // Add the page to the page list
-    LinearAllocatorPage* page = new LinearAllocatorPage;
+    auto page = new LinearAllocatorPage;
     page->mSize = m_increment;
     page->mMemory = pMemory;
     page->pPrevPage = nullptr;
@@ -442,7 +454,7 @@ void LinearAllocator::FreePages(LinearAllocatorPage* page)
 #if VALIDATE_LISTS
 void LinearAllocator::ValidateList(LinearAllocatorPage* list)
 {
-    for (LinearAllocatorPage* page = list, *lastPage = nullptr;
+    for (auto page = list, *lastPage = nullptr;
         page != nullptr;
         lastPage = page, page = page->pNextPage)
     {
@@ -484,7 +496,7 @@ void LinearAllocator::SetDebugName(const wchar_t* name)
 
 void LinearAllocator::SetPageDebugName(LinearAllocatorPage* list)
 {
-    for (LinearAllocatorPage* page = list; page != nullptr; page = page->pNextPage)
+    for (auto page = list; page != nullptr; page = page->pNextPage)
     {
         page->mUploadResource->SetName(m_debugName.c_str());
     }

--- a/Src/LinearAllocator.cpp
+++ b/Src/LinearAllocator.cpp
@@ -291,7 +291,7 @@ LinearAllocatorPage* LinearAllocator::GetNewPage()
     {
         if (hr != E_OUTOFMEMORY)
         {
-            DebugTrace("LinearAllocator::GetNewPage resource allocation failed due with unexpected error %08X\n", hr);
+            DebugTrace("LinearAllocator::GetNewPage resource allocation failed due to unexpected error %08X\n", hr);
         }
         return nullptr;
     }

--- a/Src/LinearAllocator.h
+++ b/Src/LinearAllocator.h
@@ -32,7 +32,7 @@
 //
 //      allocator.RetirePages();
 //      allocator.InsertFences( pContext, 0 );
-//      DXGIXPresentArray(...);
+//      Present(...);
 //
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
@@ -51,6 +51,12 @@ namespace DirectX
     {
     public:
         LinearAllocatorPage() noexcept;
+
+        LinearAllocatorPage(LinearAllocatorPage&&) = default;
+        LinearAllocatorPage& operator= (LinearAllocatorPage&&) = default;
+
+        LinearAllocatorPage(LinearAllocatorPage const&) = delete;
+        LinearAllocatorPage& operator=(LinearAllocatorPage const&) = delete;
 
         size_t Suballocate(_In_ size_t size, _In_ size_t alignment);
 
@@ -93,13 +99,13 @@ namespace DirectX
             _In_ size_t pageSize,
             _In_ size_t preallocateBytes = 0);
 
-        LinearAllocator(const LinearAllocator& m) = delete;
-        LinearAllocator& operator = (const LinearAllocator& m) = delete;
+        LinearAllocator(LinearAllocator&&) = default;
+        LinearAllocator& operator= (LinearAllocator&&) = default;
+
+        LinearAllocator(LinearAllocator const&) = delete;
+        LinearAllocator& operator=(LinearAllocator const&) = delete;
 
         ~LinearAllocator();
-
-        // Allow move semantics on this object.
-        LinearAllocator(LinearAllocator&& m) = default;
 
         LinearAllocatorPage* FindPageForAlloc(_In_ size_t requestedSize, _In_ size_t alignment);
 


### PR DESCRIPTION
Added a few more ``DebugTrace`` statements around failure points with GraphicsMemory to help in debugging out-of-memory scenarios.

Also applied some code review feedback to the memory code.