### PR TITLE
SpriteBatch updated with sampler-version of Begin

### DIFF
--- a/Inc/SpriteBatch.h
+++ b/Inc/SpriteBatch.h
@@ -100,6 +100,11 @@ namespace DirectX
             _In_ ID3D12GraphicsCommandList* commandList,
             SpriteSortMode sortMode = SpriteSortMode_Deferred,
             FXMMATRIX transformMatrix = MatrixIdentity);
+        void XM_CALLCONV Begin(
+            _In_ ID3D12GraphicsCommandList* commandList,
+            D3D12_GPU_DESCRIPTOR_HANDLE sampler,
+            SpriteSortMode sortMode = SpriteSortMode_Deferred,
+            FXMMATRIX transformMatrix = MatrixIdentity);
         void __cdecl End();
 
         // Draw overloads specifying position, origin and scale as XMFLOAT2.


### PR DESCRIPTION
SpriteBatch has two rendering modes;

* The first is to use a static sampler built into the rootsignature. This is the default behavior and provides the easiest usage.

* The second is to provide a heap-based sampler for the SpriteBatch creation. In this case, it uses a rootsig that references the sampler from an active heap.

In the second case, I originally only let you set it at creation time. My primary motivation was to avoid having to have many permutations of the sprite VS/PS shaders and root-signature.

One of the advantages of the heap-based sampler is that it can be changed easily between rendering batch. I therefore added support in the form of an alternative Begin() method to let you provide a new heap-based sampler to use with rendering.