### PR TITLE
Clean up use of std::exception

### DIFF
--- a/Audio/AudioEngine.cpp
+++ b/Audio/AudioEngine.cpp
@@ -1262,7 +1262,7 @@ void AudioEngine::SetMasterVolume(float volume)
 void AudioEngine::SetReverb(AUDIO_ENGINE_REVERB reverb)
 {
     if (reverb >= Reverb_MAX)
-        throw std::out_of_range("AudioEngine::SetReverb");
+        throw std::invalid_argument("AudioEngine::SetReverb");
 
     if (reverb == Reverb_Off)
     {

--- a/Audio/AudioEngine.cpp
+++ b/Audio/AudioEngine.cpp
@@ -1262,7 +1262,7 @@ void AudioEngine::SetMasterVolume(float volume)
 void AudioEngine::SetReverb(AUDIO_ENGINE_REVERB reverb)
 {
     if (reverb >= Reverb_MAX)
-        throw std::invalid_argument("AudioEngine::SetReverb");
+        throw std::invalid_argument("reverb parameter is invalid");
 
     if (reverb == Reverb_Off)
     {

--- a/Audio/AudioEngine.cpp
+++ b/Audio/AudioEngine.cpp
@@ -1350,7 +1350,7 @@ bool AudioEngine::IsCriticalError() const noexcept
 void AudioEngine::SetDefaultSampleRate(int sampleRate)
 {
     if ((sampleRate < XAUDIO2_MIN_SAMPLE_RATE) || (sampleRate > XAUDIO2_MAX_SAMPLE_RATE))
-        throw std::invalid_argument("Default sample rate is out of range");
+        throw std::out_of_range("Default sample rate is out of range");
 
     pImpl->defaultRate = sampleRate;
 }

--- a/Audio/AudioEngine.cpp
+++ b/Audio/AudioEngine.cpp
@@ -32,7 +32,7 @@ namespace
             mCriticalError.reset(CreateEventEx(nullptr, nullptr, 0, EVENT_MODIFY_STATE | SYNCHRONIZE));
             if (!mCriticalError)
             {
-                throw std::system_error(std::error_code(GetLastError(), std::system_category()), "CreateEventEx");
+                throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "CreateEventEx");
             }
         }
 
@@ -66,7 +66,7 @@ namespace
             mBufferEnd.reset(CreateEventEx(nullptr, nullptr, 0, EVENT_MODIFY_STATE | SYNCHRONIZE));
             if (!mBufferEnd)
             {
-                throw std::system_error(std::error_code(GetLastError(), std::system_category()), "CreateEventEx");
+                throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "CreateEventEx");
             }
         }
 
@@ -723,7 +723,7 @@ bool AudioEngine::Impl::Update()
             break;
 
         case WAIT_FAILED:
-            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "WaitForMultipleObjectsEx");
+            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "WaitForMultipleObjectsEx");
     }
 
     //

--- a/Audio/AudioEngine.cpp
+++ b/Audio/AudioEngine.cpp
@@ -32,7 +32,7 @@ namespace
             mCriticalError.reset(CreateEventEx(nullptr, nullptr, 0, EVENT_MODIFY_STATE | SYNCHRONIZE));
             if (!mCriticalError)
             {
-                throw std::exception("CreateEvent");
+                throw std::system_error(std::error_code(GetLastError(), std::system_category()), "CreateEventEx");
             }
         }
 
@@ -66,7 +66,7 @@ namespace
             mBufferEnd.reset(CreateEventEx(nullptr, nullptr, 0, EVENT_MODIFY_STATE | SYNCHRONIZE));
             if (!mBufferEnd)
             {
-                throw std::exception("CreateEvent");
+                throw std::system_error(std::error_code(GetLastError(), std::system_category()), "CreateEventEx");
             }
         }
 
@@ -723,7 +723,7 @@ bool AudioEngine::Impl::Update()
             break;
 
         case WAIT_FAILED:
-            throw std::exception("WaitForMultipleObjects");
+            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "WaitForMultipleObjectsEx");
     }
 
     //
@@ -827,12 +827,12 @@ void AudioEngine::Impl::AllocateVoice(
     IXAudio2SourceVoice** voice)
 {
     if (!wfx)
-        throw std::exception("Wave format is required\n");
+        throw std::invalid_argument("Wave format is required\n");
 
     // No need to call IsValid on wfx because CreateSourceVoice will do that
 
     if (!voice)
-        throw std::exception("Voice pointer must be non-null");
+        throw std::invalid_argument("Voice pointer must be non-null");
 
     *voice = nullptr;
 
@@ -852,7 +852,7 @@ void AudioEngine::Impl::AllocateVoice(
             DebugTrace((flags & SoundEffectInstance_NoSetPitch)
                        ? "ERROR: One-shot voices must support pitch-shifting for voice reuse\n"
                        : "ERROR: One-use voices cannot use 3D positional audio\n");
-            throw std::exception("Invalid flags for one-shot voice");
+            throw std::invalid_argument("Invalid flags for one-shot voice");
         }
 
     #ifdef VERBOSE_TRACE
@@ -947,7 +947,7 @@ void AudioEngine::Impl::AllocateVoice(
                     if (FAILED(hr))
                     {
                         DebugTrace("ERROR: CreateSourceVoice (reuse) failed with error %08X\n", static_cast<unsigned int>(hr));
-                        throw std::exception("CreateSourceVoice");
+                        throw std::runtime_error("CreateSourceVoice");
                     }
                 }
 
@@ -956,7 +956,7 @@ void AudioEngine::Impl::AllocateVoice(
                 if (FAILED(hr))
                 {
                     DebugTrace("ERROR: SetSourceSampleRate failed with error %08X\n", static_cast<unsigned int>(hr));
-                    throw std::exception("SetSourceSampleRate");
+                    throw std::runtime_error("SetSourceSampleRate");
                 }
             }
         }
@@ -977,7 +977,7 @@ void AudioEngine::Impl::AllocateVoice(
         {
             DebugTrace("ERROR: Too many instance voices (%zu >= %zu); see TrimVoicePool\n",
                 mVoiceInstances + 1, maxVoiceInstances);
-            throw std::exception("Too many instance voices");
+            throw std::runtime_error("Too many instance voices");
         }
 
         UINT32 vflags = (flags & SoundEffectInstance_NoSetPitch) ? XAUDIO2_VOICE_NOPITCH : 0u;
@@ -1012,7 +1012,7 @@ void AudioEngine::Impl::AllocateVoice(
         if (FAILED(hr))
         {
             DebugTrace("ERROR: CreateSourceVoice failed with error %08X\n", static_cast<unsigned int>(hr));
-            throw std::exception("CreateSourceVoice");
+            throw std::runtime_error("CreateSourceVoice");
         }
         else if (!oneshot)
         {
@@ -1131,7 +1131,7 @@ AudioEngine::AudioEngine(
             if (flags & AudioEngine_ThrowOnNoAudioHW)
             {
                 DebugTrace("ERROR: AudioEngine found no default audio device\n");
-                throw std::exception("AudioEngineNoAudioHW");
+                throw std::runtime_error("AudioEngineNoAudioHW");
             }
             else
             {
@@ -1143,7 +1143,7 @@ AudioEngine::AudioEngine(
             DebugTrace("ERROR: AudioEngine failed (%08X) to initialize using device [%ls]\n",
                 static_cast<unsigned int>(hr),
                 (deviceId) ? deviceId : L"default");
-            throw std::exception("AudioEngine");
+            throw std::runtime_error("AudioEngine");
         }
     }
 }
@@ -1198,7 +1198,7 @@ bool AudioEngine::Reset(const WAVEFORMATEX* wfx, const wchar_t* deviceId)
             if (pImpl->mEngineFlags & AudioEngine_ThrowOnNoAudioHW)
             {
                 DebugTrace("ERROR: AudioEngine found no default audio device on Reset\n");
-                throw std::exception("AudioEngineNoAudioHW");
+                throw std::runtime_error("AudioEngineNoAudioHW");
             }
             else
             {
@@ -1210,7 +1210,7 @@ bool AudioEngine::Reset(const WAVEFORMATEX* wfx, const wchar_t* deviceId)
         {
             DebugTrace("ERROR: AudioEngine failed (%08X) to Reset using device [%ls]\n",
                 static_cast<unsigned int>(hr), (deviceId) ? deviceId : L"default");
-            throw std::exception("AudioEngine::Reset");
+            throw std::runtime_error("AudioEngine::Reset");
         }
     }
 
@@ -1350,7 +1350,7 @@ bool AudioEngine::IsCriticalError() const noexcept
 void AudioEngine::SetDefaultSampleRate(int sampleRate)
 {
     if ((sampleRate < XAUDIO2_MIN_SAMPLE_RATE) || (sampleRate > XAUDIO2_MAX_SAMPLE_RATE))
-        throw std::exception("Default sample rate is out of range");
+        throw std::invalid_argument("Default sample rate is out of range");
 
     pImpl->defaultRate = sampleRate;
 }
@@ -1552,7 +1552,7 @@ std::vector<AudioEngine::RendererDetail> AudioEngine::GetRendererDetails()
     while (operation->Status == Windows::Foundation::AsyncStatus::Started) { Sleep(100); }
     if (operation->Status != Windows::Foundation::AsyncStatus::Completed)
     {
-        throw std::exception("FindAllAsync");
+        throw std::runtime_error("FindAllAsync");
     }
 
     DeviceInformationCollection^ devices = operation->GetResults();
@@ -1607,7 +1607,7 @@ std::vector<AudioEngine::RendererDetail> AudioEngine::GetRendererDetails()
 
     if (status != ABI::Windows::Foundation::AsyncStatus::Completed)
     {
-        throw std::exception("FindAllAsyncDeviceClass");
+        throw std::runtime_error("FindAllAsyncDeviceClass");
     }
 
     ComPtr<IVectorView<DeviceInformation*>> devices;

--- a/Audio/DynamicSoundEffectInstance.cpp
+++ b/Audio/DynamicSoundEffectInstance.cpp
@@ -58,7 +58,7 @@ public:
         mBufferEvent.reset(CreateEventEx(nullptr, nullptr, 0, EVENT_MODIFY_STATE | SYNCHRONIZE));
         if (!mBufferEvent)
         {
-            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "CreateEventEx");
+            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "CreateEventEx");
         }
 
         CreateIntegerPCM(&mWaveFormat, sampleRate, channels, sampleBits);
@@ -226,7 +226,7 @@ void DynamicSoundEffectInstance::Impl::OnUpdate()
             break;
 
         case WAIT_FAILED:
-            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "WaitForSingleObjectEx");
+            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "WaitForSingleObjectEx");
     }
 }
 

--- a/Audio/DynamicSoundEffectInstance.cpp
+++ b/Audio/DynamicSoundEffectInstance.cpp
@@ -41,7 +41,7 @@ public:
         if (!channels || (channels > 8))
         {
             DebugTrace("DynamicSoundEffectInstance channels must be in range 1...8\n");
-            throw std::invalid_argument("DynamicSoundEffectInstance");
+            throw std::out_of_range("DynamicSoundEffectInstance channel count out of range");
         }
 
         switch (sampleBits)
@@ -52,7 +52,7 @@ public:
 
             default:
                 DebugTrace("DynamicSoundEffectInstance sampleBits must be 8-bit or 16-bit\n");
-                throw std::invalid_argument("DynamicSoundEffectInstance");
+                throw std::invalid_argument("DynamicSoundEffectInstance supports 8 or 16 bit");
         }
 
         mBufferEvent.reset(CreateEventEx(nullptr, nullptr, 0, EVENT_MODIFY_STATE | SYNCHRONIZE));

--- a/Audio/DynamicSoundEffectInstance.cpp
+++ b/Audio/DynamicSoundEffectInstance.cpp
@@ -58,7 +58,7 @@ public:
         mBufferEvent.reset(CreateEventEx(nullptr, nullptr, 0, EVENT_MODIFY_STATE | SYNCHRONIZE));
         if (!mBufferEvent)
         {
-            throw std::exception("CreateEvent");
+            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "CreateEventEx");
         }
 
         CreateIntegerPCM(&mWaveFormat, sampleRate, channels, sampleBits);
@@ -177,7 +177,7 @@ _Use_decl_annotations_
 void DynamicSoundEffectInstance::Impl::SubmitBuffer(const uint8_t* pAudioData, uint32_t offset, size_t audioBytes)
 {
     if (!pAudioData || !audioBytes)
-        throw std::exception("Invalid audio data buffer");
+        throw std::invalid_argument("Invalid audio data buffer");
 
     if (audioBytes > UINT32_MAX)
         throw std::out_of_range("SubmitBuffer");
@@ -204,7 +204,7 @@ void DynamicSoundEffectInstance::Impl::SubmitBuffer(const uint8_t* pAudioData, u
         DebugTrace("\tFormat Tag %u, %u channels, %u-bit, %u Hz, %zu bytes [%u offset)\n",
             mWaveFormat.wFormatTag, mWaveFormat.nChannels, mWaveFormat.wBitsPerSample, mWaveFormat.nSamplesPerSec, audioBytes, offset);
     #endif
-        throw std::exception("SubmitSourceBuffer");
+        throw std::runtime_error("SubmitSourceBuffer");
     }
 }
 
@@ -226,7 +226,7 @@ void DynamicSoundEffectInstance::Impl::OnUpdate()
             break;
 
         case WAIT_FAILED:
-            throw std::exception("WaitForSingleObjectEx");
+            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "WaitForSingleObjectEx");
     }
 }
 

--- a/Audio/DynamicSoundEffectInstance.cpp
+++ b/Audio/DynamicSoundEffectInstance.cpp
@@ -35,7 +35,7 @@ public:
             || (sampleRate > XAUDIO2_MAX_SAMPLE_RATE))
         {
             DebugTrace("DynamicSoundEffectInstance sampleRate must be in range %u...%u\n", XAUDIO2_MIN_SAMPLE_RATE, XAUDIO2_MAX_SAMPLE_RATE);
-            throw std::invalid_argument("DynamicSoundEffectInstance");
+            throw std::out_of_range("DynamicSoundEffectInstance");
         }
 
         if (!channels || (channels > 8))

