### PR TITLE
Code review for standard library header usage

### DIFF
--- a/Inc/Audio.h
+++ b/Inc/Audio.h
@@ -12,6 +12,13 @@
 
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include <objbase.h>
 #include <mmreg.h>
 #include <Audioclient.h>
@@ -50,13 +57,6 @@
 #endif
 
 #include <DirectXMath.h>
-
-
-#include <cstdint>
-#include <functional>
-#include <memory>
-#include <string>
-#include <vector>
 
 
 namespace DirectX

--- a/Inc/BufferHelpers.h
+++ b/Inc/BufferHelpers.h
@@ -17,6 +17,8 @@
 #include <d3d12.h>
 #endif
 
+#include <cstddef>
+
 
 namespace DirectX
 {

--- a/Inc/DDSTextureLoader.h
+++ b/Inc/DDSTextureLoader.h
@@ -23,6 +23,7 @@
 #include <d3d12.h>
 #endif
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <vector>

--- a/Inc/DescriptorHeap.h
+++ b/Inc/DescriptorHeap.h
@@ -17,10 +17,10 @@
 #include <d3d12.h>
 #endif
 
+#include <cassert>
+#include <cstddef>
 #include <cstdint>
 #include <stdexcept>
-
-#include <assert.h>
 
 #include <wrl/client.h>
 

--- a/Inc/DirectXHelpers.h
+++ b/Inc/DirectXHelpers.h
@@ -17,15 +17,15 @@
 #include <d3d12.h>
 #endif
 
-#include <DirectXMath.h>
-
+#include <cassert>
+#include <cstddef>
 #include <initializer_list>
 #include <utility>
 #include <vector>
 
-#include <assert.h>
-
 #include <wrl/client.h>
+
+#include <DirectXMath.h>
 
 #ifndef _GAMING_XBOX
 #pragma comment(lib,"dxguid.lib")
@@ -74,7 +74,7 @@
 //  UpdateSubresources
 //  D3D12IsLayoutOpaque
 //  CommandListCast
-// 
+//
 
 
 namespace DirectX
@@ -173,7 +173,7 @@ namespace DirectX
 
         if (stateBefore == stateAfter)
             return;
-        
+
         D3D12_RESOURCE_BARRIER desc = {};
         desc.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
         desc.Transition.pResource = resource;

--- a/Inc/EffectPipelineStateDescription.h
+++ b/Inc/EffectPipelineStateDescription.h
@@ -19,6 +19,7 @@
 #endif
 
 #include <cstdint>
+#include <cstring>
 
 #include "RenderTargetState.h"
 

--- a/Inc/Effects.h
+++ b/Inc/Effects.h
@@ -17,9 +17,11 @@
 #include <d3d12.h>
 #endif
 
-#include <DirectXMath.h>
+#include <cstddef>
 #include <memory>
 #include <string>
+
+#include <DirectXMath.h>
 
 #include "RenderTargetState.h"
 #include "EffectPipelineStateDescription.h"
@@ -247,7 +249,7 @@ namespace DirectX
         void XM_CALLCONV SetDiffuseColor(FXMVECTOR value);
         void __cdecl SetAlpha(float value);
         void XM_CALLCONV SetColorAndAlpha(FXMVECTOR value);
-        
+
         // Fog settings.
         void __cdecl SetFogStart(float value) override;
         void __cdecl SetFogEnd(float value) override;
@@ -293,7 +295,7 @@ namespace DirectX
         void XM_CALLCONV SetDiffuseColor(FXMVECTOR value);
         void __cdecl SetAlpha(float value);
         void XM_CALLCONV SetColorAndAlpha(FXMVECTOR value);
-        
+
         // Fog settings.
         void __cdecl SetFogStart(float value) override;
         void __cdecl SetFogEnd(float value) override;
@@ -302,7 +304,7 @@ namespace DirectX
         // Texture settings.
         void __cdecl SetTexture(D3D12_GPU_DESCRIPTOR_HANDLE srvDescriptor, D3D12_GPU_DESCRIPTOR_HANDLE samplerDescriptor);
         void __cdecl SetTexture2(D3D12_GPU_DESCRIPTOR_HANDLE srvDescriptor, D3D12_GPU_DESCRIPTOR_HANDLE samplerDescriptor);
-        
+
     private:
         // Private implementation.
         class Impl;
@@ -346,7 +348,7 @@ namespace DirectX
         void XM_CALLCONV SetEmissiveColor(FXMVECTOR value);
         void __cdecl SetAlpha(float value);
         void XM_CALLCONV SetColorAndAlpha(FXMVECTOR value);
-        
+
         // Light settings.
         void XM_CALLCONV SetAmbientLightColor(FXMVECTOR value) override;
 
@@ -369,7 +371,7 @@ namespace DirectX
         void __cdecl SetEnvironmentMapAmount(float value);
         void XM_CALLCONV SetEnvironmentMapSpecular(FXMVECTOR value);
         void __cdecl SetFresnelFactor(float value);
-        
+
     private:
         // Private implementation.
         class Impl;
@@ -411,7 +413,7 @@ namespace DirectX
         void __cdecl DisableSpecular();
         void __cdecl SetAlpha(float value);
         void XM_CALLCONV SetColorAndAlpha(FXMVECTOR value);
-        
+
         // Light settings.
         void XM_CALLCONV SetAmbientLightColor(FXMVECTOR value) override;
 
@@ -429,7 +431,7 @@ namespace DirectX
 
         // Texture setting.
         void __cdecl SetTexture(D3D12_GPU_DESCRIPTOR_HANDLE srvDescriptor, D3D12_GPU_DESCRIPTOR_HANDLE samplerDescriptor);
-        
+
         // Animation settings.
         void __cdecl SetBoneTransforms(_In_reads_(count) XMMATRIX const* value, size_t count) override;
         void __cdecl ResetBoneTransforms() override;
@@ -748,10 +750,10 @@ namespace DirectX
         };
 
         virtual std::shared_ptr<IEffect> __cdecl CreateEffect(
-            const EffectInfo& info, 
+            const EffectInfo& info,
             const EffectPipelineStateDescription& opaquePipelineState,
             const EffectPipelineStateDescription& alphaPipelineState,
-            const D3D12_INPUT_LAYOUT_DESC& inputLayout, 
+            const D3D12_INPUT_LAYOUT_DESC& inputLayout,
             int textureDescriptorOffset = 0,
             int samplerDescriptorOffset = 0) = 0;
 

