### PR TITLE
Added ModelLoaderFlags

### DIFF
--- a/Inc/Model.h
+++ b/Inc/Model.h
@@ -42,6 +42,14 @@ namespace DirectX
     class ModelMesh;
 
     //----------------------------------------------------------------------------------
+    // Model loading options
+    enum ModelLoaderFlags : uint32_t
+    {
+        ModelLoader_Default = 0,
+        ModelLoader_AllowLargeModels = 0x10000,
+    };
+
+    //----------------------------------------------------------------------------------
     // Each mesh part is a submesh with a single effect
     class ModelMeshPart
     {
@@ -249,12 +257,24 @@ namespace DirectX
             int samplerDescriptorOffset = 0) const;
 
         // Loads a model from a DirectX SDK .SDKMESH file
-        static std::unique_ptr<Model> __cdecl CreateFromSDKMESH(_In_reads_bytes_(dataSize) const uint8_t* meshData, _In_ size_t dataSize, _In_opt_ ID3D12Device* device = nullptr);
-        static std::unique_ptr<Model> __cdecl CreateFromSDKMESH(_In_z_ const wchar_t* szFileName, _In_opt_ ID3D12Device* device = nullptr);
+        static std::unique_ptr<Model> __cdecl CreateFromSDKMESH(
+            _In_opt_ ID3D12Device* device,
+            _In_reads_bytes_(dataSize) const uint8_t* meshData, _In_ size_t dataSize,
+            uint32_t flags = ModelLoader_Default);
+        static std::unique_ptr<Model> __cdecl CreateFromSDKMESH(
+            _In_opt_ ID3D12Device* device,
+            _In_z_ const wchar_t* szFileName,
+            uint32_t flags = ModelLoader_Default);
 
         // Loads a model from a .VBO file
-        static std::unique_ptr<Model> __cdecl CreateFromVBO(_In_reads_bytes_(dataSize) const uint8_t* meshData, _In_ size_t dataSize, _In_opt_ ID3D12Device* device = nullptr);
-        static std::unique_ptr<Model> __cdecl CreateFromVBO(_In_z_ const wchar_t* szFileName, _In_opt_ ID3D12Device* device = nullptr);
+        static std::unique_ptr<Model> __cdecl CreateFromVBO(
+            _In_opt_ ID3D12Device* device,
+            _In_reads_bytes_(dataSize) const uint8_t* meshData, _In_ size_t dataSize,
+            uint32_t flags = ModelLoader_Default);
+        static std::unique_ptr<Model> __cdecl CreateFromVBO(
+            _In_opt_ ID3D12Device* device,
+            _In_z_ const wchar_t* szFileName,
+            uint32_t flags = ModelLoader_Default);
 
         // Utility function for getting a GPU descriptor for a mesh part/material index. If there is no texture the 
         // descriptor will be zero.

--- a/Inc/Model.h
+++ b/Inc/Model.h
@@ -45,9 +45,12 @@ namespace DirectX
     // Model loading options
     enum ModelLoaderFlags : uint32_t
     {
-        ModelLoader_Default = 0,
-        ModelLoader_AllowLargeModels = 0x10000,
+        ModelLoader_Default             = 0x0,
+        ModelLoader_MaterialColorsSRGB  = 0x1,
+        ModelLoader_AllowLargeModels    = 0x2,
     };
+
+    inline ModelLoaderFlags operator|(ModelLoaderFlags a, ModelLoaderFlags b) noexcept { return static_cast<ModelLoaderFlags>(static_cast<int>(a) | static_cast<int>(b)); }
 
     //----------------------------------------------------------------------------------
     // Each mesh part is a submesh with a single effect
@@ -260,21 +263,21 @@ namespace DirectX
         static std::unique_ptr<Model> __cdecl CreateFromSDKMESH(
             _In_opt_ ID3D12Device* device,
             _In_reads_bytes_(dataSize) const uint8_t* meshData, _In_ size_t dataSize,
-            uint32_t flags = ModelLoader_Default);
+            ModelLoaderFlags flags = ModelLoader_Default);
         static std::unique_ptr<Model> __cdecl CreateFromSDKMESH(
             _In_opt_ ID3D12Device* device,
             _In_z_ const wchar_t* szFileName,
-            uint32_t flags = ModelLoader_Default);
+            ModelLoaderFlags flags = ModelLoader_Default);
 
         // Loads a model from a .VBO file
         static std::unique_ptr<Model> __cdecl CreateFromVBO(
             _In_opt_ ID3D12Device* device,
             _In_reads_bytes_(dataSize) const uint8_t* meshData, _In_ size_t dataSize,
-            uint32_t flags = ModelLoader_Default);
+            ModelLoaderFlags flags = ModelLoader_Default);
         static std::unique_ptr<Model> __cdecl CreateFromVBO(
             _In_opt_ ID3D12Device* device,
             _In_z_ const wchar_t* szFileName,
-            uint32_t flags = ModelLoader_Default);
+            ModelLoaderFlags flags = ModelLoader_Default);
 
         // Utility function for getting a GPU descriptor for a mesh part/material index. If there is no texture the 
         // descriptor will be zero.

--- a/Src/ModelLoadVBO.cpp
+++ b/Src/ModelLoadVBO.cpp
@@ -50,7 +50,7 @@ _Use_decl_annotations_
 std::unique_ptr<Model> DirectX::Model::CreateFromVBO(
     ID3D12Device* device,
     const uint8_t* meshData, size_t dataSize,
-    uint32_t flags)
+    ModelLoaderFlags flags)
 {
     if (!InitOnceExecuteOnce(&g_InitOnce, InitializeDecl, nullptr, nullptr))
         throw std::exception("One-time initialization failed");
@@ -135,7 +135,7 @@ _Use_decl_annotations_
 std::unique_ptr<Model> DirectX::Model::CreateFromVBO(
     ID3D12Device* device,
     const wchar_t* szFileName,
-    uint32_t flags)
+    ModelLoaderFlags flags)
 {
     size_t dataSize = 0;
     std::unique_ptr<uint8_t[]> data;


### PR DESCRIPTION
A few minor feature requests and some other workflows I have made me revisit the Model loader APIs. This rearranges the optional device value first to be more consistent with DirectXTK--it can be null.

Also added two features:

* Allowing models that are larger than the 'required resource support size' constants for Direct3D

* Converting material color information in ``SDKMESH`` from sRGB colorspace to linear.

> Breaking change to ``Model::CreateFrom*`` methods but it's easy to fix up. Just put the ``device`` or ``nullptr`` first.