--- a/Audio/SoundCommon.cpp
+++ b/Audio/SoundCommon.cpp
@@ -717,7 +717,7 @@ void SoundEffectInstanceBase::Apply3D(const AudioListener& listener, const Audio
     if (!(mFlags & SoundEffectInstance_Use3D))
     {
         DebugTrace("ERROR: Apply3D called for an instance created without SoundEffectInstance_Use3D set\n");
-        throw std::exception("Apply3D");
+        throw std::runtime_error("Apply3D");
     }
 
     DWORD dwCalcFlags = X3DAUDIO_CALCULATE_MATRIX | X3DAUDIO_CALCULATE_DOPPLER | X3DAUDIO_CALCULATE_LPF_DIRECT;

--- a/Audio/SoundCommon.h
+++ b/Audio/SoundCommon.h
@@ -248,7 +248,7 @@ namespace DirectX
             if ((mFlags & SoundEffectInstance_NoSetPitch) && pitch != 0.f)
             {
                 DebugTrace("ERROR: Sound effect instance was created with the NoSetPitch flag\n");
-                throw std::exception("SetPitch");
+                throw std::runtime_error("SetPitch");
             }
 
             mPitch = pitch;

--- a/Audio/SoundEffect.cpp
+++ b/Audio/SoundEffect.cpp
@@ -352,7 +352,7 @@ void SoundEffect::Impl::Play(float volume, float pitch, float pan)
         DebugTrace("ERROR: SoundEffect failed (%08X) when submitting buffer:\n", static_cast<unsigned int>(hr));
         DebugTrace("\tFormat Tag %u, %u channels, %u-bit, %u Hz, %u bytes\n",
             mWaveFormat->wFormatTag, mWaveFormat->nChannels, mWaveFormat->wBitsPerSample, mWaveFormat->nSamplesPerSec, mAudioBytes);
-        throw std::exception("SubmitSourceBuffer");
+        throw std::runtime_error("SubmitSourceBuffer");
     }
 
     InterlockedIncrement(&mOneShots);
@@ -375,7 +375,7 @@ SoundEffect::SoundEffect(AudioEngine* engine, const wchar_t* waveFileName)
     {
         DebugTrace("ERROR: SoundEffect failed (%08X) to load from .wav file \"%ls\"\n",
             static_cast<unsigned int>(hr), waveFileName);
-        throw std::exception("SoundEffect");
+        throw std::runtime_error("SoundEffect");
     }
 
 #ifdef DIRECTX_ENABLE_SEEK_TABLES
@@ -391,7 +391,7 @@ SoundEffect::SoundEffect(AudioEngine* engine, const wchar_t* waveFileName)
     {
         DebugTrace("ERROR: SoundEffect failed (%08X) to intialize from .wav file \"%ls\"\n",
             static_cast<unsigned int>(hr), waveFileName);
-        throw std::exception("SoundEffect");
+        throw std::runtime_error("SoundEffect");
     }
 }
 
@@ -409,7 +409,7 @@ SoundEffect::SoundEffect(AudioEngine* engine, std::unique_ptr<uint8_t[]>& wavDat
     if (FAILED(hr))
     {
         DebugTrace("ERROR: SoundEffect failed (%08X) to intialize\n", static_cast<unsigned int>(hr));
-        throw std::exception("SoundEffect");
+        throw std::runtime_error("SoundEffect");
     }
 }
 
@@ -428,7 +428,7 @@ SoundEffect::SoundEffect(AudioEngine* engine, std::unique_ptr<uint8_t[]>& wavDat
     if (FAILED(hr))
     {
         DebugTrace("ERROR: SoundEffect failed (%08X) to intialize\n", static_cast<unsigned int>(hr));
-        throw std::exception("SoundEffect");
+        throw std::runtime_error("SoundEffect");
     }
 }
 
@@ -444,7 +444,7 @@ SoundEffect::SoundEffect(AudioEngine* engine, std::unique_ptr<uint8_t[]>& wavDat
     if (FAILED(hr))
     {
         DebugTrace("ERROR: SoundEffect failed (%08X) to intialize\n", static_cast<unsigned int>(hr));
-        throw std::exception("SoundEffect");
+        throw std::runtime_error("SoundEffect");
     }
 }
 

--- a/Audio/SoundEffectInstance.cpp
+++ b/Audio/SoundEffectInstance.cpp
@@ -215,7 +215,7 @@ void SoundEffectInstance::Impl::Play(bool loop)
             wfx->wFormatTag, wfx->nChannels, wfx->wBitsPerSample, wfx->nSamplesPerSec, length);
     #endif
         mBase.Stop(true, mLooped);
-        throw std::exception("SubmitSourceBuffer");
+        throw std::runtime_error("SubmitSourceBuffer");
     }
 }
 

--- a/Audio/SoundStreamInstance.cpp
+++ b/Audio/SoundStreamInstance.cpp
@@ -140,7 +140,7 @@ public:
         mBufferRead.reset(CreateEventEx(nullptr, nullptr, 0, EVENT_MODIFY_STATE | SYNCHRONIZE));
         if (!mBufferEnd || !mBufferRead)
         {
-            throw std::exception("CreateEvent");
+            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "CreateEventEx");
         }
 
         ThrowIfFailed(AllocateStreamingBuffers(wfx));
@@ -263,7 +263,7 @@ public:
             break;
 
         case WAIT_FAILED:
-            throw std::exception("WaitForMultipleObjects");
+            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "WaitForMultipleObjectsEx");
         }
     }
 

--- a/Audio/SoundStreamInstance.cpp
+++ b/Audio/SoundStreamInstance.cpp
@@ -140,7 +140,7 @@ public:
         mBufferRead.reset(CreateEventEx(nullptr, nullptr, 0, EVENT_MODIFY_STATE | SYNCHRONIZE));
         if (!mBufferEnd || !mBufferRead)
         {
-            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "CreateEventEx");
+            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "CreateEventEx");
         }
 
         ThrowIfFailed(AllocateStreamingBuffers(wfx));
@@ -263,7 +263,7 @@ public:
             break;
 
         case WAIT_FAILED:
-            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "WaitForMultipleObjectsEx");
+            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "WaitForMultipleObjectsEx");
         }
     }
 

