### PR TITLE
ResourceUploadBatch updated to support copy & compute queues

### DIFF
--- a/Inc/GeometricPrimitive.h
+++ b/Inc/GeometricPrimitive.h
@@ -62,7 +62,17 @@ namespace DirectX
         static void __cdecl CreateTeapot(std::vector<VertexType>& vertices, std::vector<uint16_t>& indices, float size = 1, size_t tessellation = 8, bool rhcoords = true);
 
         // Load VB/IB resources for static geometry.
-        void __cdecl LoadStaticBuffers(_In_ ID3D12Device* device, ResourceUploadBatch& resourceUploadBatch);
+        void __cdecl LoadStaticBuffers(
+            _In_ ID3D12Device* device,
+            ResourceUploadBatch& resourceUploadBatch);
+
+        // Transition VB/IB resources for static geometry.
+        void __cdecl Transition(
+            _In_ ID3D12GraphicsCommandList* commandList,
+            D3D12_RESOURCE_STATES stateBeforeVB,
+            D3D12_RESOURCE_STATES stateAfterVB,
+            D3D12_RESOURCE_STATES stateBeforeIB,
+            D3D12_RESOURCE_STATES stateAfterIB);
 
         // Draw the primitive.
         void __cdecl Draw(_In_ ID3D12GraphicsCommandList* commandList) const;

--- a/Inc/ResourceUploadBatch.h
+++ b/Inc/ResourceUploadBatch.h
@@ -38,7 +38,7 @@ namespace DirectX
         virtual ~ResourceUploadBatch();
 
         // Call this before your multiple calls to Upload.
-        void __cdecl Begin();
+        void __cdecl Begin(D3D12_COMMAND_LIST_TYPE commandType = D3D12_COMMAND_LIST_TYPE_DIRECT);
 
         // Asynchronously uploads a resource. The memory in subRes is copied.
         // The resource must be in the COPY_DEST state.
@@ -66,8 +66,7 @@ namespace DirectX
         // Submits all the uploads to the driver.
         // No more uploads can happen after this call until Begin is called again.
         // This returns a handle to an event that can be waited on.
-        std::future<void> __cdecl End(
-            _In_ ID3D12CommandQueue* commandQueue);
+        std::future<void> __cdecl End(_In_ ID3D12CommandQueue* commandQueue);
 
         // Validates if the given DXGI format is supported for autogen mipmaps
         bool __cdecl IsSupportedForGenerateMips(DXGI_FORMAT format) noexcept;

--- a/Src/ResourceUploadBatch.cpp
+++ b/Src/ResourceUploadBatch.cpp
@@ -305,6 +305,7 @@ public:
     Impl(
         _In_ ID3D12Device* device) noexcept
         : mDevice(device)
+        , mCommandType(D3D12_COMMAND_LIST_TYPE_DIRECT)
         , mInBeginEndBlock(false)
         , mTypedUAVLoadAdditionalFormats(false)
         , mStandardSwizzle64KBSupported(false)
@@ -322,19 +323,32 @@ public:
     }
 
     // Call this before your multiple calls to Upload.
-    void Begin()
+    void Begin(D3D12_COMMAND_LIST_TYPE commandType)
     {
         if (mInBeginEndBlock)
             throw std::exception("Can't Begin: already in a Begin-End block.");
 
-        ThrowIfFailed(mDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_GRAPHICS_PPV_ARGS(mCmdAlloc.ReleaseAndGetAddressOf())));
+        switch (commandType)
+        {
+        case D3D12_COMMAND_LIST_TYPE_DIRECT:
+        case D3D12_COMMAND_LIST_TYPE_COMPUTE:
+        case D3D12_COMMAND_LIST_TYPE_COPY:
+            break;
+
+        default:
+            DebugTrace("ResourceUploadBatch only supports Direct, Compute, and Copy command queues\n");
+            throw std::invalid_argument("ResourceUploadBatch ");
+        }
+
+        ThrowIfFailed(mDevice->CreateCommandAllocator(commandType, IID_GRAPHICS_PPV_ARGS(mCmdAlloc.ReleaseAndGetAddressOf())));
 
         SetDebugObjectName(mCmdAlloc.Get(), L"ResourceUploadBatch");
 