--- a/Inc/GeometricPrimitive.h
+++ b/Inc/GeometricPrimitive.h
@@ -11,6 +11,7 @@
 
 #include "VertexTypes.h"
 
+#include <cstddef>
 #include <memory>
 #include <vector>
 

--- a/Inc/GraphicsMemory.h
+++ b/Inc/GraphicsMemory.h
@@ -17,6 +17,8 @@
 #include <d3d12.h>
 #endif
 
+#include <cstddef>
+#include <cstring>
 #include <memory>
 
 
@@ -34,7 +36,7 @@ namespace DirectX
             _In_ LinearAllocatorPage* page,
             _In_ D3D12_GPU_VIRTUAL_ADDRESS gpuAddress,
             _In_ ID3D12Resource* resource,
-            _In_ void* memory, 
+            _In_ void* memory,
             _In_ size_t offset,
             _In_ size_t size) noexcept;
 
@@ -51,7 +53,7 @@ namespace DirectX
         void* Memory() const noexcept { return mMemory; }
         size_t ResourceOffset() const noexcept { return mBufferOffset; }
         size_t Size() const noexcept { return mSize; }
-        
+
         explicit operator bool () const noexcept { return mResource != nullptr; }
 
         // Clear the pointer. Using operator -> will produce bad results.
@@ -91,7 +93,7 @@ namespace DirectX
         void* Memory() const noexcept { return mSharedResource->Memory(); }
         size_t ResourceOffset() const noexcept { return mSharedResource->ResourceOffset(); }
         size_t Size() const noexcept { return mSharedResource->Size(); }
-        
+
         explicit operator bool () const noexcept { return mSharedResource != nullptr; }
 
         bool operator == (const SharedGraphicsResource& other) const noexcept { return mSharedResource.get() == other.mSharedResource.get(); }
@@ -102,7 +104,7 @@ namespace DirectX
         void __cdecl Reset(GraphicsResource&&);
         void __cdecl Reset(SharedGraphicsResource&&) noexcept;
         void __cdecl Reset(const SharedGraphicsResource& resource) noexcept;
-        
+
     private:
         std::shared_ptr<GraphicsResource> mSharedResource;
     };
@@ -151,11 +153,11 @@ namespace DirectX
             return alloc;
         }
 
-        // Submits all the pending one-shot memory to the GPU. 
+        // Submits all the pending one-shot memory to the GPU.
         // The memory will be recycled once the GPU is done with it.
         void __cdecl Commit(_In_ ID3D12CommandQueue* commandQueue);
 
-        // This frees up any unused memory. 
+        // This frees up any unused memory.
         // If you want to make sure all memory is reclaimed, idle the GPU before calling this.
         // It is not recommended that you call this unless absolutely necessary (e.g. your
         // memory budget changes at run-time, or perhaps you're changing levels in your game.)
@@ -176,4 +178,3 @@ namespace DirectX
         std::unique_ptr<Impl> pImpl;
     };
 }
-

--- a/Inc/Model.h
+++ b/Inc/Model.h
@@ -18,9 +18,8 @@
 #include <dxgiformat.h>
 #endif
 