--- a/Audio/WaveBank.cpp
+++ b/Audio/WaveBank.cpp
@@ -162,7 +162,7 @@ void WaveBank::Impl::Play(unsigned int index, float volume, float pitch, float p
     if (mStreaming)
     {
         DebugTrace("ERROR: One-shots can only be created from an in-memory wave bank\n");
-        throw std::exception("WaveBank::Play");
+        throw std::runtime_error("WaveBank::Play");
     }
 
     if (index >= mReader.Count())
@@ -249,7 +249,7 @@ void WaveBank::Impl::Play(unsigned int index, float volume, float pitch, float p
         DebugTrace("ERROR: WaveBank failed (%08X) when submitting buffer:\n", static_cast<unsigned int>(hr));
         DebugTrace("\tFormat Tag %u, %u channels, %u-bit, %u Hz, %u bytes\n",
             wfx->wFormatTag, wfx->nChannels, wfx->wBitsPerSample, wfx->nSamplesPerSec, metadata.lengthBytes);
-        throw std::exception("SubmitSourceBuffer");
+        throw std::runtime_error("SubmitSourceBuffer");
     }
 
     InterlockedIncrement(&mOneShots);
@@ -270,7 +270,7 @@ WaveBank::WaveBank(AudioEngine* engine, const wchar_t* wbFileName)
     {
         DebugTrace("ERROR: WaveBank failed (%08X) to intialize from .xwb file \"%ls\"\n",
             static_cast<unsigned int>(hr), wbFileName);
-        throw std::exception("WaveBank");
+        throw std::runtime_error("WaveBank");
     }
 
     DebugTrace("INFO: WaveBank \"%hs\" with %u entries loaded from .xwb file \"%ls\"\n",
@@ -346,7 +346,7 @@ std::unique_ptr<SoundEffectInstance> WaveBank::CreateInstance(unsigned int index
     if (pImpl->mStreaming)
     {
         DebugTrace("ERROR: SoundEffectInstances can only be created from an in-memory wave bank\n");
-        throw std::exception("WaveBank::CreateInstance");
+        throw std::runtime_error("WaveBank::CreateInstance");
     }
 
     if (index >= wb.Count())
@@ -389,7 +389,7 @@ std::unique_ptr<SoundStreamInstance> WaveBank::CreateStreamInstance(unsigned int
     if (!pImpl->mStreaming)
     {
         DebugTrace("ERROR: SoundStreamInstances can only be created from a streaming wave bank\n");
-        throw std::exception("WaveBank::CreateStreamInstance");
+        throw std::runtime_error("WaveBank::CreateStreamInstance");
     }
 
     if (index >= wb.Count())

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ set(LIBRARY_SOURCES
     Src/BufferHelpers.cpp
     Src/CommonStates.cpp
     Src/d3dx12.h
-    Src/dds.h
+    Src/DDS.h
     Src/DDSTextureLoader.cpp
     Src/DebugEffect.cpp
     Src/DemandCreate.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ set(LIBRARY_SOURCES
     Src/BufferHelpers.cpp
     Src/CommonStates.cpp
     Src/d3dx12.h
-    Src/DDS.h
+    Src/dds.h
     Src/DDSTextureLoader.cpp
     Src/DebugEffect.cpp
     Src/DemandCreate.h

--- a/Src/AlphaTestEffect.cpp
+++ b/Src/AlphaTestEffect.cpp
@@ -215,12 +215,12 @@ AlphaTestEffect::Impl::Impl(
     if (effectFlags & EffectFlags::PerPixelLightingBit)
     {
         DebugTrace("ERROR: AlphaTestEffect does not implement EffectFlags::PerPixelLighting\n");
-        throw std::invalid_argument("AlphaTestEffect");
+        throw std::invalid_argument("PerPixelLighting effect flag is invalid");
     }
     else if (effectFlags & EffectFlags::Lighting)
     {
         DebugTrace("ERROR: DualTextureEffect does not implement EffectFlags::Lighting\n");
-        throw std::invalid_argument("AlphaTestEffect");
+        throw std::invalid_argument("Lighting effect flag is invalid");
     }
 
     // Create pipeline state.

--- a/Src/AlphaTestEffect.cpp
+++ b/Src/AlphaTestEffect.cpp
@@ -353,7 +353,7 @@ void AlphaTestEffect::Impl::Apply(_In_ ID3D12GraphicsCommandList* commandList)
                 break;
 
             default:
-                throw std::exception("Unknown alpha test function");
+                throw std::runtime_error("Unknown alpha test function");
         }
 
         // x = compareTo, y = threshold, zw = resultSelector.
@@ -370,7 +370,7 @@ void AlphaTestEffect::Impl::Apply(_In_ ID3D12GraphicsCommandList* commandList)
     if (!texture.ptr || !textureSampler.ptr)
     {
         DebugTrace("ERROR: Missing texture or sampler for AlphaTestEffect (texture %llu, sampler %llu)\n", texture.ptr, textureSampler.ptr);
-        throw std::exception("AlphaTestEffect");
+        throw std::runtime_error("AlphaTestEffect");
     }
 
     // **NOTE** If D3D asserts or crashes here, you probably need to call commandList->SetDescriptorHeaps() with the required descriptor heaps.

--- a/Src/BasicEffect.cpp
+++ b/Src/BasicEffect.cpp
@@ -559,7 +559,7 @@ void BasicEffect::Impl::Apply(_In_ ID3D12GraphicsCommandList* commandList)
         if (!texture.ptr || !sampler.ptr)
         {
             DebugTrace("ERROR: Missing texture or sampler for BasicEffect (texture %llu, sampler %llu)\n", texture.ptr, sampler.ptr);
-            throw std::exception("BasicEffect");
+            throw std::runtime_error("BasicEffect");
         }
 
         // **NOTE** If D3D asserts or crashes here, you probably need to call commandList->SetDescriptorHeaps() with the required descriptor heaps.

--- a/Src/BasicPostProcess.cpp
+++ b/Src/BasicPostProcess.cpp
@@ -231,7 +231,7 @@ BasicPostProcess::Impl::Impl(_In_ ID3D12Device* device, const RenderTargetState&
     mDeviceResources(deviceResourcesPool.DemandCreate(device))
 {
     if (ifx >= Effect_Max)
-        throw std::out_of_range("Effect not defined");
+        throw std::invalid_argument("Effect not defined");
    
     switch (ifx)
     {

--- a/Src/BasicPostProcess.cpp
+++ b/Src/BasicPostProcess.cpp
@@ -328,7 +328,7 @@ void BasicPostProcess::Impl::Process(_In_ ID3D12GraphicsCommandList* commandList
     if (!texture.ptr)
     {
         DebugTrace("ERROR: Missing texture for BasicPostProcess (texture %llu)\n", texture.ptr);
-        throw std::exception("BasicPostProcess");
+        throw std::runtime_error("BasicPostProcess");
     }
     commandList->SetGraphicsRootDescriptorTable(RootParameterIndex::TextureSRV, texture);
 
@@ -391,7 +391,7 @@ void BasicPostProcess::Impl::DownScale2x2()
 
     if (!texWidth || !texHeight)
     {
-        throw std::exception("Call SetSourceTexture before setting post-process effect");
+        throw std::logic_error("Call SetSourceTexture before setting post-process effect");
     }
 
     float tu = 1.0f / float(texWidth);
@@ -418,7 +418,7 @@ void BasicPostProcess::Impl::DownScale4x4()
 
     if (!texWidth || !texHeight)
     {
-        throw std::exception("Call SetSourceTexture before setting post-process effect");
+        throw std::logic_error("Call SetSourceTexture before setting post-process effect");
     }
 
     float tu = 1.0f / float(texWidth);
@@ -446,7 +446,7 @@ void BasicPostProcess::Impl::GaussianBlur5x5(float multiplier)
 
     if (!texWidth || !texHeight)
     {
-        throw std::exception("Call SetSourceTexture before setting post-process effect");
+        throw std::logic_error("Call SetSourceTexture before setting post-process effect");
     }
 
     float tu = 1.0f / float(texWidth);
@@ -502,7 +502,7 @@ void  BasicPostProcess::Impl::Bloom(bool horizontal, float size, float brightnes
 
     if (!texWidth || !texHeight)
     {
-        throw std::exception("Call SetSourceTexture before setting post-process effect");
+        throw std::logic_error("Call SetSourceTexture before setting post-process effect");
     }
 
     float tu = 0.f;

--- a/Src/BinaryReader.cpp
+++ b/Src/BinaryReader.cpp
@@ -27,7 +27,7 @@ BinaryReader::BinaryReader(_In_z_ wchar_t const* fileName) noexcept(false) :
     {
         DebugTrace("ERROR: BinaryReader failed (%08X) to load '%ls'\n",
             static_cast<unsigned int>(hr), fileName);
-        throw std::exception("BinaryReader");
+        throw std::runtime_error("BinaryReader");
     }
 
     mPos = mOwnedData.get();

--- a/Src/BinaryReader.h
+++ b/Src/BinaryReader.h
@@ -48,7 +48,7 @@ namespace DirectX
                 throw std::overflow_error("ReadArray");
 
             if (newPos > mEnd)
-                throw std::exception("End of file");
+                throw std::runtime_error("End of file");
 
             auto result = reinterpret_cast<T const*>(mPos);
 

--- a/Src/DescriptorHeap.cpp
+++ b/Src/DescriptorHeap.cpp
@@ -71,7 +71,7 @@ DescriptorHeap::DescriptorHeap(
     m_increment(0)
 {
     if (count > UINT32_MAX)
-        throw std::exception("Too many descriptors");
+        throw std::invalid_argument("Too many descriptors");
 
     D3D12_DESCRIPTOR_HEAP_DESC desc = {};
     desc.Flags = flags;
@@ -211,6 +211,6 @@ void DescriptorPile::AllocateRange(size_t numDescriptors, _Out_ IndexType& start
     if (m_top > Count())
     {
         DebugTrace("DescriptorPile has %zu of %zu descriptors; failed request for %zu more\n", start, Count(), numDescriptors);
-        throw std::exception("Can't allocate more descriptors");
+        throw std::runtime_error("Can't allocate more descriptors");
     }
 }

--- a/Src/DescriptorHeap.cpp
+++ b/Src/DescriptorHeap.cpp
@@ -197,7 +197,7 @@ void DescriptorPile::AllocateRange(size_t numDescriptors, _Out_ IndexType& start
     // make sure we didn't allocate zero
     if (numDescriptors == 0)
     {
-        throw std::out_of_range("Can't allocate zero descriptors");
+        throw std::invalid_argument("Can't allocate zero descriptors");
     }
 
     // get the current top

--- a/Src/DirectXHelpers.cpp
+++ b/Src/DirectXHelpers.cpp
@@ -78,12 +78,12 @@ void DirectX::CreateShaderResourceView(
 
         case D3D12_RESOURCE_DIMENSION_BUFFER:
             DebugTrace("ERROR: CreateShaderResourceView cannot be used with DIMENSION_BUFFER.\n");
-            throw std::exception("buffer resources not supported");
+            throw std::invalid_argument("buffer resources not supported");
 
         case D3D12_RESOURCE_DIMENSION_UNKNOWN:
         default:
             DebugTrace("ERROR: CreateShaderResourceView cannot be used with DIMENSION_UNKNOWN (%d).\n", desc.Dimension);
-            throw std::exception("unknown resource dimension");
+            throw std::invalid_argument("unknown resource dimension");
     }
 
     device->CreateShaderResourceView(tex, &srvDesc, srvDescriptor);

--- a/Src/DualPostProcess.cpp
+++ b/Src/DualPostProcess.cpp
@@ -176,7 +176,7 @@ DualPostProcess::Impl::Impl(_In_ ID3D12Device* device, const RenderTargetState& 
     mDeviceResources(deviceResourcesPool.DemandCreate(device))
 {
     if (ifx >= Effect_Max)
-        throw std::out_of_range("Effect not defined");
+        throw std::invalid_argument("Effect not defined");
    
     // Create root signature.
     {

--- a/Src/DualPostProcess.cpp
+++ b/Src/DualPostProcess.cpp
@@ -251,7 +251,7 @@ void DualPostProcess::Impl::Process(_In_ ID3D12GraphicsCommandList* commandList)
     if (!texture.ptr || !texture2.ptr)
     {
         DebugTrace("ERROR: Missing texture(s) for DualPostProcess (%llu, %llu)\n", texture.ptr, texture2.ptr);
-        throw std::exception("DualPostProcess");
+        throw std::runtime_error("DualPostProcess");
     }
     commandList->SetGraphicsRootDescriptorTable(RootParameterIndex::TextureSRV, texture);
     commandList->SetGraphicsRootDescriptorTable(RootParameterIndex::TextureSRV2, texture2);

--- a/Src/DualTextureEffect.cpp
+++ b/Src/DualTextureEffect.cpp
@@ -206,12 +206,12 @@ DualTextureEffect::Impl::Impl(
     if (effectFlags & EffectFlags::PerPixelLightingBit)
     {
         DebugTrace("ERROR: DualTextureEffect does not implement EffectFlags::PerPixelLighting\n");
-        throw std::invalid_argument("DualTextureEffect");
+        throw std::invalid_argument("PerPixelLighting effect flag is invalid");
     }
     else if (effectFlags & EffectFlags::Lighting)
     {
         DebugTrace("ERROR: DualTextureEffect does not implement EffectFlags::Lighting\n");
-        throw std::invalid_argument("DualTextureEffect");
+        throw std::invalid_argument("Lighting effect flag is invalid");
     }
 
     // Create pipeline state.

--- a/Src/DualTextureEffect.cpp
+++ b/Src/DualTextureEffect.cpp
@@ -277,12 +277,12 @@ void DualTextureEffect::Impl::Apply(_In_ ID3D12GraphicsCommandList* commandList)
     if (!texture1.ptr || !texture2.ptr)
     {
         DebugTrace("ERROR: Missing texture(s) for DualTextureEffect (texture1 %llu, texture2 %llu)\n", texture1.ptr, texture2.ptr);
-        throw std::exception("DualTextureEffect");
+        throw std::runtime_error("DualTextureEffect");
     }
     if (!texture1Sampler.ptr || !texture2Sampler.ptr)
     {
         DebugTrace("ERROR: Missing sampler(s) for DualTextureEffect (samplers1 %llu, samplers2 %llu)\n", texture2Sampler.ptr, texture2Sampler.ptr);
-        throw std::exception("DualTextureEffect");
+        throw std::runtime_error("DualTextureEffect");
     }
 
     // **NOTE** If D3D asserts or crashes here, you probably need to call commandList->SetDescriptorHeaps() with the required descriptor heaps.

--- a/Src/EffectCommon.cpp
+++ b/Src/EffectCommon.cpp
@@ -341,7 +341,7 @@ void EffectLights::ValidateLightIndex(int whichLight)
 {
     if (whichLight < 0 || whichLight >= MaxDirectionalLights)
     {
-        throw std::out_of_range("whichLight parameter out of range");
+        throw std::invalid_argument("whichLight parameter out of range");
     }
 }
 

--- a/Src/EffectCommon.cpp
+++ b/Src/EffectCommon.cpp
@@ -341,7 +341,7 @@ void EffectLights::ValidateLightIndex(int whichLight)
 {
     if (whichLight < 0 || whichLight >= MaxDirectionalLights)
     {
-        throw std::invalid_argument("whichLight parameter out of range");
+        throw std::invalid_argument("whichLight parameter invalid");
     }
 }
 

--- a/Src/EffectFactory.cpp
+++ b/Src/EffectFactory.cpp
@@ -87,27 +87,27 @@ std::shared_ptr<IEffect> EffectFactory::Impl::CreateEffect(
     {
         DebugTrace("ERROR: EffectFactory created without texture descriptor heap with texture index set (diffuse %d, specular %d, normal %d, emissive %d)!\n",
             info.diffuseTextureIndex, info.specularTextureIndex, info.normalTextureIndex, info.emissiveTextureIndex);
-        throw std::exception("EffectFactory");
+        throw std::runtime_error("EffectFactory");
     }
     if (!mSamplerDescriptors && (info.samplerIndex != -1 || info.samplerIndex2 != -1))
     {
         DebugTrace("ERROR: EffectFactory created without sampler descriptor heap with sampler index set (samplerIndex %d, samplerIndex2 %d)!\n",
             info.samplerIndex, info.samplerIndex2);
-        throw std::exception("EffectFactory");
+        throw std::runtime_error("EffectFactory");
     }
 
     // If we have descriptors, make sure we have both texture and sampler descriptors
     if ((mTextureDescriptors == nullptr) != (mSamplerDescriptors == nullptr))
     {
         DebugTrace("ERROR: A texture or sampler descriptor heap was provided, but both are required.\n");
-        throw std::exception("EffectFactory");
+        throw std::runtime_error("EffectFactory");
     }
 
     // Validate the we have either both texture and sampler descriptors, or neither
     if ((info.diffuseTextureIndex == -1) != (info.samplerIndex == -1))
     {
         DebugTrace("ERROR: Material provides either a texture or sampler, but both are required.\n");
-        throw std::exception("EffectFactory");
+        throw std::runtime_error("EffectFactory");
     }
 
     int diffuseTextureIndex = (info.diffuseTextureIndex != -1 && mTextureDescriptors != nullptr) ? info.diffuseTextureIndex + textureDescriptorOffset : -1;
@@ -240,7 +240,7 @@ std::shared_ptr<IEffect> EffectFactory::Impl::CreateEffect(
             if (samplerIndex2 == -1)
             {
                 DebugTrace("ERROR: Dual-texture requires a second sampler (emissive %d)\n", emissiveTextureIndex);
-                throw std::exception("EffectFactory");
+                throw std::runtime_error("EffectFactory");
             }
 
             effect->SetTexture2(
@@ -253,7 +253,7 @@ std::shared_ptr<IEffect> EffectFactory::Impl::CreateEffect(
             if (samplerIndex2 == -1)
             {
                 DebugTrace("ERROR: Dual-texture requires a second sampler (specular %d)\n", specularTextureIndex);
-                throw std::exception("EffectFactory");
+                throw std::runtime_error("EffectFactory");
             }
 
             effect->SetTexture2(
@@ -468,20 +468,20 @@ EffectFactory::EffectFactory(_In_ ID3D12DescriptorHeap* textureDescriptors, _In_
 {
     if (!textureDescriptors)
     {
-        throw std::exception("Texture descriptor heap cannot be null if no device is provided. Use the alternative EffectFactory constructor instead.");
+        throw std::invalid_argument("Texture descriptor heap cannot be null if no device is provided. Use the alternative EffectFactory constructor instead.");
     }
     if (!samplerDescriptors)
     {
-        throw std::exception("Descriptor heap cannot be null if no device is provided. Use the alternative EffectFactory constructor instead.");
+        throw std::invalid_argument("Descriptor heap cannot be null if no device is provided. Use the alternative EffectFactory constructor instead.");
     }
 
     if (textureDescriptors->GetDesc().Type != D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV)
     {
-        throw std::exception("EffectFactory::CreateEffect requires a CBV_SRV_UAV descriptor heap for textureDescriptors.");
+        throw std::invalid_argument("EffectFactory::CreateEffect requires a CBV_SRV_UAV descriptor heap for textureDescriptors.");
     }
     if (samplerDescriptors->GetDesc().Type != D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER)
     {
-        throw std::exception("EffectFactory::CreateEffect requires a SAMPLER descriptor heap for samplerDescriptors.");
+        throw std::invalid_argument("EffectFactory::CreateEffect requires a SAMPLER descriptor heap for samplerDescriptors.");
     }
 
     ComPtr<ID3D12Device> device;

--- a/Src/EffectPipelineStateDescription.cpp
+++ b/Src/EffectPipelineStateDescription.cpp
@@ -103,6 +103,6 @@ void EffectPipelineStateDescription::CreatePipelineState(
     if (FAILED(hr))
     { 
         DebugTrace("ERROR: CreatePipelineState failed to create a PSO. Enable the Direct3D Debug Layer for more information (%08X)\n", static_cast<unsigned int>(hr));
-        throw std::exception("CreateGraphicsPipelineState");
+        throw std::runtime_error("CreateGraphicsPipelineState");
     }
 }

--- a/Src/EffectTextureFactory.cpp
+++ b/Src/EffectTextureFactory.cpp
@@ -99,7 +99,7 @@ _Use_decl_annotations_
 size_t EffectTextureFactory::Impl::CreateTexture(_In_z_ const wchar_t* name, int descriptorSlot)
 {
     if (!name)
-        throw std::exception("invalid arguments");
+        throw std::invalid_argument("name required for CreateTexture");
 
     auto it = mTextureCache.find(name);
 
@@ -123,7 +123,7 @@ size_t EffectTextureFactory::Impl::CreateTexture(_In_z_ const wchar_t* name, int
             if (!GetFileAttributesExW(fullName, GetFileExInfoStandard, &fileAttr))
             {
                 DebugTrace("ERROR: EffectTextureFactory could not find texture file '%ls'\n", name);
-                throw std::exception("CreateTexture");
+                throw std::runtime_error("EffectTextureFactory::CreateTexture");
             }
         }
 
@@ -157,7 +157,7 @@ size_t EffectTextureFactory::Impl::CreateTexture(_In_z_ const wchar_t* name, int
             {
                 DebugTrace("ERROR: CreateDDSTextureFromFile failed (%08X) for '%ls'\n",
                     static_cast<unsigned int>(hr), fullName);
-                throw std::exception("CreateDDSTextureFromFile");
+                throw std::runtime_error("EffectTextureFactory::CreateDDSTextureFromFile");
             }
         }
         else
@@ -176,7 +176,7 @@ size_t EffectTextureFactory::Impl::CreateTexture(_In_z_ const wchar_t* name, int
             {
                 DebugTrace("ERROR: CreateWICTextureFromFile failed (%08X) for '%ls'\n",
                     static_cast<unsigned int>(hr), fullName);
-                throw std::exception("CreateWICTextureFromFile");
+                throw std::runtime_error("EffectTextureFactory::CreateWICTextureFromFile");
             }
         }
 
@@ -317,7 +317,7 @@ _Use_decl_annotations_
 void EffectTextureFactory::GetResource(size_t slot, ID3D12Resource** resource, bool* isCubeMap)
 {
     if (slot >= pImpl->mResources.size())
-        throw std::exception("Accessing resource out of range.");
+        throw std::out_of_range("Accessing resource out of range.");
 
     const auto& textureEntry = pImpl->mResources[slot];
 

--- a/Src/EffectTextureFactory.cpp
+++ b/Src/EffectTextureFactory.cpp
@@ -317,7 +317,7 @@ _Use_decl_annotations_
 void EffectTextureFactory::GetResource(size_t slot, ID3D12Resource** resource, bool* isCubeMap)
 {
     if (slot >= pImpl->mResources.size())
-        throw std::out_of_range("Accessing resource out of range.");
+        throw std::invalid_argument("Resource slot is invalid");
 
     const auto& textureEntry = pImpl->mResources[slot];
 

--- a/Src/EnvironmentMapEffect.cpp
+++ b/Src/EnvironmentMapEffect.cpp
@@ -518,12 +518,12 @@ void EnvironmentMapEffect::Impl::Apply(_In_ ID3D12GraphicsCommandList* commandLi
     if (!texture.ptr || !environmentMap.ptr)
     {
         DebugTrace("ERROR: Missing texture(s) for EnvironmentMapEffect (texture %llu, environmentMap %llu)\n", texture.ptr, environmentMap.ptr);
-        throw std::exception("EnvironmentMapEffect");
+        throw std::runtime_error("EnvironmentMapEffect");
     }
     if (!textureSampler.ptr || !environmentMapSampler.ptr)
     {
         DebugTrace("ERROR: Missing sampler(s) for EnvironmentMapEffect (sampler %llu, environmentMap %llu)\n", textureSampler.ptr, environmentMapSampler.ptr);
-        throw std::exception("EnvironmentMapEffect");
+        throw std::runtime_error("EnvironmentMapEffect");
     }
 
     // **NOTE** If D3D asserts or crashes here, you probably need to call commandList->SetDescriptorHeaps() with the required descriptor heaps.

--- a/Src/EnvironmentMapEffect.cpp
+++ b/Src/EnvironmentMapEffect.cpp
@@ -403,7 +403,7 @@ EnvironmentMapEffect::Impl::Impl(
     if (effectFlags & EffectFlags::VertexColor)
     {
         DebugTrace("ERROR: EnvironmentMapEffect does not implement EffectFlags::VertexColor\n");
-        throw std::invalid_argument("EnvironmentMapEffect");
+        throw std::invalid_argument("VertexColor effect flag is invalid");
     }
 
     constants.environmentMapAmount = 1;

--- a/Src/GamePad.cpp
+++ b/Src/GamePad.cpp
@@ -100,7 +100,7 @@ public:
     {
         if (s_gamePad)
         {
-            throw std::exception("GamePad is a singleton");
+            throw std::logic_error("GamePad is a singleton");
         }
 
         s_gamePad = this;
@@ -419,7 +419,7 @@ public:
 
         if (s_gamePad)
         {
-            throw std::exception("GamePad is a singleton");
+            throw std::logic_error("GamePad is a singleton");
         }
 
         s_gamePad = this;
@@ -427,7 +427,7 @@ public:
         mChanged.reset(CreateEventEx(nullptr, nullptr, 0, EVENT_MODIFY_STATE | SYNCHRONIZE));
         if (!mChanged)
         {
-            throw std::exception("CreateEventEx");
+            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "CreateEventEx");
         }
 
         ThrowIfFailed(GetActivationFactory(HStringReference(RuntimeClass_Windows_Gaming_Input_Gamepad).Get(), mStatics.GetAddressOf()));
@@ -902,7 +902,7 @@ public:
 
         if (s_gamePad)
         {
-            throw std::exception("GamePad is a singleton");
+            throw std::logic_error("GamePad is a singleton");
         }
 
         s_gamePad = this;
@@ -910,7 +910,7 @@ public:
         mChanged.reset(CreateEventEx(nullptr, nullptr, 0, EVENT_MODIFY_STATE | SYNCHRONIZE));
         if (!mChanged)
         {
-            throw std::exception("CreateEventEx");
+            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "CreateEventEx");
         }
 
         ThrowIfFailed(GetActivationFactory(HStringReference(RuntimeClass_Windows_Xbox_Input_Gamepad).Get(), mStatics.GetAddressOf()));
@@ -1203,7 +1203,7 @@ private:
                 {
                     if (empty >= MAX_PLAYER_COUNT)
                     {
-                        throw std::exception("Too many gamepads found");
+                        throw std::runtime_error("Too many gamepads found");
                     }
 
                     mGamePad[empty] = pad;
@@ -1257,7 +1257,7 @@ public:
 
         if (s_gamePad)
         {
-            throw std::exception("GamePad is a singleton");
+            throw std::logic_error("GamePad is a singleton");
         }
 
         s_gamePad = this;
@@ -1667,7 +1667,7 @@ void GamePad::RegisterEvents(HANDLE ctrlChanged, HANDLE userChanged) noexcept
 GamePad& GamePad::Get()
 {
     if (!Impl::s_gamePad || !Impl::s_gamePad->mOwner)
-        throw std::exception("GamePad is a singleton");
+        throw std::logic_error("GamePad singleton not created");
 
     return *Impl::s_gamePad->mOwner;
 }

--- a/Src/GamePad.cpp
+++ b/Src/GamePad.cpp
@@ -427,7 +427,7 @@ public:
         mChanged.reset(CreateEventEx(nullptr, nullptr, 0, EVENT_MODIFY_STATE | SYNCHRONIZE));
         if (!mChanged)
         {
-            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "CreateEventEx");
+            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "CreateEventEx");
         }
 
         ThrowIfFailed(GetActivationFactory(HStringReference(RuntimeClass_Windows_Gaming_Input_Gamepad).Get(), mStatics.GetAddressOf()));
@@ -910,7 +910,7 @@ public:
         mChanged.reset(CreateEventEx(nullptr, nullptr, 0, EVENT_MODIFY_STATE | SYNCHRONIZE));
         if (!mChanged)
         {
-            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "CreateEventEx");
+            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "CreateEventEx");
         }
 
         ThrowIfFailed(GetActivationFactory(HStringReference(RuntimeClass_Windows_Xbox_Input_Gamepad).Get(), mStatics.GetAddressOf()));

--- a/Src/GeometricPrimitive.cpp
+++ b/Src/GeometricPrimitive.cpp
@@ -59,15 +59,15 @@ void GeometricPrimitive::Impl::Initialize(
     _In_opt_ ID3D12Device* device)
 {
     if (vertices.size() >= USHRT_MAX)
-        throw std::exception("Too many vertices for 16-bit index buffer");
+        throw std::invalid_argument("Too many vertices for 16-bit index buffer");
 
     if (indices.size() > UINT32_MAX)
-        throw std::exception("Too many indices");
+        throw std::invalid_argument("Too many indices");
 
     // Vertex data
     uint64_t sizeInBytes = uint64_t(vertices.size()) * sizeof(vertices[0]);
     if (sizeInBytes > uint64_t(D3D12_REQ_RESOURCE_SIZE_IN_MEGABYTES_EXPRESSION_A_TERM * 1024u * 1024u))
-        throw std::exception("VB too large for DirectX 12");
+        throw std::invalid_argument("VB too large for DirectX 12");
 
     auto vertSizeBytes = static_cast<size_t>(sizeInBytes);
 
@@ -79,7 +79,7 @@ void GeometricPrimitive::Impl::Initialize(
     // Index data
     sizeInBytes = uint64_t(indices.size()) * sizeof(indices[0]);
     if (sizeInBytes > uint64_t(D3D12_REQ_RESOURCE_SIZE_IN_MEGABYTES_EXPRESSION_A_TERM * 1024u * 1024u))
-        throw std::exception("IB too large for DirectX 12");
+        throw std::invalid_argument("IB too large for DirectX 12");
 
     auto indSizeBytes = static_cast<size_t>(sizeInBytes);
 
@@ -673,20 +673,20 @@ std::unique_ptr<GeometricPrimitive> GeometricPrimitive::CreateCustom(
 {
     // Extra validation
     if (vertices.empty() || indices.empty())
-        throw std::exception("Requires both vertices and indices");
+        throw std::invalid_argument("Requires both vertices and indices");
 
     if (indices.size() % 3)
-        throw std::exception("Expected triangular faces");
+        throw std::invalid_argument("Expected triangular faces");
 
     size_t nVerts = vertices.size();
     if (nVerts >= USHRT_MAX)
-        throw std::exception("Too many vertices for 16-bit index buffer");
+        throw std::invalid_argument("Too many vertices for 16-bit index buffer");
 
     for (auto it = indices.cbegin(); it != indices.cend(); ++it)
     {
         if (*it >= nVerts)
         {
-            throw std::exception("Index not in vertices list");
+            throw std::out_of_range("Index not in vertices list");
         }
     }
     // Create the primitive object.

--- a/Src/Geometry.cpp
+++ b/Src/Geometry.cpp
@@ -24,7 +24,7 @@ namespace
     {
         // Use >=, not > comparison, because some D3D level 9_x hardware does not support 0xFFFF index values.
         if (value >= USHRT_MAX)
-            throw std::exception("Index value out of range: cannot tesselate primitive so finely");
+            throw std::out_of_range("Index value out of range: cannot tesselate primitive so finely");
     }
 
 
@@ -150,7 +150,7 @@ void DirectX::ComputeSphere(VertexCollection& vertices, IndexCollection& indices
     indices.clear();
 
     if (tessellation < 3)
-        throw std::out_of_range("tesselation parameter out of range");
+        throw std::invalid_argument("tesselation parameter out of range");
 
     size_t verticalSegments = tessellation;
     size_t horizontalSegments = tessellation * 2;
@@ -617,7 +617,7 @@ void DirectX::ComputeCylinder(VertexCollection& vertices, IndexCollection& indic
     indices.clear();
 
     if (tessellation < 3)
-        throw std::out_of_range("tesselation parameter out of range");
+        throw std::invalid_argument("tesselation parameter out of range");
 
     height /= 2;
 
@@ -666,7 +666,7 @@ void DirectX::ComputeCone(VertexCollection& vertices, IndexCollection& indices, 
     indices.clear();
 
     if (tessellation < 3)
-        throw std::out_of_range("tesselation parameter out of range");
+        throw std::invalid_argument("tesselation parameter out of range");
 
     height /= 2;
 
@@ -720,7 +720,7 @@ void DirectX::ComputeTorus(VertexCollection& vertices, IndexCollection& indices,
     indices.clear();
 
     if (tessellation < 3)
-        throw std::out_of_range("tesselation parameter out of range");
+        throw std::invalid_argument("tesselation parameter out of range");
 
     size_t stride = tessellation + 1;
 
@@ -1162,7 +1162,7 @@ void DirectX::ComputeTeapot(VertexCollection& vertices, IndexCollection& indices
     indices.clear();
 
     if (tessellation < 1)
-        throw std::out_of_range("tesselation parameter out of range");
+        throw std::invalid_argument("tesselation parameter out of range");
 
     XMVECTOR scaleVector = XMVectorReplicate(size);
 

--- a/Src/Geometry.cpp
+++ b/Src/Geometry.cpp
@@ -150,7 +150,7 @@ void DirectX::ComputeSphere(VertexCollection& vertices, IndexCollection& indices
     indices.clear();
 
     if (tessellation < 3)
-        throw std::invalid_argument("tesselation parameter out of range");
+        throw std::invalid_argument("tesselation parameter must be at least 3");
 
     size_t verticalSegments = tessellation;
     size_t horizontalSegments = tessellation * 2;
@@ -617,7 +617,7 @@ void DirectX::ComputeCylinder(VertexCollection& vertices, IndexCollection& indic
     indices.clear();
 
     if (tessellation < 3)
-        throw std::invalid_argument("tesselation parameter out of range");
+        throw std::invalid_argument("tesselation parameter must be at least 3");
 
     height /= 2;
 
@@ -666,7 +666,7 @@ void DirectX::ComputeCone(VertexCollection& vertices, IndexCollection& indices, 
     indices.clear();
 
     if (tessellation < 3)
-        throw std::invalid_argument("tesselation parameter out of range");
+        throw std::invalid_argument("tesselation parameter must be at least 3");
 
     height /= 2;
 
@@ -720,7 +720,7 @@ void DirectX::ComputeTorus(VertexCollection& vertices, IndexCollection& indices,
     indices.clear();
 
     if (tessellation < 3)
-        throw std::invalid_argument("tesselation parameter out of range");
+        throw std::invalid_argument("tesselation parameter must be at least 3");
 
     size_t stride = tessellation + 1;
 
@@ -1162,7 +1162,7 @@ void DirectX::ComputeTeapot(VertexCollection& vertices, IndexCollection& indices
     indices.clear();
 
     if (tessellation < 1)
-        throw std::invalid_argument("tesselation parameter out of range");
+        throw std::invalid_argument("tesselation parameter must be non-zero");
 
     XMVECTOR scaleVector = XMVectorReplicate(size);
 

--- a/Src/GraphicsMemory.cpp
+++ b/Src/GraphicsMemory.cpp
@@ -218,7 +218,7 @@ public:
     #if (defined(_XBOX_ONE) && defined(_TITLE)) || defined(_GAMING_XBOX)
         if (s_graphicsMemory)
         {
-            throw std::exception("GraphicsMemory is a singleton");
+            throw std::logic_error("GraphicsMemory is a singleton");
         }
 
         s_graphicsMemory = this;
@@ -251,7 +251,7 @@ public:
     #if !(defined(_XBOX_ONE) && defined(_TITLE)) && !defined(_GAMING_XBOX)
         if (s_graphicsMemory.find(device) != s_graphicsMemory.cend())
         {
-            throw std::exception("GraphicsMemory is a per-device singleton");
+            throw std::logic_error("GraphicsMemory is a per-device singleton");
         }
         s_graphicsMemory[device] = this;
     #endif
@@ -393,7 +393,7 @@ void GraphicsMemory::ResetStatistics()
 GraphicsMemory& GraphicsMemory::Get(_In_opt_ ID3D12Device*)
 {
     if (!Impl::s_graphicsMemory || !Impl::s_graphicsMemory->mOwner)
-        throw std::exception("GraphicsMemory singleton not created");
+        throw std::logic_error("GraphicsMemory singleton not created");
 
     return *Impl::s_graphicsMemory->mOwner;
 }
@@ -401,7 +401,7 @@ GraphicsMemory& GraphicsMemory::Get(_In_opt_ ID3D12Device*)
 GraphicsMemory& GraphicsMemory::Get(_In_opt_ ID3D12Device* device)
 {
     if (Impl::s_graphicsMemory.empty())
-        throw std::exception("GraphicsMemory singleton not created");
+        throw std::logic_error("GraphicsMemory singleton not created");
 
     std::map<ID3D12Device*, GraphicsMemory::Impl*>::const_iterator it;
     if (!device)
@@ -417,7 +417,7 @@ GraphicsMemory& GraphicsMemory::Get(_In_opt_ ID3D12Device* device)
     }
 
     if (it == Impl::s_graphicsMemory.cend() || !it->second->mOwner)
-        throw std::exception("GraphicsMemory per-device singleton not created");
+        throw std::logic_error("GraphicsMemory per-device singleton not created");
 
     return *it->second->mOwner;
 }

--- a/Src/Keyboard.cpp
+++ b/Src/Keyboard.cpp
@@ -67,7 +67,7 @@ public:
     {
         if (s_keyboard)
         {
-            throw std::exception("Keyboard is a singleton");
+            throw std::logic_error("Keyboard is a singleton");
         }
 
         s_keyboard = this;
@@ -209,7 +209,7 @@ public:
     {
         if (s_keyboard)
         {
-            throw std::exception("Keyboard is a singleton");
+            throw std::logic_error("Keyboard is a singleton");
         }
 
         s_keyboard = this;
@@ -342,7 +342,7 @@ public:
     {
         if (s_keyboard)
         {
-            throw std::exception("Keyboard is a singleton");
+            throw std::logic_error("Keyboard is a singleton");
         }
 
         s_keyboard = this;
@@ -603,7 +603,7 @@ bool Keyboard::IsConnected() const
 Keyboard& Keyboard::Get()
 {
     if (!Impl::s_keyboard || !Impl::s_keyboard->mOwner)
-        throw std::exception("Keyboard is a singleton");
+        throw std::logic_error("Keyboard singleton not created");
 
     return *Impl::s_keyboard->mOwner;
 }

--- a/Src/LinearAllocator.cpp
+++ b/Src/LinearAllocator.cpp
@@ -41,7 +41,7 @@ size_t LinearAllocatorPage::Suballocate(_In_ size_t size, _In_ size_t alignment)
     {
         // Use of suballocate should be limited to pages with free space,
         // so really shouldn't happen.
-        throw std::exception("LinearAllocatorPage::Suballocate");
+        throw std::runtime_error("LinearAllocatorPage::Suballocate");
     }
     mOffset = offset + size;
     return offset;
@@ -123,7 +123,7 @@ LinearAllocatorPage* LinearAllocator::FindPageForAlloc(_In_ size_t size, _In_ si
     if (alignment > m_increment)
         throw std::out_of_range("Alignment must be less or equal to the allocator's increment");
     if (size == 0)
-        throw std::exception("Cannot honor zero size allocation request.");
+        throw std::invalid_argument("Cannot honor zero size allocation request.");
 #endif
 
     auto page = GetPageForAlloc(size, alignment);
@@ -453,7 +453,7 @@ void LinearAllocator::ValidateList(LinearAllocatorPage* list)
     {
         if (page->pPrevPage != lastPage)
         {
-            throw std::exception("Broken link to previous");
+            throw std::runtime_error("Broken link to previous");
         }
     }
 }

--- a/Src/Model.cpp
+++ b/Src/Model.cpp
@@ -55,19 +55,19 @@ void ModelMeshPart::Draw(_In_ ID3D12GraphicsCommandList* commandList) const
     if (!indexBufferSize || !vertexBufferSize)
     {
         DebugTrace("ERROR: Model part missing values for vertex and/or index buffer size (indexBufferSize %u, vertexBufferSize %u)!\n", indexBufferSize, vertexBufferSize);
-        throw std::exception("ModelMeshPart");
+        throw std::runtime_error("ModelMeshPart");
     }
 
     if (!staticIndexBuffer && !indexBuffer)
     {
         DebugTrace("ERROR: Model part missing index buffer!\n");
-        throw std::exception("ModelMeshPart");
+        throw std::runtime_error("ModelMeshPart");
     }
 
     if (!staticVertexBuffer && !vertexBuffer)
     {
         DebugTrace("ERROR: Model part missing vertex buffer!\n");
-        throw std::exception("ModelMeshPart");
+        throw std::runtime_error("ModelMeshPart");
     }
 
     D3D12_VERTEX_BUFFER_VIEW vbv;
@@ -94,19 +94,19 @@ void ModelMeshPart::DrawInstanced(_In_ ID3D12GraphicsCommandList* commandList, u
     if (!indexBufferSize || !vertexBufferSize)
     {
         DebugTrace("ERROR: Model part missing values for vertex and/or index buffer size (indexBufferSize %u, vertexBufferSize %u)!\n", indexBufferSize, vertexBufferSize);
-        throw std::exception("ModelMeshPart");
+        throw std::runtime_error("ModelMeshPart");
     }
 
     if (!staticIndexBuffer && !indexBuffer)
     {
         DebugTrace("ERROR: Model part missing index buffer!\n");
-        throw std::exception("ModelMeshPart");
+        throw std::runtime_error("ModelMeshPart");
     }
 
     if (!staticVertexBuffer && !vertexBuffer)
     {
         DebugTrace("ERROR: Model part missing vertex buffer!\n");
-        throw std::exception("ModelMeshPart");
+        throw std::runtime_error("ModelMeshPart");
     }
 
     D3D12_VERTEX_BUFFER_VIEW vbv;
@@ -301,7 +301,7 @@ void Model::LoadStaticBuffers(
             if (!part->vertexBuffer)
             {
                 DebugTrace("ERROR: Model part missing vertex buffer!\n");
-                throw std::exception("ModelMeshPart");
+                throw std::runtime_error("ModelMeshPart");
             }
 
             part->vertexBufferSize = static_cast<uint32_t>(part->vertexBuffer.Size());
@@ -357,7 +357,7 @@ void Model::LoadStaticBuffers(
             if (!part->indexBuffer)
             {
                 DebugTrace("ERROR: Model part missing index buffer!\n");
-                throw std::exception("ModelMeshPart");
+                throw std::runtime_error("ModelMeshPart");
             }
 
             part->indexBufferSize = static_cast<uint32_t>(part->indexBuffer.Size());
@@ -421,7 +421,7 @@ std::vector<std::shared_ptr<IEffect>> Model::CreateEffects(
     if (materials.empty())
     {
         DebugTrace("ERROR: Model has no material information to create effects!\n");
-        throw std::exception("CreateEffects");
+        throw std::runtime_error("CreateEffects");
     }
 
     std::vector<std::shared_ptr<IEffect>> effects;
@@ -492,10 +492,10 @@ std::shared_ptr<IEffect> Model::CreateEffectForMeshPart(
     const auto& m = materials[part->materialIndex];
 
     if (!part->vbDecl || part->vbDecl->empty())
-        throw std::exception("Model mesh part missing vertex buffer input elements data");
+        throw std::runtime_error("Model mesh part missing vertex buffer input elements data");
 
     if (part->vbDecl->size() > D3D12_IA_VERTEX_INPUT_STRUCTURE_ELEMENT_COUNT)
-        throw std::exception("Model mesh part input layout size is too large for DirectX 12");
+        throw std::runtime_error("Model mesh part input layout size is too large for DirectX 12");
 
     D3D12_INPUT_LAYOUT_DESC il = {};
     il.NumElements = static_cast<UINT>(part->vbDecl->size());

--- a/Src/ModelLoadSDKMESH.cpp
+++ b/Src/ModelLoadSDKMESH.cpp
@@ -368,7 +368,7 @@ namespace
         }
 
         if (!posfound)
-            throw std::exception("SV_Position is required");
+            throw std::runtime_error("SV_Position is required");
 
         if (texcoords == 2)
         {
@@ -391,74 +391,74 @@ std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(
     ModelLoaderFlags flags)
 {
     if (!meshData)
-        throw std::exception("meshData cannot be null");
+        throw std::invalid_argument("meshData cannot be null");
 
     uint64_t dataSize = idataSize;
 
     // File Headers
     if (dataSize < sizeof(DXUT::SDKMESH_HEADER))
-        throw std::exception("End of file");
+        throw std::runtime_error("End of file");
     auto header = reinterpret_cast<const DXUT::SDKMESH_HEADER*>(meshData);
 
     size_t headerSize = sizeof(DXUT::SDKMESH_HEADER)
         + header->NumVertexBuffers * sizeof(DXUT::SDKMESH_VERTEX_BUFFER_HEADER)
         + header->NumIndexBuffers * sizeof(DXUT::SDKMESH_INDEX_BUFFER_HEADER);
     if (header->HeaderSize != headerSize)
-        throw std::exception("Not a valid SDKMESH file");
+        throw std::runtime_error("Not a valid SDKMESH file");
 
     if (dataSize < header->HeaderSize)
-        throw std::exception("End of file");
+        throw std::runtime_error("End of file");
 
     if (header->Version != DXUT::SDKMESH_FILE_VERSION && header->Version != DXUT::SDKMESH_FILE_VERSION_V2)
-        throw std::exception("Not a supported SDKMESH version");
+        throw std::runtime_error("Not a supported SDKMESH version");
 
     if (header->IsBigEndian)
-        throw std::exception("Loading BigEndian SDKMESH files not supported");
+        throw std::runtime_error("Loading BigEndian SDKMESH files not supported");
 
     if (!header->NumMeshes)
-        throw std::exception("No meshes found");
+        throw std::runtime_error("No meshes found");
 
     if (!header->NumVertexBuffers)
-        throw std::exception("No vertex buffers found");
+        throw std::runtime_error("No vertex buffers found");
 
     if (!header->NumIndexBuffers)
-        throw std::exception("No index buffers found");
+        throw std::runtime_error("No index buffers found");
 
     if (!header->NumTotalSubsets)
-        throw std::exception("No subsets found");
+        throw std::runtime_error("No subsets found");
 
     if (!header->NumMaterials)
-        throw std::exception("No materials found");
+        throw std::runtime_error("No materials found");
 
     // Sub-headers
     if (dataSize < header->VertexStreamHeadersOffset
         || (dataSize < (header->VertexStreamHeadersOffset + uint64_t(header->NumVertexBuffers) * sizeof(DXUT::SDKMESH_VERTEX_BUFFER_HEADER))))
-        throw std::exception("End of file");
+        throw std::runtime_error("End of file");
     auto vbArray = reinterpret_cast<const DXUT::SDKMESH_VERTEX_BUFFER_HEADER*>(meshData + header->VertexStreamHeadersOffset);
 
     if (dataSize < header->IndexStreamHeadersOffset
         || (dataSize < (header->IndexStreamHeadersOffset + uint64_t(header->NumIndexBuffers) * sizeof(DXUT::SDKMESH_INDEX_BUFFER_HEADER))))
-        throw std::exception("End of file");
+        throw std::runtime_error("End of file");
     auto ibArray = reinterpret_cast<const DXUT::SDKMESH_INDEX_BUFFER_HEADER*>(meshData + header->IndexStreamHeadersOffset);
 
     if (dataSize < header->MeshDataOffset
         || (dataSize < (header->MeshDataOffset + uint64_t(header->NumMeshes) * sizeof(DXUT::SDKMESH_MESH))))
-        throw std::exception("End of file");
+        throw std::runtime_error("End of file");
     auto meshArray = reinterpret_cast<const DXUT::SDKMESH_MESH*>(meshData + header->MeshDataOffset);
 
     if (dataSize < header->SubsetDataOffset
         || (dataSize < (header->SubsetDataOffset + uint64_t(header->NumTotalSubsets) * sizeof(DXUT::SDKMESH_SUBSET))))
-        throw std::exception("End of file");
+        throw std::runtime_error("End of file");
     auto subsetArray = reinterpret_cast<const DXUT::SDKMESH_SUBSET*>(meshData + header->SubsetDataOffset);
 
     if (dataSize < header->FrameDataOffset
         || (dataSize < (header->FrameDataOffset + uint64_t(header->NumFrames) * sizeof(DXUT::SDKMESH_FRAME))))
-        throw std::exception("End of file");
+        throw std::runtime_error("End of file");
     // TODO - auto frameArray = reinterpret_cast<const DXUT::SDKMESH_FRAME*>( meshData + header->FrameDataOffset );
 
     if (dataSize < header->MaterialDataOffset
         || (dataSize < (header->MaterialDataOffset + uint64_t(header->NumMaterials) * sizeof(DXUT::SDKMESH_MATERIAL))))
-        throw std::exception("End of file");
+        throw std::runtime_error("End of file");
 
     const DXUT::SDKMESH_MATERIAL* materialArray = nullptr;
     const DXUT::SDKMESH_MATERIAL_V2* materialArray_v2 = nullptr;
@@ -475,7 +475,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(
     uint64_t bufferDataOffset = header->HeaderSize + header->NonBufferDataSize;
     if ((dataSize < bufferDataOffset)
         || (dataSize < bufferDataOffset + header->BufferDataSize))
-        throw std::exception("End of file");
+        throw std::runtime_error("End of file");
     const uint8_t* bufferData = meshData + bufferDataOffset;
 
     // Create vertex buffers
@@ -491,17 +491,17 @@ std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(
         auto& vh = vbArray[j];
 
         if (vh.SizeBytes > UINT32_MAX)
-            throw std::exception("VB too large");
+            throw std::runtime_error("VB too large");
 
         if (!(flags & ModelLoader_AllowLargeModels))
         {
             if (vh.SizeBytes > (D3D12_REQ_RESOURCE_SIZE_IN_MEGABYTES_EXPRESSION_A_TERM * 1024u * 1024u))
-                throw std::exception("VB too large for DirectX 12");
+                throw std::runtime_error("VB too large for DirectX 12");
         }
 
         if (dataSize < vh.DataOffset
             || (dataSize < vh.DataOffset + vh.SizeBytes))
-            throw std::exception("End of file");
+            throw std::runtime_error("End of file");
 
         vbDecls[j] = std::make_shared<std::vector<D3D12_INPUT_ELEMENT_DESC>>();
         unsigned int ilflags = GetInputLayoutDesc(vh.Decl, *vbDecls[j].get());
@@ -535,20 +535,20 @@ std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(
         auto& ih = ibArray[j];
 
         if (ih.SizeBytes > UINT32_MAX)
-            throw std::exception("IB too large");
+            throw std::runtime_error("IB too large");
 
         if (!(flags & ModelLoader_AllowLargeModels))
         {
             if (ih.SizeBytes > (D3D12_REQ_RESOURCE_SIZE_IN_MEGABYTES_EXPRESSION_A_TERM * 1024u * 1024u))
-                throw std::exception("IB too large for DirectX 12");
+                throw std::runtime_error("IB too large for DirectX 12");
         }
 
         if (dataSize < ih.DataOffset
             || (dataSize < ih.DataOffset + ih.SizeBytes))
-            throw std::exception("End of file");
+            throw std::runtime_error("End of file");
 
         if (ih.IndexType != DXUT::IT_16BIT && ih.IndexType != DXUT::IT_32BIT)
-            throw std::exception("Invalid index buffer type found");
+            throw std::runtime_error("Invalid index buffer type found");
     }
 
     // Create meshes
@@ -570,13 +570,13 @@ std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(
             || !mh.NumVertexBuffers
             || mh.IndexBuffer >= header->NumIndexBuffers
             || mh.VertexBuffers[0] >= header->NumVertexBuffers)
-            throw std::exception("Invalid mesh found");
+            throw std::out_of_range("Invalid mesh found");
 
         // mh.NumVertexBuffers is sometimes not what you'd expect, so we skip validating it
 
         if (dataSize < mh.SubsetOffset
             || (dataSize < mh.SubsetOffset + uint64_t(mh.NumSubsets) * sizeof(UINT)))
-            throw std::exception("End of file");
+            throw std::runtime_error("End of file");
 
         auto subsets = reinterpret_cast<const UINT*>(meshData + mh.SubsetOffset);
 
@@ -584,7 +584,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(
         {
             if (dataSize < mh.FrameInfluenceOffset
                 || (dataSize < mh.FrameInfluenceOffset + uint64_t(mh.NumFrameInfluences) * sizeof(UINT)))
-                throw std::exception("End of file");
+                throw std::runtime_error("End of file");
 
             // TODO - auto influences = reinterpret_cast<const UINT*>( meshData + mh.FrameInfluenceOffset );
         }
@@ -604,7 +604,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(
         {
             auto sIndex = subsets[j];
             if (sIndex >= header->NumTotalSubsets)
-                throw std::exception("Invalid mesh found");
+                throw std::out_of_range("Invalid mesh found");
 
             auto& subset = subsetArray[sIndex];
 
@@ -623,14 +623,14 @@ std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(
 
                 case DXUT::PT_QUAD_PATCH_LIST:
                 case DXUT::PT_TRIANGLE_PATCH_LIST:
-                    throw std::exception("Direct3D9 era tessellation not supported");
+                    throw std::runtime_error("Direct3D9 era tessellation not supported");
 
                 default:
-                    throw std::exception("Unknown primitive type");
+                    throw std::runtime_error("Unknown primitive type");
             }
 
             if (subset.MaterialID >= header->NumMaterials)
-                throw std::exception("Invalid mesh found");
+                throw std::out_of_range("Invalid mesh found");
 
             auto& mat = materials[subset.MaterialID];
 
@@ -718,7 +718,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(
     {
         DebugTrace("ERROR: CreateFromSDKMESH failed (%08X) loading '%ls'\n",
             static_cast<unsigned int>(hr), szFileName);
-        throw std::exception("CreateFromSDKMESH");
+        throw std::runtime_error("CreateFromSDKMESH");
     }
 
     auto model = CreateFromSDKMESH(device, data.get(), dataSize, flags);

--- a/Src/ModelLoadVBO.cpp
+++ b/Src/ModelLoadVBO.cpp
@@ -64,7 +64,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromVBO(
     auto header = reinterpret_cast<const VBO::header_t*>(meshData);
 
     if (!header->numVertices || !header->numIndices)
-        throw std::exceruntime_errorption("No vertices or indices found");
+        throw std::runtime_error("No vertices or indices found");
 
     uint64_t sizeInBytes = uint64_t(header->numVertices) * sizeof(VertexPositionNormalTexture);
     if (sizeInBytes > UINT32_MAX)

--- a/Src/ModelLoadVBO.cpp
+++ b/Src/ModelLoadVBO.cpp
@@ -53,7 +53,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromVBO(
     ModelLoaderFlags flags)
 {
     if (!InitOnceExecuteOnce(&g_InitOnce, InitializeDecl, nullptr, nullptr))
-        throw std::system_error(std::error_code(GetLastError(), std::system_category()), "InitOnceExecuteOnce");
+        throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "InitOnceExecuteOnce");
 
     if (!meshData)
         throw std::invalid_argument("meshData cannot be null");

--- a/Src/ModelLoadVBO.cpp
+++ b/Src/ModelLoadVBO.cpp
@@ -53,49 +53,49 @@ std::unique_ptr<Model> DirectX::Model::CreateFromVBO(
     ModelLoaderFlags flags)
 {
     if (!InitOnceExecuteOnce(&g_InitOnce, InitializeDecl, nullptr, nullptr))
-        throw std::exception("One-time initialization failed");
+        throw std::system_error(std::error_code(GetLastError(), std::system_category()), "InitOnceExecuteOnce");
 
     if (!meshData)
-        throw std::exception("meshData cannot be null");
+        throw std::invalid_argument("meshData cannot be null");
 
     // File Header
     if (dataSize < sizeof(VBO::header_t))
-        throw std::exception("End of file");
+        throw std::runtime_error("End of file");
     auto header = reinterpret_cast<const VBO::header_t*>(meshData);
 
     if (!header->numVertices || !header->numIndices)
-        throw std::exception("No vertices or indices found");
+        throw std::exceruntime_errorption("No vertices or indices found");
 
     uint64_t sizeInBytes = uint64_t(header->numVertices) * sizeof(VertexPositionNormalTexture);
     if (sizeInBytes > UINT32_MAX)
-        throw std::exception("VB too large");
+        throw std::runtime_error("VB too large");
 
     if (!(flags & ModelLoader_AllowLargeModels))
     {
         if (sizeInBytes > uint64_t(D3D12_REQ_RESOURCE_SIZE_IN_MEGABYTES_EXPRESSION_A_TERM * 1024u * 1024u))
-            throw std::exception("VB too large for DirectX 12");
+            throw std::runtime_error("VB too large for DirectX 12");
     }
 
     auto vertSize = static_cast<size_t>(sizeInBytes);
 
     if (dataSize < (vertSize + sizeof(VBO::header_t)))
-        throw std::exception("End of file");
+        throw std::runtime_error("End of file");
     auto verts = reinterpret_cast<const VertexPositionNormalTexture*>(meshData + sizeof(VBO::header_t));
 
     sizeInBytes = uint64_t(header->numIndices) * sizeof(uint16_t);
     if (sizeInBytes > UINT32_MAX)
-        throw std::exception("IB too large");
+        throw std::runtime_error("IB too large");
 
     if (!(flags & ModelLoader_AllowLargeModels))
     {
         if (sizeInBytes > uint64_t(D3D12_REQ_RESOURCE_SIZE_IN_MEGABYTES_EXPRESSION_A_TERM * 1024u * 1024u))
-            throw std::exception("IB too large for DirectX 12");
+            throw std::runtime_error("IB too large for DirectX 12");
     }
 
     auto indexSize = static_cast<size_t>(sizeInBytes);
 
     if (dataSize < (sizeof(VBO::header_t) + vertSize + indexSize))
-        throw std::exception("End of file");
+        throw std::runtime_error("End of file");
     auto indices = reinterpret_cast<const uint16_t*>(meshData + sizeof(VBO::header_t) + vertSize);
 
     // Create vertex buffer
@@ -144,7 +144,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromVBO(
     {
         DebugTrace("ERROR: CreateFromVBO failed (%08X) loading '%ls'\n",
             static_cast<unsigned int>(hr), szFileName);
-        throw std::exception("CreateFromVBO");
+        throw std::runtime_error("CreateFromVBO");
     }
 
     auto model = CreateFromVBO(device, data.get(), dataSize, flags);

--- a/Src/Mouse.cpp
+++ b/Src/Mouse.cpp
@@ -67,7 +67,7 @@ public:
     {
         if (s_mouse)
         {
-            throw std::exception("Mouse is a singleton");
+            throw std::logic_error("Mouse is a singleton");
         }
 
         s_mouse = this;
@@ -86,7 +86,7 @@ public:
         mScrollWheelValue.reset(CreateEventEx(nullptr, nullptr, CREATE_EVENT_MANUAL_RESET, EVENT_MODIFY_STATE | SYNCHRONIZE));
         if (!mScrollWheelValue)
         {
-            throw std::exception("CreateEventEx");
+            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "CreateEventEx");
         }
     }
 
@@ -121,7 +121,7 @@ public:
 
         DWORD result = WaitForSingleObjectEx(mScrollWheelValue.get(), 0, FALSE);
         if (result == WAIT_FAILED)
-            throw std::exception("WaitForSingleObjectEx");
+            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "WaitForSingleObjectEx");
 
         if (result == WAIT_OBJECT_0)
         {
@@ -205,7 +205,7 @@ public:
         CURSORINFO info = { sizeof(CURSORINFO), 0, nullptr, {} };
         if (!GetCursorInfo(&info))
         {
-            throw std::exception("GetCursorInfo");
+            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "GetCursorInfo");
         }
 
         bool isvisible = (info.flags & CURSOR_SHOWING) != 0;
@@ -270,7 +270,7 @@ void Mouse::ProcessMessage(UINT message, WPARAM wParam, LPARAM lParam)
 
     DWORD result = WaitForSingleObjectEx(pImpl->mScrollWheelValue.get(), 0, FALSE);
     if (result == WAIT_FAILED)
-        throw std::exception("WaitForSingleObjectEx");
+        throw std::system_error(std::error_code(GetLastError(), std::system_category()), "WaitForSingleObjectEx");
 
     if (result == WAIT_OBJECT_0)
     {
@@ -445,7 +445,7 @@ public:
     {
         if (s_mouse)
         {
-            throw std::exception("Mouse is a singleton");
+            throw std::logic_error("Mouse is a singleton");
         }
 
         s_mouse = this;
@@ -459,7 +459,7 @@ public:
             || !mAbsoluteMode
             || !mRelativeMode)
         {
-            throw std::exception("CreateEventEx");
+            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "CreateEventEx");
         }
     }
 
@@ -481,7 +481,7 @@ public:
 
         DWORD result = WaitForSingleObjectEx(mScrollWheelValue.get(), 0, FALSE);
         if (result == WAIT_FAILED)
-            throw std::exception("WaitForSingleObjectEx");
+            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "WaitForSingleObjectEx");
 
         if (result == WAIT_OBJECT_0)
         {
@@ -493,7 +493,7 @@ public:
             result = WaitForSingleObjectEx(mRelativeRead.get(), 0, FALSE);
 
             if (result == WAIT_FAILED)
-                throw std::exception("WaitForSingleObjectEx");
+                throw std::system_error(std::error_code(GetLastError(), std::system_category()), "WaitForSingleObjectEx");
 
             if (result == WAIT_OBJECT_0)
             {
@@ -528,7 +528,7 @@ public:
         tme.dwHoverTime = 1;
         if (!TrackMouseEvent(&tme))
         {
-            throw std::exception("TrackMouseEvent");
+            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "TrackMouseEvent");
         }
     }
 
@@ -557,7 +557,7 @@ public:
         CURSORINFO info = { sizeof(CURSORINFO), 0, nullptr, {} };
         if (!GetCursorInfo(&info))
         {
-            throw std::exception("GetCursorInfo");
+            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "GetCursorInfo");
         }
 
         bool isvisible = (info.flags & CURSOR_SHOWING) != 0;
@@ -581,7 +581,7 @@ public:
         Rid.hwndTarget = window;
         if (!RegisterRawInputDevices(&Rid, 1, sizeof(RAWINPUTDEVICE)))
         {
-            throw std::exception("RegisterRawInputDevices");
+            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "RegisterRawInputDevices");
         }
 
         mWindow = window;
@@ -705,7 +705,7 @@ void Mouse::ProcessMessage(UINT message, WPARAM wParam, LPARAM lParam)
         break;
 
         case WAIT_FAILED:
-            throw std::exception("WaitForMultipleObjectsEx");
+            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "WaitForMultipleObjectsEx");
     }
 
     switch (message)
@@ -743,7 +743,7 @@ void Mouse::ProcessMessage(UINT message, WPARAM wParam, LPARAM lParam)
                 UINT resultData = GetRawInputData(reinterpret_cast<HRAWINPUT>(lParam), RID_INPUT, &raw, &rawSize, sizeof(RAWINPUTHEADER));
                 if (resultData == UINT(-1))
                 {
-                    throw std::exception("GetRawInputData");
+                    throw std::runtime_error("GetRawInputData");
                 }
 
                 if (raw.header.dwType == RIM_TYPEMOUSE)
@@ -874,7 +874,7 @@ public:
     {
         if (s_mouse)
         {
-            throw std::exception("Mouse is a singleton");
+            throw std::logic_error("Mouse is a singleton");
         }
 
         s_mouse = this;
@@ -959,7 +959,7 @@ public:
     {
         if (s_mouse)
         {
-            throw std::exception("Mouse is a singleton");
+            throw std::logic_error("Mouse is a singleton");
         }
 
         s_mouse = this;
@@ -969,7 +969,7 @@ public:
         if (!mScrollWheelValue
             || !mRelativeRead)
         {
-            throw std::exception("CreateEventEx");
+            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "CreateEventEx");
         }
     }
 
@@ -986,7 +986,7 @@ public:
 
         DWORD result = WaitForSingleObjectEx(mScrollWheelValue.get(), 0, FALSE);
         if (result == WAIT_FAILED)
-            throw std::exception("WaitForSingleObjectEx");
+            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "WaitForSingleObjectEx");
 
         if (result == WAIT_OBJECT_0)
         {
@@ -998,7 +998,7 @@ public:
             result = WaitForSingleObjectEx(mRelativeRead.get(), 0, FALSE);
 
             if (result == WAIT_FAILED)
-                throw std::exception("WaitForSingleObjectEx");
+                throw std::system_error(std::error_code(GetLastError(), std::system_category()), "WaitForSingleObjectEx");
 
             if (result == WAIT_OBJECT_0)
             {
@@ -1462,7 +1462,7 @@ void Mouse::SetVisible(bool visible)
 Mouse& Mouse::Get()
 {
     if (!Impl::s_mouse || !Impl::s_mouse->mOwner)
-        throw std::exception("Mouse is a singleton");
+        throw std::logic_error("Mouse singleton not created");
 
     return *Impl::s_mouse->mOwner;
 }

--- a/Src/Mouse.cpp
+++ b/Src/Mouse.cpp
@@ -86,7 +86,7 @@ public:
         mScrollWheelValue.reset(CreateEventEx(nullptr, nullptr, CREATE_EVENT_MANUAL_RESET, EVENT_MODIFY_STATE | SYNCHRONIZE));
         if (!mScrollWheelValue)
         {
-            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "CreateEventEx");
+            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "CreateEventEx");
         }
     }
 
@@ -121,7 +121,7 @@ public:
 
         DWORD result = WaitForSingleObjectEx(mScrollWheelValue.get(), 0, FALSE);
         if (result == WAIT_FAILED)
-            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "WaitForSingleObjectEx");
+            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "WaitForSingleObjectEx");
 
         if (result == WAIT_OBJECT_0)
         {
@@ -205,7 +205,7 @@ public:
         CURSORINFO info = { sizeof(CURSORINFO), 0, nullptr, {} };
         if (!GetCursorInfo(&info))
         {
-            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "GetCursorInfo");
+            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "GetCursorInfo");
         }
 
         bool isvisible = (info.flags & CURSOR_SHOWING) != 0;
@@ -270,7 +270,7 @@ void Mouse::ProcessMessage(UINT message, WPARAM wParam, LPARAM lParam)
 
     DWORD result = WaitForSingleObjectEx(pImpl->mScrollWheelValue.get(), 0, FALSE);
     if (result == WAIT_FAILED)
-        throw std::system_error(std::error_code(GetLastError(), std::system_category()), "WaitForSingleObjectEx");
+        throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "WaitForSingleObjectEx");
 
     if (result == WAIT_OBJECT_0)
     {
@@ -459,7 +459,7 @@ public:
             || !mAbsoluteMode
             || !mRelativeMode)
         {
-            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "CreateEventEx");
+            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "CreateEventEx");
         }
     }
 
@@ -481,7 +481,7 @@ public:
 
         DWORD result = WaitForSingleObjectEx(mScrollWheelValue.get(), 0, FALSE);
         if (result == WAIT_FAILED)
-            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "WaitForSingleObjectEx");
+            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "WaitForSingleObjectEx");
 
         if (result == WAIT_OBJECT_0)
         {
@@ -493,7 +493,7 @@ public:
             result = WaitForSingleObjectEx(mRelativeRead.get(), 0, FALSE);
 
             if (result == WAIT_FAILED)
-                throw std::system_error(std::error_code(GetLastError(), std::system_category()), "WaitForSingleObjectEx");
+                throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "WaitForSingleObjectEx");
 
             if (result == WAIT_OBJECT_0)
             {
@@ -528,7 +528,7 @@ public:
         tme.dwHoverTime = 1;
         if (!TrackMouseEvent(&tme))
         {
-            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "TrackMouseEvent");
+            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "TrackMouseEvent");
         }
     }
 
@@ -557,7 +557,7 @@ public:
         CURSORINFO info = { sizeof(CURSORINFO), 0, nullptr, {} };
         if (!GetCursorInfo(&info))
         {
-            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "GetCursorInfo");
+            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "GetCursorInfo");
         }
 
         bool isvisible = (info.flags & CURSOR_SHOWING) != 0;
@@ -581,7 +581,7 @@ public:
         Rid.hwndTarget = window;
         if (!RegisterRawInputDevices(&Rid, 1, sizeof(RAWINPUTDEVICE)))
         {
-            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "RegisterRawInputDevices");
+            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "RegisterRawInputDevices");
         }
 
         mWindow = window;
@@ -705,7 +705,7 @@ void Mouse::ProcessMessage(UINT message, WPARAM wParam, LPARAM lParam)
         break;
 
         case WAIT_FAILED:
-            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "WaitForMultipleObjectsEx");
+            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "WaitForMultipleObjectsEx");
     }
 
     switch (message)
@@ -969,7 +969,7 @@ public:
         if (!mScrollWheelValue
             || !mRelativeRead)
         {
-            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "CreateEventEx");
+            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "CreateEventEx");
         }
     }
 
@@ -986,7 +986,7 @@ public:
 
         DWORD result = WaitForSingleObjectEx(mScrollWheelValue.get(), 0, FALSE);
         if (result == WAIT_FAILED)
-            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "WaitForSingleObjectEx");
+            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "WaitForSingleObjectEx");
 
         if (result == WAIT_OBJECT_0)
         {
@@ -998,7 +998,7 @@ public:
             result = WaitForSingleObjectEx(mRelativeRead.get(), 0, FALSE);
 
             if (result == WAIT_FAILED)
-                throw std::system_error(std::error_code(GetLastError(), std::system_category()), "WaitForSingleObjectEx");
+                throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "WaitForSingleObjectEx");
 
             if (result == WAIT_OBJECT_0)
             {

--- a/Src/NormalMapEffect.cpp
+++ b/Src/NormalMapEffect.cpp
@@ -361,7 +361,7 @@ void NormalMapEffect::Impl::Apply(_In_ ID3D12GraphicsCommandList* commandList)
     if (!texture.ptr || !sampler.ptr || !normal.ptr)
     {
         DebugTrace("ERROR: Missing texture(s) or sampler for NormalMapEffect (texture %llu, normal %llu, sampler %llu)\n", texture.ptr, normal.ptr, sampler.ptr);
-        throw std::exception("NormalMapEffect");
+        throw std::runtime_error("NormalMapEffect");
     }
 
     // **NOTE** If D3D asserts or crashes here, you probably need to call commandList->SetDescriptorHeaps() with the required descriptor heaps.
@@ -374,7 +374,7 @@ void NormalMapEffect::Impl::Apply(_In_ ID3D12GraphicsCommandList* commandList)
         if (!specular.ptr)
         {
             DebugTrace("ERROR: Missing specular texure NormalMapEffect (texture %llu)\n", specular.ptr);
-            throw std::exception("NormalMapEffect");
+            throw std::runtime_error("NormalMapEffect");
         }
         commandList->SetGraphicsRootDescriptorTable(RootParameterIndex::TextureSpecularSRV, specular);
     }

--- a/Src/PBREffect.cpp
+++ b/Src/PBREffect.cpp
@@ -392,13 +392,13 @@ void PBREffect::Impl::Apply(_In_ ID3D12GraphicsCommandList* commandList)
     if (!descriptors[RadianceTexture].ptr || !descriptors[RadianceSampler].ptr)
     {
         DebugTrace("ERROR: Missing radiance texture or sampler for PBREffect (texture %llu, sampler %llu)\n", descriptors[RadianceTexture].ptr, descriptors[RadianceSampler].ptr);
-        throw std::exception("PBREffect");
+        throw std::runtime_error("PBREffect");
     }
 
     if (!descriptors[IrradianceTexture].ptr)
     {
         DebugTrace("ERROR: Missing irradiance texture for PBREffect (texture %llu)\n", descriptors[IrradianceTexture].ptr);
-        throw std::exception("PBREffect");
+        throw std::runtime_error("PBREffect");
     }
 
     // Set the root parameters
@@ -423,19 +423,19 @@ void PBREffect::Impl::Apply(_In_ ID3D12GraphicsCommandList* commandList)
         if (!descriptors[AlbedoTexture].ptr || !descriptors[SurfaceSampler].ptr)
         {
             DebugTrace("ERROR: Missing albedo texture or sampler for PBREffect (texture %llu, sampler %llu)\n", descriptors[AlbedoTexture].ptr, descriptors[SurfaceSampler].ptr);
-            throw std::exception("PBREffect");
+            throw std::runtime_error("PBREffect");
         }
 
         if (!descriptors[NormalTexture].ptr)
         {
             DebugTrace("ERROR: Missing normal map texture for PBREffect (texture %llu)\n", descriptors[NormalTexture].ptr);
-            throw std::exception("PBREffect");
+            throw std::runtime_error("PBREffect");
         }
 
         if (!descriptors[RMATexture].ptr)
         {
             DebugTrace("ERROR: Missing roughness/metalness texture for PBREffect (texture %llu)\n", descriptors[RMATexture].ptr);
-            throw std::exception("PBREffect");
+            throw std::runtime_error("PBREffect");
         }
 
         for (unsigned i = 0; i < ConstantBuffer; i++)
@@ -452,7 +452,7 @@ void PBREffect::Impl::Apply(_In_ ID3D12GraphicsCommandList* commandList)
             if (!descriptors[EmissiveTexture].ptr)
             {
                 DebugTrace("ERROR: Missing emissive map texture for PBREffect (texture %llu)\n", descriptors[NormalTexture].ptr);
-                throw std::exception("PBREffect");
+                throw std::runtime_error("PBREffect");
             }
 
             commandList->SetGraphicsRootDescriptorTable(EmissiveTexture, descriptors[EmissiveTexture]);

--- a/Src/PBREffect.cpp
+++ b/Src/PBREffect.cpp
@@ -230,7 +230,7 @@ PBREffect::Impl::Impl(_In_ ID3D12Device* device,
         if (effectFlags & (EffectFlags::Emissive | EffectFlags::Velocity))
         {
             DebugTrace("ERROR: PBREffect does not support emissive or velocity without surface textures\n");
-            throw std::invalid_argument("PBREffect");
+            throw std::invalid_argument("Specified effects flags requires Texture");
         }
     }
 
@@ -286,12 +286,12 @@ PBREffect::Impl::Impl(_In_ ID3D12Device* device,
     if (effectFlags & EffectFlags::Fog)
     {
         DebugTrace("ERROR: PBEffect does not implement EffectFlags::Fog\n");
-        throw std::invalid_argument("PBREffect");
+        throw std::invalid_argument("Fog effect flag is invalid");
     }
     else  if (effectFlags & EffectFlags::VertexColor)
     {
         DebugTrace("ERROR: PBEffect does not implement EffectFlags::VertexColor\n");
-        throw std::invalid_argument("PBREffect");
+        throw std::invalid_argument("VertexColor effect flag is invalid");
     }
 
     // Create pipeline state.

--- a/Src/PBREffectFactory.cpp
+++ b/Src/PBREffectFactory.cpp
@@ -75,12 +75,12 @@ std::shared_ptr<IEffect> PBREffectFactory::Impl::CreateEffect(
     if (!mTextureDescriptors)
     {
         DebugTrace("ERROR: PBREffectFactory created without texture descriptor heap!\n");
-        throw std::invalid_argument("PBREffectFactory");
+        throw std::logic_error("PBREffectFactory");
     }
     if (!mSamplerDescriptors)
     {
         DebugTrace("ERROR: PBREffectFactory created without sampler descriptor heap!\n");
-        throw std::invalid_argument("PBREffectFactory");
+        throw std::logic_error("PBREffectFactory");
     }
 
     int albetoTextureIndex = (info.diffuseTextureIndex != -1) ? info.diffuseTextureIndex + textureDescriptorOffset : -1;

--- a/Src/PBREffectFactory.cpp
+++ b/Src/PBREffectFactory.cpp
@@ -75,12 +75,12 @@ std::shared_ptr<IEffect> PBREffectFactory::Impl::CreateEffect(
     if (!mTextureDescriptors)
     {
         DebugTrace("ERROR: PBREffectFactory created without texture descriptor heap!\n");
-        throw std::exception("PBREffectFactory");
+        throw std::invalid_argument("PBREffectFactory");
     }
     if (!mSamplerDescriptors)
     {
         DebugTrace("ERROR: PBREffectFactory created without sampler descriptor heap!\n");
-        throw std::exception("PBREffectFactory");
+        throw std::invalid_argument("PBREffectFactory");
     }
 
     int albetoTextureIndex = (info.diffuseTextureIndex != -1) ? info.diffuseTextureIndex + textureDescriptorOffset : -1;
@@ -167,20 +167,20 @@ PBREffectFactory::PBREffectFactory(_In_ ID3D12DescriptorHeap* textureDescriptors
 {
     if (!textureDescriptors)
     {
-        throw std::exception("Texture descriptor heap cannot be null if no device is provided. Use the alternative PBREffectFactory constructor instead.");
+        throw std::invalid_argument("Texture descriptor heap cannot be null if no device is provided. Use the alternative PBREffectFactory constructor instead.");
     }
     if (!samplerDescriptors)
     {
-        throw std::exception("Descriptor heap cannot be null if no device is provided. Use the alternative PBREffectFactory constructor instead.");
+        throw std::invalid_argument("Descriptor heap cannot be null if no device is provided. Use the alternative PBREffectFactory constructor instead.");
     }
 
     if (textureDescriptors->GetDesc().Type != D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV)
     {
-        throw std::exception("PBREffectFactory::CreateEffect requires a CBV_SRV_UAV descriptor heap for textureDescriptors.");
+        throw std::invalid_argument("PBREffectFactory::CreateEffect requires a CBV_SRV_UAV descriptor heap for textureDescriptors.");
     }
     if (samplerDescriptors->GetDesc().Type != D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER)
     {
-        throw std::exception("PBREffectFactory::CreateEffect requires a SAMPLER descriptor heap for samplerDescriptors.");
+        throw std::invalid_argument("PBREffectFactory::CreateEffect requires a SAMPLER descriptor heap for samplerDescriptors.");
     }
 
     ComPtr<ID3D12Device> device;

--- a/Src/PlatformHelpers.h
+++ b/Src/PlatformHelpers.h
@@ -31,7 +31,7 @@ namespace DirectX
     public:
         com_exception(HRESULT hr) noexcept : result(hr) {}
 
-        const char* what() const override
+        const char* what() const noexcept override
         {
             static char s_str[64] = {};
             sprintf_s(s_str, "Failure with HRESULT of %08X", static_cast<unsigned int>(result));

--- a/Src/PrimitiveBatch.cpp
+++ b/Src/PrimitiveBatch.cpp
@@ -74,16 +74,16 @@ PrimitiveBatchBase::Impl::Impl(_In_ ID3D12Device* device, size_t maxIndices, siz
     mBaseVertex(0)
 {
     if (!maxVertices)
-        throw std::exception("maxVertices must be greater than 0");
+        throw std::invalid_argument("maxVertices must be greater than 0");
 
     if (vertexSize > D3D12_REQ_MULTI_ELEMENT_STRUCTURE_SIZE_IN_BYTES)
-        throw std::exception("Vertex size is too large for DirectX 12");
+        throw std::invalid_argument("Vertex size is too large for DirectX 12");
 
     if ((uint64_t(maxIndices) * sizeof(uint16_t)) > uint64_t(D3D12_REQ_RESOURCE_SIZE_IN_MEGABYTES_EXPRESSION_A_TERM * 1024u * 1024u))
-        throw std::exception("IB too large for DirectX 12");
+        throw std::invalid_argument("IB too large for DirectX 12");
 
     if ((uint64_t(maxVertices) * uint64_t(vertexSize)) > uint64_t(D3D12_REQ_RESOURCE_SIZE_IN_MEGABYTES_EXPRESSION_A_TERM * 1024u * 1024u))
-        throw std::exception("VB too large for DirectX 12");
+        throw std::invalid_argument("VB too large for DirectX 12");
 }
 
 
@@ -92,7 +92,7 @@ PrimitiveBatchBase::Impl::Impl(_In_ ID3D12Device* device, size_t maxIndices, siz
 void PrimitiveBatchBase::Impl::Begin(_In_ ID3D12GraphicsCommandList* cmdList)
 {
     if (mInBeginEndPair)
-        throw std::exception("Cannot nest Begin calls");
+        throw std::logic_error("Cannot nest Begin calls");
 
     mCommandList = cmdList;
     mInBeginEndPair = true;
@@ -103,7 +103,7 @@ void PrimitiveBatchBase::Impl::Begin(_In_ ID3D12GraphicsCommandList* cmdList)
 void PrimitiveBatchBase::Impl::End()
 {
     if (!mInBeginEndPair)
-        throw std::exception("Begin must be called before End");
+        throw std::logic_error("Begin must be called before End");
 
     FlushBatch();
 
@@ -141,16 +141,16 @@ _Use_decl_annotations_
 void PrimitiveBatchBase::Impl::Draw(D3D_PRIMITIVE_TOPOLOGY topology, bool isIndexed, uint16_t const* indices, size_t indexCount, size_t vertexCount, void** pMappedVertices)
 {
     if (isIndexed && !indices)
-        throw std::exception("Indices cannot be null");
+        throw std::invalid_argument("Indices cannot be null");
 
     if (indexCount >= mMaxIndices)
-        throw std::exception("Too many indices");
+        throw std::invalid_argument("Too many indices");
 
     if (vertexCount >= mMaxVertices)
-        throw std::exception("Too many vertices");
+        throw std::invalid_argument("Too many vertices");
 
     if (!mInBeginEndPair)
-        throw std::exception("Begin must be called before Draw");
+        throw std::logic_error("Begin must be called before Draw");
 
     assert(pMappedVertices != nullptr);
 

--- a/Src/ResourceUploadBatch.cpp
+++ b/Src/ResourceUploadBatch.cpp
@@ -538,7 +538,7 @@ public:
 
         HANDLE gpuCompletedEvent = CreateEventEx(nullptr, nullptr, 0, EVENT_ALL_ACCESS);
         if (!gpuCompletedEvent)
-            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "CreateEventEx");
+            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "CreateEventEx");
 
         ThrowIfFailed(commandQueue->Signal(fence.Get(), 1ULL));
         ThrowIfFailed(fence->SetEventOnCompletion(1ULL, gpuCompletedEvent));
@@ -561,7 +561,7 @@ public:
             {
                 if (wr == WAIT_FAILED)
                 {
-                    throw std::system_error(std::error_code(GetLastError(), std::system_category()), "WaitForSingleObject");
+                    throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "WaitForSingleObject");
                 }
                 else
                 {

--- a/Src/ResourceUploadBatch.cpp
+++ b/Src/ResourceUploadBatch.cpp
@@ -321,7 +321,7 @@ public:
 
         default:
             DebugTrace("ResourceUploadBatch only supports Direct, Compute, and Copy command queues\n");
-            throw std::invalid_argument("ResourceUploadBatch");
+            throw std::invalid_argument("commandType parameter is invalid");
         }
 
         ThrowIfFailed(mDevice->CreateCommandAllocator(commandType, IID_GRAPHICS_PPV_ARGS(mCmdAlloc.ReleaseAndGetAddressOf())));

--- a/Src/SkinnedEffect.cpp
+++ b/Src/SkinnedEffect.cpp
@@ -532,7 +532,7 @@ void SkinnedEffect::SetTexture(D3D12_GPU_DESCRIPTOR_HANDLE srvDescriptor, D3D12_
 void SkinnedEffect::SetBoneTransforms(_In_reads_(count) XMMATRIX const* value, size_t count)
 {
     if (count > MaxBones)
-        throw std::out_of_range("count parameter out of range");
+        throw std::invalid_argument("count parameter exceeds MaxBones");
 
     auto boneConstant = pImpl->constants.bones;
 

--- a/Src/SkinnedEffect.cpp
+++ b/Src/SkinnedEffect.cpp
@@ -301,7 +301,7 @@ void SkinnedEffect::Impl::Apply(_In_ ID3D12GraphicsCommandList* commandList)
     if (!texture.ptr || !sampler.ptr)
     {
         DebugTrace("ERROR: Missing texture or sampler for SkinnedEffect (texture %llu, sampler %llu)\n", texture.ptr, sampler.ptr);
-        throw std::exception("SkinnedEffect");
+        throw std::runtime_error("SkinnedEffect");
     }
 
     // **NOTE** If D3D asserts or crashes here, you probably need to call commandList->SetDescriptorHeaps() with the required descriptor heaps.

--- a/Src/SkinnedEffect.cpp
+++ b/Src/SkinnedEffect.cpp
@@ -230,7 +230,7 @@ SkinnedEffect::Impl::Impl(
     if (effectFlags & EffectFlags::VertexColor)
     {
         DebugTrace("ERROR: SkinnedEffect does not implement EffectFlags::VertexColor\n");
-        throw std::invalid_argument("SkinnedEffect");
+        throw std::invalid_argument("VertexColor effect flag is invalid");
     }
 
     // Create pipeline state.

--- a/Src/SpriteBatch.cpp
+++ b/Src/SpriteBatch.cpp
@@ -502,7 +502,7 @@ void XM_CALLCONV SpriteBatch::Impl::Begin(
     if (mInBeginEndPair)
     {
         DebugTrace("ERROR: Cannot nest Begin calls on a single SpriteBatch\n");
-        throw std::exception("SpriteBatch::Begin");
+        throw std::logic_error("SpriteBatch::Begin");
     }
 
     mSortMode = sortMode;
@@ -524,7 +524,7 @@ void SpriteBatch::Impl::End()
     if (!mInBeginEndPair)
     {
         DebugTrace("ERROR: Begin must be called before End\n");
-        throw std::exception("SpriteBatch::End");
+        throw std::logic_error("SpriteBatch::End");
     }
 
     if (mSortMode != SpriteSortMode_Immediate)
@@ -556,11 +556,11 @@ void XM_CALLCONV SpriteBatch::Impl::Draw(D3D12_GPU_DESCRIPTOR_HANDLE texture,
     if (!mInBeginEndPair)
     {
         DebugTrace("ERROR: Begin must be called before Draw\n");
-        throw std::exception("SpriteBatch::Draw");
+        throw std::logic_error("SpriteBatch::Draw");
     }
 
     if (!texture.ptr)
-        throw std::exception("Invalid texture for Draw");
+        throw std::invalid_argument("Invalid texture for Draw");
 
     // Get a pointer to the output sprite.
     if (mSpriteQueueCount >= mSpriteQueueArraySize)
@@ -979,7 +979,7 @@ XMMATRIX SpriteBatch::Impl::GetViewportTransform(_In_ DXGI_MODE_ROTATION rotatio
     if (!mSetViewport)
     {
         DebugTrace("ERROR: SpriteBatch requires viewport information via SetViewport\n");
-        throw std::exception("Viewport not set.");
+        throw std::runtime_error("Viewport not set.");
     }
 
     // Compute the matrix.
@@ -1076,12 +1076,12 @@ void XM_CALLCONV SpriteBatch::Begin(
     FXMMATRIX transformMatrix)
 {
     if (!sampler.ptr)
-        throw std::exception("Invalid heap-based sampler for Begin");
+        throw std::invalid_argument("Invalid heap-based sampler for Begin");
 
     if (!pImpl->mSampler.ptr)
     {
         DebugTrace("ERROR: sampler version of Begin requires SpriteBatch was created with a heap-based sampler\n");
-        throw std::exception("SpriteBatch::Begin");
+        throw std::runtime_error("SpriteBatch::Begin");
     }
 
     pImpl->mSampler = sampler;

--- a/Src/SpriteFont.cpp
+++ b/Src/SpriteFont.cpp
@@ -117,7 +117,7 @@ SpriteFont::Impl::Impl(
         if (reader->Read<uint8_t>() != *magic)
         {
             DebugTrace("ERROR: SpriteFont provided with an invalid .spritefont file\n");
-            throw std::exception("Not a MakeSpriteFont output binary");
+            throw std::runtime_error("Not a MakeSpriteFont output binary");
         }
     }
 
@@ -196,7 +196,7 @@ SpriteFont::Impl::Impl(
 {
     if (!std::is_sorted(iglyphs, iglyphs + glyphCount))
     {
-        throw std::exception("Glyphs must be in ascending codepoint order");
+        throw std::runtime_error("Glyphs must be in ascending codepoint order");
     }
 
     glyphsIndex.reserve(glyphs.size());
@@ -252,7 +252,7 @@ SpriteFont::Glyph const* SpriteFont::Impl::FindGlyph(wchar_t character) const
     }
 
     DebugTrace("ERROR: SpriteFont encountered a character not in the font (%u, %C), and no default glyph was provided\n", character, character);
-    throw std::exception("Character not in font");
+    throw std::runtime_error("Character not in font");
 }
 
 
@@ -392,7 +392,7 @@ const wchar_t* SpriteFont::Impl::ConvertUTF8(_In_z_ const char *text) noexcept(f
     if (!result)
     {
         DebugTrace("ERROR: MultiByteToWideChar failed with error %u.\n", GetLastError());
-        throw std::exception("MultiByteToWideChar");
+        throw std::system_error(std::error_code(GetLastError(), std::system_category()), "MultiByteToWideChar");
     }
 
     return utfBuffer.get();

--- a/Src/SpriteFont.cpp
+++ b/Src/SpriteFont.cpp
@@ -392,7 +392,7 @@ const wchar_t* SpriteFont::Impl::ConvertUTF8(_In_z_ const char *text) noexcept(f
     if (!result)
     {
         DebugTrace("ERROR: MultiByteToWideChar failed with error %u.\n", GetLastError());
-        throw std::system_error(std::error_code(GetLastError(), std::system_category()), "MultiByteToWideChar");
+        throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "MultiByteToWideChar");
     }
 
     return utfBuffer.get();

--- a/Src/ToneMapPostProcess.cpp
+++ b/Src/ToneMapPostProcess.cpp
@@ -276,10 +276,10 @@ ToneMapPostProcess::Impl::Impl(_In_ ID3D12Device* device, const RenderTargetStat
     mDeviceResources(deviceResourcesPool.DemandCreate(device))
 {
     if (op >= Operator_Max)
-        throw std::out_of_range("Tonemap operator not defined");
+        throw std::invalid_argument("Tonemap operator not defined");
 
     if (func > TransferFunction_Max)
-        throw std::out_of_range("Transfer function not defined");
+        throw std::invalid_argument("Transfer function not defined");
 
     // Create root signature.
     {

--- a/Src/ToneMapPostProcess.cpp
+++ b/Src/ToneMapPostProcess.cpp
@@ -369,7 +369,7 @@ void ToneMapPostProcess::Impl::Process(_In_ ID3D12GraphicsCommandList* commandLi
     if (!texture.ptr)
     {
         DebugTrace("ERROR: Missing texture for ToneMapPostProcess (texture %llu)\n", texture.ptr);
-        throw std::exception("ToneMapPostProcess");
+        throw std::runtime_error("ToneMapPostProcess");
     }
     commandList->SetGraphicsRootDescriptorTable(RootParameterIndex::TextureSRV, texture);
 

--- a/Src/pch.h
+++ b/Src/pch.h
@@ -167,6 +167,7 @@
 #include <set>
 #include <stdexcept>
 #include <string>
+#include <system_error>
 #include <type_traits>
 #include <utility>
 #include <vector>


### PR DESCRIPTION
The ctor for ``std::exception`` that takes a 'what' string is a MSVC extension. This PR updates the code to use derived classes for improved portability.

* ``std::invalid_arguments`` for E_INVALIDARG-like exceptions
* ``std::system_error`` for Win32 APIs that report via GetLastError()
* ``std::logic_error`` for usage problems like missing proper Begin()/End()
* ``std::out_of_range`` in a few specific places
* ``std::runtime_error`` otherwise