-        ThrowIfFailed(mDevice->CreateCommandList(1, D3D12_COMMAND_LIST_TYPE_DIRECT, mCmdAlloc.Get(), nullptr, IID_GRAPHICS_PPV_ARGS(mList.ReleaseAndGetAddressOf())));
+        ThrowIfFailed(mDevice->CreateCommandList(1, commandType, mCmdAlloc.Get(), nullptr, IID_GRAPHICS_PPV_ARGS(mList.ReleaseAndGetAddressOf())));
 
         SetDebugObjectName(mList.Get(), L"ResourceUploadBatch");
 
+        mCommandType = commandType;
         mInBeginEndBlock = true;
     }
 
@@ -399,12 +413,20 @@ public:
 
     // Asynchronously generate mips from a resource.
     // Resource must be in the PIXEL_SHADER_RESOURCE state
-    void GenerateMips(
-        _In_ ID3D12Resource* resource)
+    void GenerateMips(_In_ ID3D12Resource* resource)
     {
         if (resource == nullptr)
         {
             throw std::invalid_argument("Nullptr passed to GenerateMips");
+        }
+
+        if (!mInBeginEndBlock)
+            throw std::exception("Can't call GenerateMips on a closed ResourceUploadBatch.");
+
+        if (mCommandType == D3D12_COMMAND_LIST_TYPE_COPY)
+        {
+            DebugTrace("ERROR: GenerateMips cannot operate on a copy queue\n");
+            throw std::exception("GenerateMips cannot operate on a copy queue");
         }
 
         const auto desc = resource->GetDesc();
@@ -476,6 +498,13 @@ public:
         if (!mInBeginEndBlock)
             throw std::exception("Can't call Upload on a closed ResourceUploadBatch.");
 
+        if (stateAfter == D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE
+            || stateAfter == D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE)
+        {
+            if (mCommandType == D3D12_COMMAND_LIST_TYPE_COPY || mCommandType == D3D12_COMMAND_LIST_TYPE_COMPUTE)
+                return;
+        }
+
         TransitionResource(mList.Get(), resource, stateBefore, stateAfter);
     }
 
@@ -539,6 +568,7 @@ public:
         });
 
         // Reset our state
+        mCommandType = D3D12_COMMAND_LIST_TYPE_DIRECT;
         mInBeginEndBlock = false;
         mList.Reset();
         mCmdAlloc.Reset();
@@ -603,14 +633,17 @@ private:
 
             SetDebugObjectName(staging.Get(), L"GenerateMips Staging");
 
+            D3D12_RESOURCE_STATES originalState = (mCommandType == D3D12_COMMAND_LIST_TYPE_COMPUTE)
+                ? D3D12_RESOURCE_STATE_COPY_DEST : D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+
             // Copy the top mip of resource to staging
-            Transition(resource, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_COPY_SOURCE);
+            TransitionResource(mList.Get(), resource, originalState, D3D12_RESOURCE_STATE_COPY_SOURCE);
 
             CD3DX12_TEXTURE_COPY_LOCATION src(resource, 0);
             CD3DX12_TEXTURE_COPY_LOCATION dst(staging.Get(), 0);
             mList->CopyTextureRegion(&dst, 0, 0, 0, &src, nullptr);
 