-#include <DirectXMath.h>
-#include <DirectXCollision.h>
-
+#include <cassert>
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <iterator>
@@ -30,9 +29,10 @@
 #include <utility>
 #include <vector>
 
-#include <assert.h>
-
 #include <wrl/client.h>
+
+#include <DirectXMath.h>
+#include <DirectXCollision.h>
 
 #include "GraphicsMemory.h"
 #include "Effects.h"
@@ -106,7 +106,7 @@ namespace DirectX
         // Draw the mesh with a callback for each mesh part
         static void __cdecl DrawMeshParts(_In_ ID3D12GraphicsCommandList* commandList, _In_ const ModelMeshPart::Collection& meshParts, DrawCallback callback);
 
-        // Draw the mesh with a range of effects that mesh parts will index into. 
+        // Draw the mesh with a range of effects that mesh parts will index into.
         // Effects can be any IEffect pointer type (including smart pointer). Value or reference types will not compile.
         // The iterator passed to this method should have random access capabilities for best performance.
         template<typename TEffectIterator, typename TEffectIteratorCategory = typename TEffectIterator::iterator_category>
@@ -172,7 +172,7 @@ namespace DirectX
         void __cdecl DrawOpaque(_In_ ID3D12GraphicsCommandList* commandList, ModelMeshPart::DrawCallback callback) const;
         void __cdecl DrawAlpha(_In_ ID3D12GraphicsCommandList* commandList, ModelMeshPart::DrawCallback callback) const;
 
-        // Draw the mesh with a range of effects that mesh parts will index into. 
+        // Draw the mesh with a range of effects that mesh parts will index into.
         // TEffectPtr can be any IEffect pointer type (including smart pointer). Value or reference types will not compile.
         template<typename TEffectIterator, typename TEffectIteratorCategory = typename TEffectIterator::iterator_category>
         void DrawOpaque(_In_ ID3D12GraphicsCommandList* commandList, TEffectIterator effects) const
@@ -208,10 +208,10 @@ namespace DirectX
 
         //
         // NOTE
-        // 
+        //
         // The Model::Draw functions use variadic templates and perfect-forwarding in order to support future overloads to the ModelMesh::Draw
         // family of functions. This means that a new ModelMesh::Draw overload can be added, removed or altered, but the Model::Draw* routines
-        // will still remain compatible. The correct ModelMesh::Draw overload will be selected by the compiler depending on the arguments you 
+        // will still remain compatible. The correct ModelMesh::Draw overload will be selected by the compiler depending on the arguments you
         // provide to Model::Draw*.
         //
 
@@ -301,7 +301,7 @@ namespace DirectX
             _In_z_ const wchar_t* szFileName,
             ModelLoaderFlags flags = ModelLoader_Default);
 
