### PR TITLE
Adding ModelBone support for transform hierarchies

### DIFF
--- a/Inc/Model.h
+++ b/Inc/Model.h
@@ -246,8 +246,8 @@ namespace DirectX
         Model(Model&&) = default;
         Model& operator= (Model&&) = default;
 
-        Model(Model const&) = default;
-        Model& operator= (Model const&) = default;
+        Model(Model const& other);
+        Model& operator= (Model const& rhs);
 
         virtual ~Model();
 

--- a/Inc/Model.h
+++ b/Inc/Model.h
@@ -63,21 +63,18 @@ namespace DirectX
         ModelBone() noexcept :
             parentIndex(c_Invalid),
             childIndex(c_Invalid),
-            siblingIndex(c_Invalid),
-            animIndex(c_Invalid)
+            siblingIndex(c_Invalid)
         {}
 
-        ModelBone(uint32_t parent, uint32_t child, uint32_t sibling, uint32_t anim) noexcept :
+        ModelBone(uint32_t parent, uint32_t child, uint32_t sibling) noexcept :
             parentIndex(parent),
             childIndex(child),
-            siblingIndex(sibling),
-            animIndex(anim)
+            siblingIndex(sibling)
         {}
 
         uint32_t            parentIndex;
         uint32_t            childIndex;
         uint32_t            siblingIndex;
-        uint32_t            animIndex;
         std::wstring        name;
 
         using Collection = std::vector<ModelBone>;