-            Transition(staging.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+            TransitionResource(mList.Get(), staging.Get(), D3D12_RESOURCE_STATE_COPY_DEST, originalState);
         }
         else
         {
@@ -659,12 +692,15 @@ private:
         barrierUAV.Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE;
         barrierUAV.UAV.pResource = staging.Get();
 
+        D3D12_RESOURCE_STATES originalState = mCommandType == D3D12_COMMAND_LIST_TYPE_COMPUTE
+            ? D3D12_RESOURCE_STATE_COPY_DEST : D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+
         // Barrier for transitioning the subresources to UAVs
         D3D12_RESOURCE_BARRIER srv2uavDesc = {};
         srv2uavDesc.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
         srv2uavDesc.Transition.pResource = staging.Get();
         srv2uavDesc.Transition.Subresource = 0;
-        srv2uavDesc.Transition.StateBefore = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+        srv2uavDesc.Transition.StateBefore = originalState;
         srv2uavDesc.Transition.StateAfter = D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
 
         // Barrier for transitioning the subresources to SRVs
@@ -673,7 +709,7 @@ private:
         uav2srvDesc.Transition.pResource = staging.Get();
         uav2srvDesc.Transition.Subresource = 0;
         uav2srvDesc.Transition.StateBefore = D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
-        uav2srvDesc.Transition.StateAfter = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+        uav2srvDesc.Transition.StateAfter = originalState;
 
         // based on format, select srgb or not
         ComPtr<ID3D12PipelineState> pso = mGenMipsResources->generateMipsPSO;
@@ -738,7 +774,7 @@ private:
             barrier[0].Type = barrier[1].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
             barrier[0].Transition.Subresource = barrier[1].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
             barrier[0].Transition.pResource = staging.Get();
-            barrier[0].Transition.StateBefore = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+            barrier[0].Transition.StateBefore = originalState;
             barrier[0].Transition.StateAfter = D3D12_RESOURCE_STATE_COPY_SOURCE;
 
             barrier[1].Transition.pResource = resource;
@@ -751,7 +787,7 @@ private:
             mList->CopyResource(resource, staging.Get());
 
             // Transition the target resource back to pixel shader resource
-            Transition(resource, D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+            TransitionResource(mList.Get(), resource, D3D12_RESOURCE_STATE_COPY_DEST, originalState);
 
             mTrackedObjects.push_back(staging);
         }
@@ -788,14 +824,17 @@ private:
 
         SetDebugObjectName(resourceCopy.Get(), L"GenerateMips Resource Copy");
 
+        D3D12_RESOURCE_STATES originalState = mCommandType == D3D12_COMMAND_LIST_TYPE_COMPUTE
+            ? D3D12_RESOURCE_STATE_COPY_DEST : D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+
         // Copy the top mip of resource data
-        Transition(resource, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_COPY_SOURCE);
+        TransitionResource(mList.Get(), resource, originalState, D3D12_RESOURCE_STATE_COPY_SOURCE);
 
         CD3DX12_TEXTURE_COPY_LOCATION src(resource, 0);
         CD3DX12_TEXTURE_COPY_LOCATION dst(resourceCopy.Get(), 0);
         mList->CopyTextureRegion(&dst, 0, 0, 0, &src, nullptr);
 
-        Transition(resourceCopy.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+        TransitionResource(mList.Get(), resourceCopy.Get(), D3D12_RESOURCE_STATE_COPY_DEST, originalState);
         
         // Generate the mips
         GenerateMips_UnorderedAccessPath(resourceCopy.Get());
@@ -805,7 +844,7 @@ private:
         barrier[0].Type = barrier[1].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
         barrier[0].Transition.Subresource = barrier[1].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
         barrier[0].Transition.pResource = resourceCopy.Get();
-        barrier[0].Transition.StateBefore = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+        barrier[0].Transition.StateBefore = originalState;
         barrier[0].Transition.StateAfter = D3D12_RESOURCE_STATE_COPY_SOURCE;
 
         barrier[1].Transition.pResource = resource;
@@ -817,7 +856,7 @@ private:
         // Copy the entire resource back
         mList->CopyResource(resource, resourceCopy.Get());
 
-        Transition(resource, D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+        TransitionResource(mList.Get(), resource, D3D12_RESOURCE_STATE_COPY_DEST, originalState);
 
         // Track these object lifetimes on the GPU
         mTrackedObjects.push_back(resourceCopy);
@@ -877,6 +916,9 @@ private:
 
         SetDebugObjectName(aliasCopy.Get(), L"GenerateMips BGR Alias Copy");
 
+        D3D12_RESOURCE_STATES originalState = (mCommandType == D3D12_COMMAND_LIST_TYPE_COMPUTE)
+            ? D3D12_RESOURCE_STATE_COPY_DEST : D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+
         // Copy the top mip of the resource data BGR to RGB
         D3D12_RESOURCE_BARRIER aliasBarrier[3] = {};
         aliasBarrier[0].Type = D3D12_RESOURCE_BARRIER_TYPE_ALIASING;
@@ -885,7 +927,7 @@ private:
         aliasBarrier[1].Type = aliasBarrier[2].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
         aliasBarrier[1].Transition.Subresource = aliasBarrier[2].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
         aliasBarrier[1].Transition.pResource = resource;
-        aliasBarrier[1].Transition.StateBefore = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+        aliasBarrier[1].Transition.StateBefore = originalState;
         aliasBarrier[1].Transition.StateAfter = D3D12_RESOURCE_STATE_COPY_SOURCE;
 
         mList->ResourceBarrier(2, aliasBarrier);
@@ -900,7 +942,7 @@ private:
 
         aliasBarrier[1].Transition.pResource = resourceCopy.Get();
         aliasBarrier[1].Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_DEST;
-        aliasBarrier[1].Transition.StateAfter = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+        aliasBarrier[1].Transition.StateAfter = originalState;
 
         mList->ResourceBarrier(2, aliasBarrier);
         GenerateMips_UnorderedAccessPath(resourceCopy.Get());
@@ -921,7 +963,7 @@ private:
 
         // Copy the entire resource back
         mList->CopyResource(resource, aliasCopy.Get());
-        Transition(resource, D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+        TransitionResource(mList.Get(), resource, D3D12_RESOURCE_STATE_COPY_DEST, originalState);
 
         // Track these object lifetimes on the GPU
         mTrackedObjects.push_back(heap);
@@ -948,6 +990,8 @@ private:
 
     std::vector<ComPtr<ID3D12DeviceChild>>      mTrackedObjects;
     std::vector<SharedGraphicsResource>         mTrackedMemoryResources;
+
+    D3D12_COMMAND_LIST_TYPE                     mCommandType;
     bool                                        mInBeginEndBlock;
     bool                                        mTypedUAVLoadAdditionalFormats;
     bool                                        mStandardSwizzle64KBSupported;
@@ -983,9 +1027,9 @@ ResourceUploadBatch& ResourceUploadBatch::operator= (ResourceUploadBatch&& moveF
 }
 
 
-void ResourceUploadBatch::Begin()
+void ResourceUploadBatch::Begin(D3D12_COMMAND_LIST_TYPE commandType)
 {
-    pImpl->Begin();
+    pImpl->Begin(commandType);
 }
 
 

--- a/Src/ResourceUploadBatch.cpp
+++ b/Src/ResourceUploadBatch.cpp
@@ -337,7 +337,7 @@ public:
 
         default:
             DebugTrace("ResourceUploadBatch only supports Direct, Compute, and Copy command queues\n");
-            throw std::invalid_argument("ResourceUploadBatch ");
+            throw std::invalid_argument("ResourceUploadBatch");
         }
 
         ThrowIfFailed(mDevice->CreateCommandAllocator(commandType, IID_GRAPHICS_PPV_ARGS(mCmdAlloc.ReleaseAndGetAddressOf())));

--- a/Src/ResourceUploadBatch.cpp
+++ b/Src/ResourceUploadBatch.cpp
@@ -523,11 +523,6 @@ public:
             case D3D12_RESOURCE_STATE_COPY_SOURCE:
                 break;
 
-            case D3D12_RESOURCE_STATE_INDEX_BUFFER:
-            case D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE:
-                stateAfter = D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
-                break;
-
             default:
                 // Ignore other states for compute queues.
                 return;
@@ -644,8 +639,9 @@ private:
 
         CD3DX12_HEAP_PROPERTIES defaultHeapProperties(D3D12_HEAP_TYPE_DEFAULT);
 
+        assert(mCommandType != D3D12_COMMAND_LIST_TYPE_COPY);
         const D3D12_RESOURCE_STATES originalState = (mCommandType == D3D12_COMMAND_LIST_TYPE_COMPUTE)
-            ? D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE : D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+            ? D3D12_RESOURCE_STATE_COPY_DEST : D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
 
         // Create a staging resource if we have to
         ComPtr<ID3D12Resource> staging;
@@ -851,8 +847,9 @@ private:
 
         SetDebugObjectName(resourceCopy.Get(), L"GenerateMips Resource Copy");
 
+        assert(mCommandType != D3D12_COMMAND_LIST_TYPE_COPY);
         const D3D12_RESOURCE_STATES originalState = mCommandType == D3D12_COMMAND_LIST_TYPE_COMPUTE
-            ? D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE : D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+            ? D3D12_RESOURCE_STATE_COPY_DEST : D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
 
         // Copy the top mip of resource data
         TransitionResource(mList.Get(), resource, originalState, D3D12_RESOURCE_STATE_COPY_SOURCE);
@@ -943,8 +940,9 @@ private:
 
         SetDebugObjectName(aliasCopy.Get(), L"GenerateMips BGR Alias Copy");
 
+        assert(mCommandType != D3D12_COMMAND_LIST_TYPE_COPY);
         const D3D12_RESOURCE_STATES originalState = (mCommandType == D3D12_COMMAND_LIST_TYPE_COMPUTE)
-            ? D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE : D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+            ? D3D12_RESOURCE_STATE_COPY_DEST : D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
 
         // Copy the top mip of the resource data BGR to RGB
         D3D12_RESOURCE_BARRIER aliasBarrier[3] = {};

--- a/Src/ResourceUploadBatch.cpp
+++ b/Src/ResourceUploadBatch.cpp
@@ -502,25 +502,35 @@ public:
         {
             switch (stateAfter)
             {
-            case D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE:
-            case D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE:
-                // Ignore these for copy queues
-                return;
+            case D3D12_RESOURCE_STATE_COPY_DEST:
+            case D3D12_RESOURCE_STATE_COPY_SOURCE:
+                break;
 
             default:
-                break;
+                // Ignore other states for copy queues.
+                return;
             }
         }
         else if (mCommandType == D3D12_COMMAND_LIST_TYPE_COMPUTE)
         {
-            if (stateBefore == D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE)
+            switch (stateAfter)
             {
-                stateBefore = D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
-            }
+            case D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER:
+            case D3D12_RESOURCE_STATE_UNORDERED_ACCESS:
+            case D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE:
+            case D3D12_RESOURCE_STATE_INDIRECT_ARGUMENT:
+            case D3D12_RESOURCE_STATE_COPY_DEST:
+            case D3D12_RESOURCE_STATE_COPY_SOURCE:
+                break;
 
-            if (stateAfter == D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE)
-            {
+            case D3D12_RESOURCE_STATE_INDEX_BUFFER:
+            case D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE:
                 stateAfter = D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
+                break;
+
+            default:
+                // Ignore other states for compute queues.
+                return;
             }
         }
 


### PR DESCRIPTION
The ResourceUploadBatch as originally implemented only worked on ``DIRECT`` command queues, which are the kind created by DeviceResources.

This PR adds supports for both COPY and COMPUTE command queues as an option.

* ``COPY`` queues only support loading. They cannot support GenerateMips

* `` COMPUTE`` queues can support the current features.

> The only other supported command queue types are ``VIDEO_*`` which are not relevant here.