-        // Utility function for getting a GPU descriptor for a mesh part/material index. If there is no texture the 
+        // Utility function for getting a GPU descriptor for a mesh part/material index. If there is no texture the
         // descriptor will be zero.
         D3D12_GPU_DESCRIPTOR_HANDLE __cdecl GetGpuTextureHandleForMaterialIndex(uint32_t materialIndex, _In_ ID3D12DescriptorHeap* heap, _In_ size_t descriptorSize, _In_ size_t descriptorOffset) const
         {

--- a/Inc/PostProcess.h
+++ b/Inc/PostProcess.h
@@ -17,8 +17,9 @@
 #include <d3d12.h>
 #endif
 
-#include <DirectXMath.h>
 #include <memory>
+
+#include <DirectXMath.h>
 
 #include "RenderTargetState.h"
 

--- a/Inc/PrimitiveBatch.h
+++ b/Inc/PrimitiveBatch.h
@@ -17,7 +17,9 @@
 #include <d3d12.h>
 #endif
 
+#include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <memory>
 #include <utility>
 

--- a/Inc/ScreenGrab.h
+++ b/Inc/ScreenGrab.h
@@ -24,8 +24,9 @@
 #include <d3d12.h>
 #endif
 
-#include <OCIdl.h>
 #include <functional>
+
+#include <OCIdl.h>
 
 #pragma comment(lib,"uuid.lib")
 

--- a/Inc/SimpleMath.h
+++ b/Inc/SimpleMath.h
@@ -14,10 +14,10 @@
 #include <dxgi1_2.h>
 #endif
 
+#include <cassert>
+#include <cstddef>
+#include <cstring>
 #include <functional>
-
-#include <assert.h>
-#include <memory.h>
 
 #include <DirectXMath.h>
 #include <DirectXPackedVector.h>
@@ -403,7 +403,7 @@ namespace DirectX
 
             static void Barycentric(const Vector4& v1, const Vector4& v2, const Vector4& v3, float f, float g, Vector4& result) noexcept;
             static Vector4 Barycentric(const Vector4& v1, const Vector4& v2, const Vector4& v3, float f, float g) noexcept;
-             
+
             static void CatmullRom(const Vector4& v1, const Vector4& v2, const Vector4& v3, const Vector4& v4, float t, Vector4& result) noexcept;
             static Vector4 CatmullRom(const Vector4& v1, const Vector4& v2, const Vector4& v3, const Vector4& v4, float t) noexcept;
 

--- a/Inc/SpriteBatch.h
+++ b/Inc/SpriteBatch.h
@@ -18,10 +18,12 @@
 #include <dxgi.h>
 #endif
 
-#include <DirectXMath.h>
-#include <DirectXColors.h>
+#include <cstdint>
 #include <functional>
 #include <memory>
+
+#include <DirectXMath.h>
+#include <DirectXColors.h>
 
 #include "RenderTargetState.h"
 

--- a/Inc/SpriteFont.h
+++ b/Inc/SpriteFont.h
@@ -11,6 +11,8 @@
 
 #include "SpriteBatch.h"
 
+#include <cstddef>
+
 
 namespace DirectX
 {

--- a/Inc/WICTextureLoader.h
+++ b/Inc/WICTextureLoader.h
@@ -27,6 +27,7 @@
 #include <d3d12.h>
 #endif
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 

--- a/Inc/XboxDDSTextureLoader.h
+++ b/Inc/XboxDDSTextureLoader.h
@@ -30,6 +30,7 @@
 #pragma comment(lib,"xmem.lib")
 #endif
 
+#include <cstddef>
 #include <cstdint>
 
 #ifndef DDS_ALPHA_MODE_DEFINED
@@ -52,7 +53,7 @@ namespace Xbox
     using DirectX::DDS_ALPHA_MODE;
 
     //
-    //  NOTE: Flush the GPU caches before using textures created 
+    //  NOTE: Flush the GPU caches before using textures created
     //  with these functions.
     //
     //  The simplest means of doing this is:
@@ -61,7 +62,7 @@ namespace Xbox
     //      CreateDDSTextureFrom...
     //      CreateDDSTextureFrom...
     //      CreateDDSTextureFrom...
-    //      
+    //
     //      // Flush the GPU caches
     //      ID3D12CommandList::FlushPipelineX(D3D12XBOX_FLUSH_IDLE, 0, 0);
     //
@@ -79,11 +80,11 @@ namespace Xbox
         _In_ size_t ddsDataSize,
         _Outptr_opt_ ID3D12Resource** texture,
         _Outptr_ void** grfxMemory,
-        _Out_opt_ DDS_ALPHA_MODE* alphaMode = nullptr, 
+        _Out_opt_ DDS_ALPHA_MODE* alphaMode = nullptr,
         _In_ bool forceSRGB = false,
         _Out_opt_ bool* isCubeMap = nullptr) noexcept;
 
-    HRESULT __cdecl CreateDDSTextureFromFile( 
+    HRESULT __cdecl CreateDDSTextureFromFile(
         _In_ ID3D12Device* d3dDevice,
         _In_z_ const wchar_t* szFileName,
         _Outptr_opt_ ID3D12Resource** texture,

--- a/Src/pch.h
+++ b/Src/pch.h
@@ -149,17 +149,13 @@
 #pragma warning(pop)
 #endif
 
-#define _XM_NO_XMVECTOR_OVERLOADS_
-
-#include <DirectXMath.h>
-#include <DirectXPackedVector.h>
-#include <DirectXCollision.h>
-
 #include <algorithm>
 #include <atomic>
 #include <array>
+#include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <exception>
 #include <initializer_list>
 #include <iterator>
@@ -185,6 +181,12 @@
 #pragma warning(pop)
 
 #include <malloc.h>
+
+#define _XM_NO_XMVECTOR_OVERLOADS_
+
+#include <DirectXMath.h>
+#include <DirectXPackedVector.h>
+#include <DirectXCollision.h>
 
 #pragma warning(push)
 #pragma warning(disable : 4467 5038 5204 5220)

--- a/Src/pch.h
+++ b/Src/pch.h
@@ -155,6 +155,7 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <exception>
 #include <initializer_list>


### PR DESCRIPTION
Reviewed all the C++ standard library header usage and normalized usage for improved conformance.

* ``size_t`` requires ``cstddef``
* ``memcpy``, ``memcpy_s`` is officially in ``cstring``
* Use ``cassert`` instead of ``assert.h``

> The non-standard malloc.h is still being included for ``_aligned_malloc`` / ``_aligned_free``. To be conformant, I should update it to use ``aligned_alloc`` and ``free`` when building for C++17 which is in ``cstdlib``.

Also trimmed trailing whitespace in these files.