--- a/Src/Model.cpp
+++ b/Src/Model.cpp
@@ -220,15 +220,53 @@ void __cdecl ModelMesh::DrawAlpha(_In_ ID3D12GraphicsCommandList* commandList, M
 //--------------------------------------------------------------------------------------
 // Model
 //--------------------------------------------------------------------------------------
+
 Model::Model() noexcept
 {
 }
-
 
 Model::~Model()
 {
 }
 
+Model::Model(Model const& other) :
+    meshes(other.meshes),
+    materials(other.materials),
+    textureNames(other.textureNames),
+    bones(other.bones),
+    name(other.name)
+{
+    const size_t nbones = other.bones.size();
+    if (nbones > 0)
+    {
+        if (other.boneMatrices)
+        {
+            boneMatrices = ModelBone::MakeArray(nbones);
+            memcpy(boneMatrices.get(), other.boneMatrices.get(), sizeof(XMMATRIX) * nbones);
+        }
+        if (other.invBindPoseMatrices)
+        {
+            invBindPoseMatrices = ModelBone::MakeArray(nbones);
+            memcpy(invBindPoseMatrices.get(), other.invBindPoseMatrices.get(), sizeof(XMMATRIX) * nbones);
+        }
+    }
+}
+
+Model& Model::operator= (Model const& rhs)
+{
+    if (this != &rhs)
+    {
+        Model tmp(rhs);
+        std::swap(meshes, tmp.meshes);
+        std::swap(materials, tmp.materials);
+        std::swap(textureNames, tmp.textureNames);
+        std::swap(bones, tmp.bones);
+        std::swap(boneMatrices, tmp.boneMatrices);
+        std::swap(invBindPoseMatrices, tmp.invBindPoseMatrices);
+        std::swap(name, tmp.name);
+    }
+    return *this;
+}
 
 // Load texture resources.
 int Model::LoadTextures(IEffectTextureFactory& texFactory, int destinationDescriptorOffset) const

--- a/Src/Model.cpp
+++ b/Src/Model.cpp
@@ -89,7 +89,10 @@ void ModelMeshPart::Draw(_In_ ID3D12GraphicsCommandList* commandList) const
 
 
 _Use_decl_annotations_
-void ModelMeshPart::DrawInstanced(_In_ ID3D12GraphicsCommandList* commandList, uint32_t instanceCount, uint32_t startInstance) const
+void ModelMeshPart::DrawInstanced(
+    ID3D12GraphicsCommandList* commandList,
+    uint32_t instanceCount,
+    uint32_t startInstance) const
 {
     if (!indexBufferSize || !vertexBufferSize)
     {
@@ -128,7 +131,9 @@ void ModelMeshPart::DrawInstanced(_In_ ID3D12GraphicsCommandList* commandList, u
 
 
 _Use_decl_annotations_
-void ModelMeshPart::DrawMeshParts(ID3D12GraphicsCommandList* commandList, const ModelMeshPart::Collection& meshParts)
+void ModelMeshPart::DrawMeshParts(
+    ID3D12GraphicsCommandList* commandList,
+    const ModelMeshPart::Collection& meshParts)
 {
     for (const auto& it : meshParts)
     {
@@ -158,7 +163,8 @@ void ModelMeshPart::DrawMeshParts(
 
 
 _Use_decl_annotations_
-void ModelMeshPart::DrawMeshParts(ID3D12GraphicsCommandList* commandList,
+void ModelMeshPart::DrawMeshParts(
+    ID3D12GraphicsCommandList* commandList,
     const ModelMeshPart::Collection& meshParts,
     IEffect* effect)
 {
@@ -267,6 +273,7 @@ Model& Model::operator= (Model const& rhs)
     }
     return *this;
 }
+
 
 // Load texture resources.
 int Model::LoadTextures(IEffectTextureFactory& texFactory, int destinationDescriptorOffset) const
@@ -712,10 +719,10 @@ void Model::CopyBoneTransformsTo(size_t nbones, XMMATRIX* boneTransforms) const
 
 // Updates effect matrices (if applicable).
 void XM_CALLCONV Model::UpdateEffectMatrices(
-    Model::EffectCollection& effects,
-    DirectX::FXMMATRIX world,
-    DirectX::CXMMATRIX view,
-    DirectX::CXMMATRIX proj)
+    EffectCollection& effects,
+    FXMMATRIX world,
+    CXMMATRIX view,
+    CXMMATRIX proj)
 {
     for (auto& fx : effects)
     {

--- a/Src/ModelLoadSDKMESH.cpp
+++ b/Src/ModelLoadSDKMESH.cpp
@@ -729,7 +729,6 @@ std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(
     if (frameArray)
     {
         static_assert(DXUT::INVALID_FRAME == ModelBone::c_Invalid, "ModelBone invalid type mismatch");
-        static_assert(DXUT::INVALID_ANIMATION_DATA == ModelBone::c_Invalid, "ModelBone invalid type mismatch");
 
         ModelBone::Collection bones;
         bones.reserve(header->NumFrames);
@@ -740,8 +739,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(
             ModelBone bone(
                 frameArray[j].ParentFrame,
                 frameArray[j].ChildFrame,
-                frameArray[j].SiblingFrame,
-                frameArray[j].AnimationDataIndex);
+                frameArray[j].SiblingFrame);
 
             wchar_t boneName[DXUT::MAX_FRAME_NAME] = {};
             ASCIIToWChar(boneName, frameArray[j].Name);

--- a/Src/ModelLoadSDKMESH.cpp
+++ b/Src/ModelLoadSDKMESH.cpp
@@ -227,7 +227,7 @@ namespace
 
         bool posfound = false;
 
-        for (uint32_t index = 0; index < DXUT::MAX_VERTEX_ELEMENTS; ++index)
+        for (size_t index = 0; index < DXUT::MAX_VERTEX_ELEMENTS; ++index)
         {
             if (decl[index].Usage == 0xFF)
                 break;
@@ -462,7 +462,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(
     {
         if (dataSize < header->FrameDataOffset
             || (dataSize < (header->FrameDataOffset + uint64_t(header->NumFrames) * sizeof(DXUT::SDKMESH_FRAME))))
-            throw std::exception("End of file");
+            throw std::runtime_error("End of file");
 
         if (flags & ModelLoader_IncludeBones)
         {
@@ -500,7 +500,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(
     materialFlags.resize(header->NumVertexBuffers);
 
     bool dec3nwarning = false;
-    for (UINT j = 0; j < header->NumVertexBuffers; ++j)
+    for (size_t j = 0; j < header->NumVertexBuffers; ++j)
     {
         auto& vh = vbArray[j];
 
@@ -544,7 +544,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(
     }
 
     // Validate index buffers
-    for (UINT j = 0; j < header->NumIndexBuffers; ++j)
+    for (size_t j = 0; j < header->NumIndexBuffers; ++j)
     {
         auto& ih = ibArray[j];
 
@@ -576,7 +576,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(
 
     uint32_t partCount = 0;
 
-    for (UINT meshIndex = 0; meshIndex < header->NumMeshes; ++meshIndex)
+    for (size_t meshIndex = 0; meshIndex < header->NumMeshes; ++meshIndex)
     {
         auto& mh = meshArray[meshIndex];
 
@@ -589,21 +589,21 @@ std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(
         // mh.NumVertexBuffers is sometimes not what you'd expect, so we skip validating it
 
         if (dataSize < mh.SubsetOffset
-            || (dataSize < mh.SubsetOffset + uint64_t(mh.NumSubsets) * sizeof(UINT)))
+            || (dataSize < mh.SubsetOffset + uint64_t(mh.NumSubsets) * sizeof(uint32_t)))
             throw std::runtime_error("End of file");
 
-        auto subsets = reinterpret_cast<const UINT*>(meshData + mh.SubsetOffset);
+        auto subsets = reinterpret_cast<const uint32_t*>(meshData + mh.SubsetOffset);
 
-        const UINT* influences = nullptr;
+        const uint32_t* influences = nullptr;
         if (mh.NumFrameInfluences > 0)
         {
             if (dataSize < mh.FrameInfluenceOffset
-                || (dataSize < mh.FrameInfluenceOffset + uint64_t(mh.NumFrameInfluences) * sizeof(UINT)))
+                || (dataSize < mh.FrameInfluenceOffset + uint64_t(mh.NumFrameInfluences) * sizeof(uint32_t)))
                 throw std::runtime_error("End of file");
 
             if (flags & ModelLoader_IncludeBones)
             {
-                influences = reinterpret_cast<const UINT*>(meshData + mh.FrameInfluenceOffset);
+                influences = reinterpret_cast<const uint32_t*>(meshData + mh.FrameInfluenceOffset);
             }
         }
 
@@ -621,11 +621,11 @@ std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(
         if (influences)
         {
             mesh->boneInfluences.resize(mh.NumFrameInfluences);
-            memcpy(mesh->boneInfluences.data(), influences, sizeof(UINT) * mh.NumFrameInfluences);
+            memcpy(mesh->boneInfluences.data(), influences, sizeof(uint32_t) * mh.NumFrameInfluences);
         }
 
         // Create subsets
-        for (UINT j = 0; j < mh.NumSubsets; ++j)
+        for (size_t j = 0; j < mh.NumSubsets; ++j)
         {
             auto sIndex = subsets[j];
             if (sIndex >= header->NumTotalSubsets)

--- a/Src/ModelLoadSDKMESH.cpp
+++ b/Src/ModelLoadSDKMESH.cpp
@@ -457,10 +457,18 @@ std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(
         throw std::runtime_error("End of file");
     auto subsetArray = reinterpret_cast<const DXUT::SDKMESH_SUBSET*>(meshData + header->SubsetDataOffset);
 
-    if (dataSize < header->FrameDataOffset
-        || (dataSize < (header->FrameDataOffset + uint64_t(header->NumFrames) * sizeof(DXUT::SDKMESH_FRAME))))
-        throw std::runtime_error("End of file");
-    // TODO - auto frameArray = reinterpret_cast<const DXUT::SDKMESH_FRAME*>( meshData + header->FrameDataOffset );
+    const DXUT::SDKMESH_FRAME* frameArray = nullptr;
+    if (header->NumFrames > 0)
+    {
+        if (dataSize < header->FrameDataOffset
+            || (dataSize < (header->FrameDataOffset + uint64_t(header->NumFrames) * sizeof(DXUT::SDKMESH_FRAME))))
+            throw std::exception("End of file");
+
+        if (flags & ModelLoader_IncludeBones)
+        {
+            frameArray = reinterpret_cast<const DXUT::SDKMESH_FRAME*>(meshData + header->FrameDataOffset);
+        }
+    }
 
     if (dataSize < header->MaterialDataOffset
         || (dataSize < (header->MaterialDataOffset + uint64_t(header->NumMaterials) * sizeof(DXUT::SDKMESH_MATERIAL))))
@@ -586,13 +594,17 @@ std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(
 
         auto subsets = reinterpret_cast<const UINT*>(meshData + mh.SubsetOffset);
 
+        const UINT* influences = nullptr;
         if (mh.NumFrameInfluences > 0)
         {
             if (dataSize < mh.FrameInfluenceOffset
                 || (dataSize < mh.FrameInfluenceOffset + uint64_t(mh.NumFrameInfluences) * sizeof(UINT)))
                 throw std::runtime_error("End of file");
 
-            // TODO - auto influences = reinterpret_cast<const UINT*>( meshData + mh.FrameInfluenceOffset );
+            if (flags & ModelLoader_IncludeBones)
+            {
+                influences = reinterpret_cast<const UINT*>(meshData + mh.FrameInfluenceOffset);
+            }
         }
 
         auto mesh = std::make_shared<ModelMesh>();
@@ -605,6 +617,12 @@ std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(
         mesh->boundingBox.Center = mh.BoundingBoxCenter;
         mesh->boundingBox.Extents = mh.BoundingBoxExtents;
         BoundingSphere::CreateFromBoundingBox(mesh->boundingSphere, mesh->boundingBox);
+
+        if (influences)
+        {
+            mesh->boneInfluences.resize(mh.NumFrameInfluences);
+            memcpy(mesh->boneInfluences.data(), influences, sizeof(UINT) * mh.NumFrameInfluences);
+        }
 
         // Create subsets
         for (UINT j = 0; j < mh.NumSubsets; ++j)
@@ -705,6 +723,63 @@ std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(
     for (auto texture = std::cbegin(textureDictionary); texture != std::cend(textureDictionary); ++texture)
     {
         model->textureNames[static_cast<size_t>(texture->second)] = texture->first;
+    }
+
+    // Load model bones (if present and requested)
+    if (frameArray)
+    {
+        static_assert(DXUT::INVALID_FRAME == ModelBone::c_Invalid, "ModelBone invalid type mismatch");
+        static_assert(DXUT::INVALID_ANIMATION_DATA == ModelBone::c_Invalid, "ModelBone invalid type mismatch");
+
+        ModelBone::Collection bones;
+        bones.reserve(header->NumFrames);
+        auto transforms = ModelBone::MakeArray(header->NumFrames);
+
+        for (uint32_t j = 0; j < header->NumFrames; ++j)
+        {
+            ModelBone bone(
+                frameArray[j].ParentFrame,
+                frameArray[j].ChildFrame,
+                frameArray[j].SiblingFrame,
+                frameArray[j].AnimationDataIndex);
+
+            wchar_t boneName[DXUT::MAX_FRAME_NAME] = {};
+            ASCIIToWChar(boneName, frameArray[j].Name);
+            bone.name = boneName;
+            bones.emplace_back(bone);
+
+            transforms[j] = XMLoadFloat4x4(&frameArray[j].Matrix);
+
+            uint32_t index = frameArray[j].Mesh;
+            if (index != DXUT::INVALID_MESH)
+            {
+                if (index >= model->meshes.size())
+                {
+                    throw std::out_of_range("Invalid mesh index found in frame data");
+                }
+
+                if (model->meshes[index]->boneIndex == ModelBone::c_Invalid)
+                {
+                    // Bind the first bone that links to a given mesh
+                    model->meshes[index]->boneIndex = j;
+                }
+            }
+        }
+
+        std::swap(model->bones, bones);
+
+        // Compute inverse bind pose matrices for the model
+        auto bindPose = ModelBone::MakeArray(header->NumFrames);
+        model->CopyAbsoluteBoneTransforms(header->NumFrames, transforms.get(), bindPose.get());
+
+        auto invBoneTransforms = ModelBone::MakeArray(header->NumFrames);
+        for (size_t j = 0; j < header->NumFrames; ++j)
+        {
+            invBoneTransforms[j] = XMMatrixInverse(nullptr, bindPose[j]);
+        }
+
+        std::swap(model->boneMatrices, transforms);
+        std::swap(model->invBindPoseMatrices, invBoneTransforms);
     }
 
     return model;

--- a/Src/PlatformHelpers.h
+++ b/Src/PlatformHelpers.h
@@ -75,8 +75,6 @@ namespace DirectX
     struct virtual_deleter { void operator()(void* p) noexcept { if (p) VirtualFree(p, 0, MEM_RELEASE); } };
 #endif
 
-    struct aligned_deleter { void operator()(void* p) noexcept { _aligned_free(p); } };
-
     struct handle_closer { void operator()(HANDLE h) noexcept { if (h) CloseHandle(h); } };
 
     using ScopedHandle = std::unique_ptr<void, handle_closer>;


### PR DESCRIPTION
Adds the **ModelBone** class to *DirectX Tool Kit*'s **Model** support, with loading from ``SDKMESH`` files.

* Includes the bone transforms and inverse bind pose transforms needed for both rigid-body and skinned animation.
* The ``ModelLoader_IncludeBones`` flag must be specified to have the loaders include the bone information if present.

**ModelMeshPart** updated with optional bone index for rigid-body animation, and optional bone-influences for indirect vertex mapping for bones (used by ``SDKMESH``).

**ModelMesh** updated with **Draw** method overloads for rigid-body transform drawing.

**Model** and **ModelMesh** updated with **DrawSkinned** methods.

**Model** updated with **CopyAbsoluteBoneTransformsTo**, **CopyAbsoluteBoneTransforms**, **CopyBoneTransformsFrom**, and **CopyBoneTransformsTo** methods.

> This design differs from *XNA Game Studio* in two important ways. First, the bone tree is specified using the more complex ``SDKMESH`` design with parent, child, and sibling bone 'pointers' rather than relying on strict "content pipeline" sorting order. Second, there is no concept of a specific ``root`` bone in the Model, just that the '0th' bone is the "root" (i.e. has no parent).
