### PR TITLE
Updated pimpl pattern for default move ctors/ops/dtors

### DIFF
--- a/Audio/AudioEngine.cpp
+++ b/Audio/AudioEngine.cpp
@@ -1149,19 +1149,9 @@ AudioEngine::AudioEngine(
 }
 
 
-// Move constructor.
-AudioEngine::AudioEngine(AudioEngine&& moveFrom) noexcept
-    : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-
-// Move assignment.
-AudioEngine& AudioEngine::operator= (AudioEngine&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
+// Move ctor/operator.
+AudioEngine::AudioEngine(AudioEngine&&) noexcept = default;
+AudioEngine& AudioEngine::operator= (AudioEngine&&) noexcept = default;
 
 
 // Public destructor.

--- a/Audio/DynamicSoundEffectInstance.cpp
+++ b/Audio/DynamicSoundEffectInstance.cpp
@@ -252,25 +252,9 @@ DynamicSoundEffectInstance::DynamicSoundEffectInstance(
 }
 
 
-// Move constructor.
-DynamicSoundEffectInstance::DynamicSoundEffectInstance(DynamicSoundEffectInstance&& moveFrom) noexcept
-    : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-
-// Move assignment.
-DynamicSoundEffectInstance& DynamicSoundEffectInstance::operator= (DynamicSoundEffectInstance&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
-
-
-// Public destructor.
-DynamicSoundEffectInstance::~DynamicSoundEffectInstance()
-{
-}
+DynamicSoundEffectInstance::DynamicSoundEffectInstance(DynamicSoundEffectInstance&&) noexcept = default;
+DynamicSoundEffectInstance& DynamicSoundEffectInstance::operator= (DynamicSoundEffectInstance&&) noexcept = default;
+DynamicSoundEffectInstance::~DynamicSoundEffectInstance() = default;
 
 
 // Public methods.

--- a/Audio/SoundEffect.cpp
+++ b/Audio/SoundEffect.cpp
@@ -455,25 +455,9 @@ SoundEffect::SoundEffect(AudioEngine* engine, std::unique_ptr<uint8_t[]>& wavDat
 #endif
 
 
-// Move constructor.
-SoundEffect::SoundEffect(SoundEffect&& moveFrom) noexcept
-    : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-
-// Move assignment.
-SoundEffect& SoundEffect::operator= (SoundEffect&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
-
-
-// Public destructor.
-SoundEffect::~SoundEffect()
-{
-}
+SoundEffect::SoundEffect(SoundEffect&&) noexcept = default;
+SoundEffect& SoundEffect::operator= (SoundEffect&&) noexcept = default;
+SoundEffect::~SoundEffect() = default;
 
 
 // Public methods.

--- a/Audio/SoundEffectInstance.cpp
+++ b/Audio/SoundEffectInstance.cpp
@@ -238,19 +238,9 @@ SoundEffectInstance::SoundEffectInstance(AudioEngine* engine, WaveBank* waveBank
 }
 
 
-// Move constructor.
-SoundEffectInstance::SoundEffectInstance(SoundEffectInstance&& moveFrom) noexcept
-    : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-
-// Move assignment.
-SoundEffectInstance& SoundEffectInstance::operator= (SoundEffectInstance&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
+// Move ctor/operator.
+SoundEffectInstance::SoundEffectInstance(SoundEffectInstance&&) noexcept = default;
+SoundEffectInstance& SoundEffectInstance::operator= (SoundEffectInstance&&) noexcept = default;
 
 
 // Public destructor.

--- a/Audio/SoundStreamInstance.cpp
+++ b/Audio/SoundStreamInstance.cpp
@@ -749,19 +749,9 @@ SoundStreamInstance::SoundStreamInstance(AudioEngine* engine, WaveBank* waveBank
 }
 
 
-// Move constructor.
-SoundStreamInstance::SoundStreamInstance(SoundStreamInstance&& moveFrom) noexcept
-    : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-
-// Move assignment.
-SoundStreamInstance& SoundStreamInstance::operator= (SoundStreamInstance&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
+// Move ctor/operator.
+SoundStreamInstance::SoundStreamInstance(SoundStreamInstance&&) noexcept = default;
+SoundStreamInstance& SoundStreamInstance::operator= (SoundStreamInstance&&) noexcept = default;
 
 
 // Public destructor.

--- a/Audio/WaveBank.cpp
+++ b/Audio/WaveBank.cpp
@@ -278,25 +278,9 @@ WaveBank::WaveBank(AudioEngine* engine, const wchar_t* wbFileName)
 }
 
 
-// Move constructor.
-WaveBank::WaveBank(WaveBank&& moveFrom) noexcept
-    : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-
-// Move assignment.
-WaveBank& WaveBank::operator= (WaveBank&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
-
-
-// Public destructor.
-WaveBank::~WaveBank()
-{
-}
+WaveBank::WaveBank(WaveBank&&) noexcept = default;
+WaveBank& WaveBank::operator= (WaveBank&&) noexcept = default;
+WaveBank::~WaveBank() = default;
 
 
 // Public methods (one-shots)

--- a/Inc/Audio.h
+++ b/Inc/Audio.h
@@ -207,8 +207,8 @@ namespace DirectX
             _In_opt_z_ const wchar_t* deviceId = nullptr,
             AUDIO_STREAM_CATEGORY category = AudioCategory_GameEffects) noexcept(false);
 
-        AudioEngine(AudioEngine&& moveFrom) noexcept;
-        AudioEngine& operator= (AudioEngine&& moveFrom) noexcept;
+        AudioEngine(AudioEngine&&) noexcept;
+        AudioEngine& operator= (AudioEngine&&) noexcept;
 
         AudioEngine(AudioEngine const&) = delete;
         AudioEngine& operator= (AudioEngine const&) = delete;
@@ -306,8 +306,8 @@ namespace DirectX
     public:
         WaveBank(_In_ AudioEngine* engine, _In_z_ const wchar_t* wbFileName);
 
-        WaveBank(WaveBank&& moveFrom) noexcept;
-        WaveBank& operator= (WaveBank&& moveFrom) noexcept;
+        WaveBank(WaveBank&&) noexcept;
+        WaveBank& operator= (WaveBank&&) noexcept;
 
         WaveBank(WaveBank const&) = delete;
         WaveBank& operator= (WaveBank const&) = delete;
@@ -388,8 +388,8 @@ namespace DirectX
 
 #endif
 
-        SoundEffect(SoundEffect&& moveFrom) noexcept;
-        SoundEffect& operator= (SoundEffect&& moveFrom) noexcept;
+        SoundEffect(SoundEffect&&) noexcept;
+        SoundEffect& operator= (SoundEffect&&) noexcept;
 
         SoundEffect(SoundEffect const&) = delete;
         SoundEffect& operator= (SoundEffect const&) = delete;
@@ -613,8 +613,8 @@ namespace DirectX
     class SoundEffectInstance
     {
     public:
-        SoundEffectInstance(SoundEffectInstance&& moveFrom) noexcept;
-        SoundEffectInstance& operator= (SoundEffectInstance&& moveFrom) noexcept;
+        SoundEffectInstance(SoundEffectInstance&&) noexcept;
+        SoundEffectInstance& operator= (SoundEffectInstance&&) noexcept;
 
         SoundEffectInstance(SoundEffectInstance const&) = delete;
         SoundEffectInstance& operator= (SoundEffectInstance const&) = delete;
@@ -659,8 +659,8 @@ namespace DirectX
     class SoundStreamInstance
     {
     public:
-        SoundStreamInstance(SoundStreamInstance&& moveFrom) noexcept;
-        SoundStreamInstance& operator= (SoundStreamInstance&& moveFrom) noexcept;
+        SoundStreamInstance(SoundStreamInstance&&) noexcept;
+        SoundStreamInstance& operator= (SoundStreamInstance&&) noexcept;
 
         SoundStreamInstance(SoundStreamInstance const&) = delete;
         SoundStreamInstance& operator= (SoundStreamInstance const&) = delete;
@@ -707,8 +707,9 @@ namespace DirectX
             _In_opt_ std::function<void __cdecl(DynamicSoundEffectInstance*)> bufferNeeded,
             int sampleRate, int channels, int sampleBits = 16,
             SOUND_EFFECT_INSTANCE_FLAGS flags = SoundEffectInstance_Default);
-        DynamicSoundEffectInstance(DynamicSoundEffectInstance&& moveFrom) noexcept;
-        DynamicSoundEffectInstance& operator= (DynamicSoundEffectInstance&& moveFrom) noexcept;
+
+        DynamicSoundEffectInstance(DynamicSoundEffectInstance&&) noexcept;
+        DynamicSoundEffectInstance& operator= (DynamicSoundEffectInstance&&) noexcept;
 
         DynamicSoundEffectInstance(DynamicSoundEffectInstance const&) = delete;
         DynamicSoundEffectInstance& operator= (DynamicSoundEffectInstance const&) = delete;

--- a/Inc/CommonStates.h
+++ b/Inc/CommonStates.h
@@ -26,8 +26,9 @@ namespace DirectX
     {
     public:
         explicit CommonStates(_In_ ID3D12Device* device);
-        CommonStates(CommonStates&& moveFrom) noexcept;
-        CommonStates& operator = (CommonStates&& moveFrom) noexcept;
+
+        CommonStates(CommonStates&&) noexcept;
+        CommonStates& operator = (CommonStates&&) noexcept;
 
         CommonStates(const CommonStates&) = delete;
         CommonStates& operator = (const CommonStates&) = delete;

--- a/Inc/Effects.h
+++ b/Inc/Effects.h
@@ -42,13 +42,12 @@ namespace DirectX
         IEffect(const IEffect&) = delete;
         IEffect& operator=(const IEffect&) = delete;
 
-        IEffect(IEffect&&) = delete;
-        IEffect& operator=(IEffect&&) = delete;
-
         virtual void __cdecl Apply(_In_ ID3D12GraphicsCommandList* commandList) = 0;
 
     protected:
         IEffect() = default;
+        IEffect(IEffect&&) = default;
+        IEffect& operator=(IEffect&&) = default;
     };
 
 
@@ -61,9 +60,6 @@ namespace DirectX
         IEffectMatrices(const IEffectMatrices&) = delete;
         IEffectMatrices& operator=(const IEffectMatrices&) = delete;
 
-        IEffectMatrices(IEffectMatrices&&) = delete;
-        IEffectMatrices& operator=(IEffectMatrices&&) = delete;
-
         virtual void XM_CALLCONV SetWorld(FXMMATRIX value) = 0;
         virtual void XM_CALLCONV SetView(FXMMATRIX value) = 0;
         virtual void XM_CALLCONV SetProjection(FXMMATRIX value) = 0;
@@ -71,6 +67,8 @@ namespace DirectX
 
     protected:
         IEffectMatrices() = default;
+        IEffectMatrices(IEffectMatrices&&) = default;
+        IEffectMatrices& operator=(IEffectMatrices&&) = default;
     };
 
 
@@ -82,9 +80,6 @@ namespace DirectX
 
         IEffectLights(const IEffectLights&) = delete;
         IEffectLights& operator=(const IEffectLights&) = delete;
-
-        IEffectLights(IEffectLights&&) = delete;
-        IEffectLights& operator=(IEffectLights&&) = delete;
 
         virtual void XM_CALLCONV SetAmbientLightColor(FXMVECTOR value) = 0;
 
@@ -99,6 +94,8 @@ namespace DirectX
 
     protected:
         IEffectLights() = default;
+        IEffectLights(IEffectLights&&) = default;
+        IEffectLights& operator=(IEffectLights&&) = default;
     };
 
 
@@ -111,15 +108,14 @@ namespace DirectX
         IEffectFog(const IEffectFog&) = delete;
         IEffectFog& operator=(const IEffectFog&) = delete;
 
-        IEffectFog(IEffectFog&&) = delete;
-        IEffectFog& operator=(IEffectFog&&) = delete;
-
         virtual void __cdecl SetFogStart(float value) = 0;
         virtual void __cdecl SetFogEnd(float value) = 0;
         virtual void XM_CALLCONV SetFogColor(FXMVECTOR value) = 0;
 
     protected:
         IEffectFog() = default;
+        IEffectFog(IEffectFog&&) = default;
+        IEffectFog& operator=(IEffectFog&&) = default;
     };
 
 
@@ -132,9 +128,6 @@ namespace DirectX
         IEffectSkinning(const IEffectSkinning&) = delete;
         IEffectSkinning& operator=(const IEffectSkinning&) = delete;
 
-        IEffectSkinning(IEffectSkinning&&) = delete;
-        IEffectSkinning& operator=(IEffectSkinning&&) = delete;
-
         virtual void __cdecl SetBoneTransforms(_In_reads_(count) XMMATRIX const* value, size_t count) = 0;
         virtual void __cdecl ResetBoneTransforms() = 0;
 
@@ -142,6 +135,8 @@ namespace DirectX
 
     protected:
         IEffectSkinning() = default;
+        IEffectSkinning(IEffectSkinning&&) = default;
+        IEffectSkinning& operator=(IEffectSkinning&&) = default;
     };
 
 
@@ -171,8 +166,9 @@ namespace DirectX
     {
     public:
         BasicEffect(_In_ ID3D12Device* device, uint32_t effectFlags, const EffectPipelineStateDescription& pipelineDescription);
-        BasicEffect(BasicEffect&& moveFrom) noexcept;
-        BasicEffect& operator= (BasicEffect&& moveFrom) noexcept;
+
+        BasicEffect(BasicEffect&&) noexcept;
+        BasicEffect& operator= (BasicEffect&&) noexcept;
 
         BasicEffect(BasicEffect const&) = delete;
         BasicEffect& operator= (BasicEffect const&) = delete;
@@ -227,10 +223,12 @@ namespace DirectX
     class AlphaTestEffect : public IEffect, public IEffectMatrices, public IEffectFog
     {
     public:
-        AlphaTestEffect(_In_ ID3D12Device* device, uint32_t effectFlags, const EffectPipelineStateDescription& pipelineDescription,
+        AlphaTestEffect(_In_ ID3D12Device* device, uint32_t effectFlags,
+            const EffectPipelineStateDescription& pipelineDescription,
             D3D12_COMPARISON_FUNC alphaFunction = D3D12_COMPARISON_FUNC_GREATER);
-        AlphaTestEffect(AlphaTestEffect&& moveFrom) noexcept;
-        AlphaTestEffect& operator= (AlphaTestEffect&& moveFrom) noexcept;
+
+        AlphaTestEffect(AlphaTestEffect&&) noexcept;
+        AlphaTestEffect& operator= (AlphaTestEffect&&) noexcept;
 
         AlphaTestEffect(AlphaTestEffect const&) = delete;
         AlphaTestEffect& operator= (AlphaTestEffect const&) = delete;
@@ -274,9 +272,11 @@ namespace DirectX
     class DualTextureEffect : public IEffect, public IEffectMatrices, public IEffectFog
     {
     public:
-        DualTextureEffect(_In_ ID3D12Device* device, uint32_t effectFlags, const EffectPipelineStateDescription& pipelineDescription);
-        DualTextureEffect(DualTextureEffect&& moveFrom) noexcept;
-        DualTextureEffect& operator= (DualTextureEffect&& moveFrom) noexcept;
+        DualTextureEffect(_In_ ID3D12Device* device, uint32_t effectFlags,
+            const EffectPipelineStateDescription& pipelineDescription);
+
+        DualTextureEffect(DualTextureEffect&&) noexcept;
+        DualTextureEffect& operator= (DualTextureEffect&&) noexcept;
 
         DualTextureEffect(DualTextureEffect const&) = delete;
         DualTextureEffect& operator= (DualTextureEffect const&) = delete;
@@ -325,10 +325,12 @@ namespace DirectX
             Mapping_DualParabola,   // Dual-parabola environment map (requires Feature Level 10.0)
         };
 
-        EnvironmentMapEffect(_In_ ID3D12Device* device, uint32_t effectFlags, const EffectPipelineStateDescription& pipelineDescription,
+        EnvironmentMapEffect(_In_ ID3D12Device* device, uint32_t effectFlags,
+            const EffectPipelineStateDescription& pipelineDescription,
             Mapping mapping = Mapping_Cube);
-        EnvironmentMapEffect(EnvironmentMapEffect&& moveFrom) noexcept;
-        EnvironmentMapEffect& operator= (EnvironmentMapEffect&& moveFrom) noexcept;
+
+        EnvironmentMapEffect(EnvironmentMapEffect&&) noexcept;
+        EnvironmentMapEffect& operator= (EnvironmentMapEffect&&) noexcept;
 
         EnvironmentMapEffect(EnvironmentMapEffect const&) = delete;
         EnvironmentMapEffect& operator= (EnvironmentMapEffect const&) = delete;
@@ -388,9 +390,11 @@ namespace DirectX
     class SkinnedEffect : public IEffect, public IEffectMatrices, public IEffectLights, public IEffectFog, public IEffectSkinning
     {
     public:
-        SkinnedEffect(_In_ ID3D12Device* device, uint32_t effectFlags, const EffectPipelineStateDescription& pipelineDescription);
-        SkinnedEffect(SkinnedEffect&& moveFrom) noexcept;
-        SkinnedEffect& operator= (SkinnedEffect&& moveFrom) noexcept;
+        SkinnedEffect(_In_ ID3D12Device* device, uint32_t effectFlags,
+            const EffectPipelineStateDescription& pipelineDescription);
+
+        SkinnedEffect(SkinnedEffect&&) noexcept;
+        SkinnedEffect& operator= (SkinnedEffect&&) noexcept;
 
         SkinnedEffect(SkinnedEffect const&) = delete;
         SkinnedEffect& operator= (SkinnedEffect const&) = delete;
@@ -450,9 +454,11 @@ namespace DirectX
     class NormalMapEffect : public IEffect, public IEffectMatrices, public IEffectLights, public IEffectFog
     {
     public:
-        NormalMapEffect(_In_ ID3D12Device* device, uint32_t effectFlags, const EffectPipelineStateDescription& pipelineDescription);
-        NormalMapEffect(NormalMapEffect&& moveFrom) noexcept;
-        NormalMapEffect& operator= (NormalMapEffect&& moveFrom) noexcept;
+        NormalMapEffect(_In_ ID3D12Device* device, uint32_t effectFlags,
+            const EffectPipelineStateDescription& pipelineDescription);
+
+        NormalMapEffect(NormalMapEffect&&) noexcept;
+        NormalMapEffect& operator= (NormalMapEffect&&) noexcept;
 
         NormalMapEffect(NormalMapEffect const&) = delete;
         NormalMapEffect& operator= (NormalMapEffect const&) = delete;
@@ -510,9 +516,11 @@ namespace DirectX
     class PBREffect : public IEffect, public IEffectMatrices, public IEffectLights
     {
     public:
-        PBREffect(_In_ ID3D12Device* device, uint32_t effectFlags, const EffectPipelineStateDescription& pipelineDescription);
-        PBREffect(PBREffect&& moveFrom) noexcept;
-        PBREffect& operator= (PBREffect&& moveFrom) noexcept;
+        PBREffect(_In_ ID3D12Device* device, uint32_t effectFlags,
+            const EffectPipelineStateDescription& pipelineDescription);
+
+        PBREffect(PBREffect&&) noexcept;
+        PBREffect& operator= (PBREffect&&) noexcept;
 
         PBREffect(PBREffect const&) = delete;
         PBREffect& operator= (PBREffect const&) = delete;
@@ -588,10 +596,12 @@ namespace DirectX
             Mode_BiTangents,    // RGB bi-tangents
         };
 
-        DebugEffect(_In_ ID3D12Device* device, uint32_t effectFlags, const EffectPipelineStateDescription& pipelineDescription,
+        DebugEffect(_In_ ID3D12Device* device, uint32_t effectFlags,
+            const EffectPipelineStateDescription& pipelineDescription,
             Mode debugMode = Mode_Default);
-        DebugEffect(DebugEffect&& moveFrom) noexcept;
-        DebugEffect& operator= (DebugEffect&& moveFrom) noexcept;
+
+        DebugEffect(DebugEffect&&) noexcept;
+        DebugEffect& operator= (DebugEffect&&) noexcept;
 
         DebugEffect(DebugEffect const&) = delete;
         DebugEffect& operator= (DebugEffect const&) = delete;
@@ -629,13 +639,12 @@ namespace DirectX
         IEffectTextureFactory(const IEffectTextureFactory&) = delete;
         IEffectTextureFactory& operator=(const IEffectTextureFactory&) = delete;
 
-        IEffectTextureFactory(IEffectTextureFactory&&) = delete;
-        IEffectTextureFactory& operator=(IEffectTextureFactory&&) = delete;
-
         virtual size_t __cdecl CreateTexture(_In_z_ const wchar_t* name, int descriptorIndex) = 0;
 
     protected:
         IEffectTextureFactory() = default;
+        IEffectTextureFactory(IEffectTextureFactory&&) = default;
+        IEffectTextureFactory& operator=(IEffectTextureFactory&&) = default;
     };
 
 
@@ -654,8 +663,8 @@ namespace DirectX
             _In_ size_t numDescriptors,
             _In_ D3D12_DESCRIPTOR_HEAP_FLAGS descriptorHeapFlags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE) noexcept(false);
 
-        EffectTextureFactory(EffectTextureFactory&& moveFrom) noexcept;
-        EffectTextureFactory& operator= (EffectTextureFactory&& moveFrom) noexcept;
+        EffectTextureFactory(EffectTextureFactory&&) noexcept;
+        EffectTextureFactory& operator= (EffectTextureFactory&&) noexcept;
 
         EffectTextureFactory(EffectTextureFactory const&) = delete;
         EffectTextureFactory& operator= (EffectTextureFactory const&) = delete;
@@ -703,9 +712,6 @@ namespace DirectX
 
         IEffectFactory(const IEffectFactory&) = delete;
         IEffectFactory& operator=(const IEffectFactory&) = delete;
-
-        IEffectFactory(IEffectFactory&&) = delete;
-        IEffectFactory& operator=(IEffectFactory&&) = delete;
 
         struct EffectInfo
         {
@@ -760,6 +766,8 @@ namespace DirectX
 
     protected:
         IEffectFactory() = default;
+        IEffectFactory(IEffectFactory&&) = default;
+        IEffectFactory& operator=(IEffectFactory&&) = default;
     };
 
 
@@ -772,8 +780,8 @@ namespace DirectX
             _In_ ID3D12DescriptorHeap* textureDescriptors,
             _In_ ID3D12DescriptorHeap* samplerDescriptors);
 
-        EffectFactory(EffectFactory&& moveFrom) noexcept;
-        EffectFactory& operator= (EffectFactory&& moveFrom) noexcept;
+        EffectFactory(EffectFactory&&) noexcept;
+        EffectFactory& operator= (EffectFactory&&) noexcept;
 
         EffectFactory(EffectFactory const&) = delete;
         EffectFactory& operator= (EffectFactory const&) = delete;
@@ -819,8 +827,8 @@ namespace DirectX
             _In_ ID3D12DescriptorHeap* textureDescriptors,
             _In_ ID3D12DescriptorHeap* samplerDescriptors) noexcept(false);
 
-        PBREffectFactory(PBREffectFactory&& moveFrom) noexcept;
-        PBREffectFactory& operator= (PBREffectFactory&& moveFrom) noexcept;
+        PBREffectFactory(PBREffectFactory&&) noexcept;
+        PBREffectFactory& operator= (PBREffectFactory&&) noexcept;
 
         PBREffectFactory(PBREffectFactory const&) = delete;
         PBREffectFactory& operator= (PBREffectFactory const&) = delete;

--- a/Inc/GamePad.h
+++ b/Inc/GamePad.h
@@ -46,8 +46,9 @@ namespace DirectX
     {
     public:
         GamePad() noexcept(false);
-        GamePad(GamePad&& moveFrom) noexcept;
-        GamePad& operator= (GamePad&& moveFrom) noexcept;
+
+        GamePad(GamePad&&) noexcept;
+        GamePad& operator= (GamePad&&) noexcept;
 
         GamePad(GamePad const&) = delete;
         GamePad& operator=(GamePad const&) = delete;

--- a/Inc/GraphicsMemory.h
+++ b/Inc/GraphicsMemory.h
@@ -126,8 +126,8 @@ namespace DirectX
     public:
         explicit GraphicsMemory(_In_ ID3D12Device* device);
 
-        GraphicsMemory(GraphicsMemory&& moveFrom) noexcept;
-        GraphicsMemory& operator= (GraphicsMemory&& moveFrom) noexcept;
+        GraphicsMemory(GraphicsMemory&&) noexcept;
+        GraphicsMemory& operator= (GraphicsMemory&&) noexcept;
 
         GraphicsMemory(GraphicsMemory const&) = delete;
         GraphicsMemory& operator=(GraphicsMemory const&) = delete;

--- a/Inc/Keyboard.h
+++ b/Inc/Keyboard.h
@@ -29,8 +29,9 @@ namespace DirectX
     {
     public:
         Keyboard() noexcept(false);
-        Keyboard(Keyboard&& moveFrom) noexcept;
-        Keyboard& operator= (Keyboard&& moveFrom) noexcept;
+
+        Keyboard(Keyboard&&) noexcept;
+        Keyboard& operator= (Keyboard&&) noexcept;
 
         Keyboard(Keyboard const&) = delete;
         Keyboard& operator=(Keyboard const&) = delete;

--- a/Inc/Mouse.h
+++ b/Inc/Mouse.h
@@ -28,8 +28,9 @@ namespace DirectX
     {
     public:
         Mouse() noexcept(false);
-        Mouse(Mouse&& moveFrom) noexcept;
-        Mouse& operator= (Mouse&& moveFrom) noexcept;
+
+        Mouse(Mouse&&) noexcept;
+        Mouse& operator= (Mouse&&) noexcept;
 
         Mouse(Mouse const&) = delete;
         Mouse& operator=(Mouse const&) = delete;

--- a/Inc/PostProcess.h
+++ b/Inc/PostProcess.h
@@ -36,13 +36,12 @@ namespace DirectX
         IPostProcess(const IPostProcess&) = delete;
         IPostProcess& operator=(const IPostProcess&) = delete;
 
-        IPostProcess(IPostProcess&&) = delete;
-        IPostProcess& operator=(IPostProcess&&) = delete;
-
         virtual void __cdecl Process(_In_ ID3D12GraphicsCommandList* commandList) = 0;
 
     protected:
         IPostProcess() = default;
+        IPostProcess(IPostProcess&&) = default;
+        IPostProcess& operator=(IPostProcess&&) = default;
     };
 
 
@@ -65,8 +64,9 @@ namespace DirectX
         };
 
         BasicPostProcess(_In_ ID3D12Device* device, const RenderTargetState& rtState, Effect fx);
-        BasicPostProcess(BasicPostProcess&& moveFrom) noexcept;
-        BasicPostProcess& operator= (BasicPostProcess&& moveFrom) noexcept;
+
+        BasicPostProcess(BasicPostProcess&&) noexcept;
+        BasicPostProcess& operator= (BasicPostProcess&&) noexcept;
 
         BasicPostProcess(BasicPostProcess const&) = delete;
         BasicPostProcess& operator= (BasicPostProcess const&) = delete;
@@ -109,8 +109,9 @@ namespace DirectX
         };
 
         DualPostProcess(_In_ ID3D12Device* device, const RenderTargetState& rtState, Effect fx);
-        DualPostProcess(DualPostProcess&& moveFrom) noexcept;
-        DualPostProcess& operator= (DualPostProcess&& moveFrom) noexcept;
+
+        DualPostProcess(DualPostProcess&&) noexcept;
+        DualPostProcess& operator= (DualPostProcess&&) noexcept;
 
         DualPostProcess(DualPostProcess const&) = delete;
         DualPostProcess& operator= (DualPostProcess const&) = delete;
@@ -177,8 +178,8 @@ namespace DirectX
         #endif
         );
 
-        ToneMapPostProcess(ToneMapPostProcess&& moveFrom) noexcept;
-        ToneMapPostProcess& operator= (ToneMapPostProcess&& moveFrom) noexcept;
+        ToneMapPostProcess(ToneMapPostProcess&&) noexcept;
+        ToneMapPostProcess& operator= (ToneMapPostProcess&&) noexcept;
 
         ToneMapPostProcess(ToneMapPostProcess const&) = delete;
         ToneMapPostProcess& operator= (ToneMapPostProcess const&) = delete;

--- a/Inc/PrimitiveBatch.h
+++ b/Inc/PrimitiveBatch.h
@@ -34,8 +34,8 @@ namespace DirectX
         protected:
             PrimitiveBatchBase(_In_ ID3D12Device* device, size_t maxIndices, size_t maxVertices, size_t vertexSize);
 
-            PrimitiveBatchBase(PrimitiveBatchBase&& moveFrom) noexcept;
-            PrimitiveBatchBase& operator= (PrimitiveBatchBase&& moveFrom) noexcept;
+            PrimitiveBatchBase(PrimitiveBatchBase&&) noexcept;
+            PrimitiveBatchBase& operator= (PrimitiveBatchBase&&) noexcept;
 
             PrimitiveBatchBase(PrimitiveBatchBase const&) = delete;
             PrimitiveBatchBase& operator= (PrimitiveBatchBase const&) = delete;
@@ -67,19 +67,14 @@ namespace DirectX
         static const size_t DefaultBatchSize = 4096;
 
     public:
-        explicit PrimitiveBatch(_In_ ID3D12Device* device, size_t maxIndices = DefaultBatchSize * 3, size_t maxVertices = DefaultBatchSize)
+        explicit PrimitiveBatch(_In_ ID3D12Device* device,
+            size_t maxIndices = DefaultBatchSize * 3,
+            size_t maxVertices = DefaultBatchSize)
             : PrimitiveBatchBase(device, maxIndices, maxVertices, sizeof(TVertex))
         { }
 
-        PrimitiveBatch(PrimitiveBatch&& moveFrom) noexcept
-            : PrimitiveBatchBase(std::move(moveFrom))
-        { }
-
-        PrimitiveBatch& operator= (PrimitiveBatch&& moveFrom) noexcept
-        {
-            PrimitiveBatchBase::operator=(std::move(moveFrom));
-            return *this;
-        }
+        PrimitiveBatch(PrimitiveBatch&&) = default;
+        PrimitiveBatch& operator= (PrimitiveBatch&&) = default;
 
         PrimitiveBatch(PrimitiveBatch const&) = delete;
         PrimitiveBatch& operator= (PrimitiveBatch const&) = delete;

--- a/Inc/ResourceUploadBatch.h
+++ b/Inc/ResourceUploadBatch.h
@@ -31,8 +31,9 @@ namespace DirectX
     {
     public:
         explicit ResourceUploadBatch(_In_ ID3D12Device* device) noexcept(false);
-        ResourceUploadBatch(ResourceUploadBatch&& moveFrom) noexcept;
-        ResourceUploadBatch& operator= (ResourceUploadBatch&& moveFrom) noexcept;
+
+        ResourceUploadBatch(ResourceUploadBatch&&) noexcept;
+        ResourceUploadBatch& operator= (ResourceUploadBatch&&) noexcept;
 
         ResourceUploadBatch(ResourceUploadBatch const&) = delete;
         ResourceUploadBatch& operator= (ResourceUploadBatch const&) = delete;

--- a/Inc/SpriteBatch.h
+++ b/Inc/SpriteBatch.h
@@ -90,9 +90,12 @@ namespace DirectX
     class SpriteBatch
     {
     public:
-        SpriteBatch(_In_ ID3D12Device* device, ResourceUploadBatch& upload, const SpriteBatchPipelineStateDescription& psoDesc, _In_opt_ const D3D12_VIEWPORT* viewport = nullptr);
-        SpriteBatch(SpriteBatch&& moveFrom) noexcept;
-        SpriteBatch& operator= (SpriteBatch&& moveFrom) noexcept;
+        SpriteBatch(_In_ ID3D12Device* device, ResourceUploadBatch& upload,
+            const SpriteBatchPipelineStateDescription& psoDesc,
+            _In_opt_ const D3D12_VIEWPORT* viewport = nullptr);
+
+        SpriteBatch(SpriteBatch&&) noexcept;
+        SpriteBatch& operator= (SpriteBatch&&) noexcept;
 
         SpriteBatch(SpriteBatch const&) = delete;
         SpriteBatch& operator= (SpriteBatch const&) = delete;

--- a/Inc/SpriteFont.h
+++ b/Inc/SpriteFont.h
@@ -21,12 +21,19 @@ namespace DirectX
     public:
         struct Glyph;
 
-        SpriteFont(ID3D12Device* device, ResourceUploadBatch& upload, _In_z_ wchar_t const* fileName, D3D12_CPU_DESCRIPTOR_HANDLE cpuDescriptorDest, D3D12_GPU_DESCRIPTOR_HANDLE gpuDescriptor, bool forceSRGB = false);
-        SpriteFont(ID3D12Device* device, ResourceUploadBatch& upload, _In_reads_bytes_(dataSize) uint8_t const* dataBlob, size_t dataSize, D3D12_CPU_DESCRIPTOR_HANDLE cpuDescriptorDest, D3D12_GPU_DESCRIPTOR_HANDLE gpuDescriptor, bool forceSRGB = false);
-        SpriteFont(D3D12_GPU_DESCRIPTOR_HANDLE texture, XMUINT2 textureSize, _In_reads_(glyphCount) Glyph const* glyphs, size_t glyphCount, float lineSpacing);
+        SpriteFont(ID3D12Device* device, ResourceUploadBatch& upload,
+            _In_z_ wchar_t const* fileName,
+            D3D12_CPU_DESCRIPTOR_HANDLE cpuDescriptorDest, D3D12_GPU_DESCRIPTOR_HANDLE gpuDescriptor,
+            bool forceSRGB = false);
+        SpriteFont(ID3D12Device* device, ResourceUploadBatch& upload,
+            _In_reads_bytes_(dataSize) uint8_t const* dataBlob, size_t dataSize,
+            D3D12_CPU_DESCRIPTOR_HANDLE cpuDescriptorDest, D3D12_GPU_DESCRIPTOR_HANDLE gpuDescriptor,
+            bool forceSRGB = false);
+        SpriteFont(D3D12_GPU_DESCRIPTOR_HANDLE texture, XMUINT2 textureSize,
+            _In_reads_(glyphCount) Glyph const* glyphs, size_t glyphCount, float lineSpacing);
 
-        SpriteFont(SpriteFont&& moveFrom) noexcept;
-        SpriteFont& operator= (SpriteFont&& moveFrom) noexcept;
+        SpriteFont(SpriteFont&&) noexcept;
+        SpriteFont& operator= (SpriteFont&&) noexcept;
 
         SpriteFont(SpriteFont const&) = delete;
         SpriteFont& operator= (SpriteFont const&) = delete;

--- a/Src/AlphaTestEffect.cpp
+++ b/Src/AlphaTestEffect.cpp
@@ -399,25 +399,9 @@ AlphaTestEffect::AlphaTestEffect(
 }
 
 
-// Move constructor.
-AlphaTestEffect::AlphaTestEffect(AlphaTestEffect&& moveFrom) noexcept
-    : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-
-// Move assignment.
-AlphaTestEffect& AlphaTestEffect::operator= (AlphaTestEffect&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
-
-
-// Public destructor.
-AlphaTestEffect::~AlphaTestEffect()
-{
-}
+AlphaTestEffect::AlphaTestEffect(AlphaTestEffect&&) noexcept = default;
+AlphaTestEffect& AlphaTestEffect::operator= (AlphaTestEffect&&) noexcept = default;
+AlphaTestEffect::~AlphaTestEffect() = default;
 
 
 // IEffect methods

--- a/Src/BasicEffect.cpp
+++ b/Src/BasicEffect.cpp
@@ -589,24 +589,9 @@ BasicEffect::BasicEffect(
 
 
 // Move constructor.
-BasicEffect::BasicEffect(BasicEffect&& moveFrom) noexcept
-  : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-
-// Move assignment.
-BasicEffect& BasicEffect::operator= (BasicEffect&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
-
-
-// Public destructor.
-BasicEffect::~BasicEffect()
-{
-}
+BasicEffect::BasicEffect(BasicEffect&&) noexcept = default;
+BasicEffect& BasicEffect::operator= (BasicEffect&&) noexcept = default;
+BasicEffect::~BasicEffect() = default;
 
 
 // IEffect methods

--- a/Src/BasicPostProcess.cpp
+++ b/Src/BasicPostProcess.cpp
@@ -550,24 +550,9 @@ BasicPostProcess::BasicPostProcess(_In_ ID3D12Device* device, const RenderTarget
 
 
 // Move constructor.
-BasicPostProcess::BasicPostProcess(BasicPostProcess&& moveFrom) noexcept
-  : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-
-// Move assignment.
-BasicPostProcess& BasicPostProcess::operator= (BasicPostProcess&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
-
-
-// Public destructor.
-BasicPostProcess::~BasicPostProcess()
-{
-}
+BasicPostProcess::BasicPostProcess(BasicPostProcess&&) noexcept = default;
+BasicPostProcess& BasicPostProcess::operator= (BasicPostProcess&&) noexcept = default;
+BasicPostProcess::~BasicPostProcess() = default;
 
 
 // IPostProcess methods.

--- a/Src/CommonStates.cpp
+++ b/Src/CommonStates.cpp
@@ -523,18 +523,10 @@ CommonStates::CommonStates(ID3D12Device* device)
     pImpl = std::make_unique<Impl>(device);
 }
 
-CommonStates::CommonStates(CommonStates&& moveFrom) noexcept
-    : pImpl(std::move(moveFrom.pImpl))
-{
-}
+CommonStates::CommonStates(CommonStates&&) noexcept = default;
+CommonStates& CommonStates::operator = (CommonStates&&) noexcept = default;
+CommonStates::~CommonStates() = default;
 
-CommonStates::~CommonStates() {}
-
-CommonStates& CommonStates::operator = (CommonStates&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
 
 D3D12_GPU_DESCRIPTOR_HANDLE CommonStates::PointWrap() const { return pImpl->Get(SamplerIndex::PointWrap); }
 D3D12_GPU_DESCRIPTOR_HANDLE CommonStates::PointClamp() const { return pImpl->Get(SamplerIndex::PointClamp); }

--- a/Src/DebugEffect.cpp
+++ b/Src/DebugEffect.cpp
@@ -386,25 +386,9 @@ DebugEffect::DebugEffect(
 }
 
 
-// Move constructor.
-DebugEffect::DebugEffect(DebugEffect&& moveFrom) noexcept
-    : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-
-// Move assignment.
-DebugEffect& DebugEffect::operator= (DebugEffect&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
-
-
-// Public destructor.
-DebugEffect::~DebugEffect()
-{
-}
+DebugEffect::DebugEffect(DebugEffect&&) noexcept = default;
+DebugEffect& DebugEffect::operator= (DebugEffect&&) noexcept = default;
+DebugEffect::~DebugEffect() = default;
 
 
 // IEffect methods.

--- a/Src/DualPostProcess.cpp
+++ b/Src/DualPostProcess.cpp
@@ -304,25 +304,9 @@ DualPostProcess::DualPostProcess(_In_ ID3D12Device* device, const RenderTargetSt
 }
 
 
-// Move constructor.
-DualPostProcess::DualPostProcess(DualPostProcess&& moveFrom) noexcept
-  : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-
-// Move assignment.
-DualPostProcess& DualPostProcess::operator= (DualPostProcess&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
-
-
-// Public destructor.
-DualPostProcess::~DualPostProcess()
-{
-}
+DualPostProcess::DualPostProcess(DualPostProcess&&) noexcept = default;
+DualPostProcess& DualPostProcess::operator= (DualPostProcess&&) noexcept = default;
+DualPostProcess::~DualPostProcess() = default;
 
 
 // IPostProcess methods.

--- a/Src/DualTextureEffect.cpp
+++ b/Src/DualTextureEffect.cpp
@@ -313,25 +313,9 @@ DualTextureEffect::DualTextureEffect(
 }
 
 
-// Move constructor.
-DualTextureEffect::DualTextureEffect(DualTextureEffect&& moveFrom) noexcept
-    : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-
-// Move assignment.
-DualTextureEffect& DualTextureEffect::operator= (DualTextureEffect&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
-
-
-// Public destructor.
-DualTextureEffect::~DualTextureEffect()
-{
-}
+DualTextureEffect::DualTextureEffect(DualTextureEffect&&) noexcept = default;
+DualTextureEffect& DualTextureEffect::operator= (DualTextureEffect&&) noexcept = default;
+DualTextureEffect::~DualTextureEffect() = default;
 
 
 // IEffect methods

--- a/Src/EffectFactory.cpp
+++ b/Src/EffectFactory.cpp
@@ -503,21 +503,11 @@ EffectFactory::EffectFactory(_In_ ID3D12DescriptorHeap* textureDescriptors, _In_
     pImpl = std::make_shared<Impl>(device.Get(), textureDescriptors, samplerDescriptors);
 }
 
-EffectFactory::~EffectFactory()
-{
-}
 
+EffectFactory::EffectFactory(EffectFactory&&) noexcept = default;
+EffectFactory& EffectFactory::operator= (EffectFactory&&) noexcept = default;
+EffectFactory::~EffectFactory() = default;
 
-EffectFactory::EffectFactory(EffectFactory&& moveFrom) noexcept
-    : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-EffectFactory& EffectFactory::operator= (EffectFactory&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
 
 std::shared_ptr<IEffect> EffectFactory::CreateEffect(
     const EffectInfo& info, 
@@ -530,11 +520,14 @@ std::shared_ptr<IEffect> EffectFactory::CreateEffect(
     return pImpl->CreateEffect(info, opaquePipelineState, alphaPipelineState, inputLayout, textureDescriptorOffset, samplerDescriptorOffset);
 }
 
+
 void EffectFactory::ReleaseCache()
 {
     pImpl->ReleaseCache();
 }
 
+
+// Properties.
 void EffectFactory::SetSharing(bool enabled) noexcept
 {
     pImpl->mSharing = enabled;

--- a/Src/EffectTextureFactory.cpp
+++ b/Src/EffectTextureFactory.cpp
@@ -231,21 +231,11 @@ EffectTextureFactory::EffectTextureFactory(
     pImpl = std::make_unique<Impl>(device, resourceUploadBatch, numDescriptors, descriptorHeapFlags);
 }
 
-EffectTextureFactory::~EffectTextureFactory()
-{
-}
 
+EffectTextureFactory::EffectTextureFactory(EffectTextureFactory&&) noexcept = default;
+EffectTextureFactory& EffectTextureFactory::operator= (EffectTextureFactory&&) noexcept = default;
+EffectTextureFactory::~EffectTextureFactory() = default;
 
-EffectTextureFactory::EffectTextureFactory(EffectTextureFactory&& moveFrom) noexcept
-    : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-EffectTextureFactory& EffectTextureFactory::operator= (EffectTextureFactory&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
 
 _Use_decl_annotations_
 size_t EffectTextureFactory::CreateTexture(_In_z_ const wchar_t* name, int descriptorIndex)
@@ -253,11 +243,14 @@ size_t EffectTextureFactory::CreateTexture(_In_z_ const wchar_t* name, int descr
     return pImpl->CreateTexture(name, descriptorIndex);
 }
 
+
 void EffectTextureFactory::ReleaseCache()
 {
     pImpl->ReleaseCache();
 }
 
+
+// Properties.
 void EffectTextureFactory::SetSharing(bool enabled) noexcept
 {
     pImpl->SetSharing(enabled);

--- a/Src/EnvironmentMapEffect.cpp
+++ b/Src/EnvironmentMapEffect.cpp
@@ -556,25 +556,9 @@ EnvironmentMapEffect::EnvironmentMapEffect(
 }
 
 
-// Move constructor.
-EnvironmentMapEffect::EnvironmentMapEffect(EnvironmentMapEffect&& moveFrom) noexcept
-    : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-
-// Move assignment.
-EnvironmentMapEffect& EnvironmentMapEffect::operator= (EnvironmentMapEffect&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
-
-
-// Public destructor.
-EnvironmentMapEffect::~EnvironmentMapEffect()
-{
-}
+EnvironmentMapEffect::EnvironmentMapEffect(EnvironmentMapEffect&&) noexcept = default;
+EnvironmentMapEffect& EnvironmentMapEffect::operator= (EnvironmentMapEffect&&) noexcept = default;
+EnvironmentMapEffect::~EnvironmentMapEffect() = default;
 
 
 // IEffect methods.

--- a/Src/GamePad.cpp
+++ b/Src/GamePad.cpp
@@ -1606,9 +1606,7 @@ GamePad& GamePad::operator= (GamePad&& moveFrom) noexcept
 
 
 // Public destructor.
-GamePad::~GamePad()
-{
-}
+GamePad::~GamePad() = default;
 
 
 GamePad::State GamePad::GetState(int player, DeadZone deadZoneMode)

--- a/Src/GraphicsMemory.cpp
+++ b/Src/GraphicsMemory.cpp
@@ -369,9 +369,7 @@ GraphicsMemory& GraphicsMemory::operator= (GraphicsMemory&& moveFrom) noexcept
 
 
 // Public destructor.
-GraphicsMemory::~GraphicsMemory()
-{
-}
+GraphicsMemory::~GraphicsMemory() = default;
 
 
 GraphicsResource GraphicsMemory::Allocate(size_t size, size_t alignment)

--- a/Src/Keyboard.cpp
+++ b/Src/Keyboard.cpp
@@ -576,9 +576,7 @@ Keyboard& Keyboard::operator= (Keyboard&& moveFrom) noexcept
 
 
 // Public destructor.
-Keyboard::~Keyboard()
-{
-}
+Keyboard::~Keyboard() = default;
 
 
 Keyboard::State Keyboard::GetState() const

--- a/Src/Mouse.cpp
+++ b/Src/Mouse.cpp
@@ -1419,9 +1419,7 @@ Mouse& Mouse::operator= (Mouse&& moveFrom) noexcept
 
 
 // Public destructor.
-Mouse::~Mouse()
-{
-}
+Mouse::~Mouse() = default;
 
 
 Mouse::State Mouse::GetState() const

--- a/Src/NormalMapEffect.cpp
+++ b/Src/NormalMapEffect.cpp
@@ -495,25 +495,9 @@ NormalMapEffect::NormalMapEffect(
 }
 
 
-// Move constructor.
-NormalMapEffect::NormalMapEffect(NormalMapEffect&& moveFrom) noexcept
-    : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-
-// Move assignment.
-NormalMapEffect& NormalMapEffect::operator= (NormalMapEffect&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
-
-
-// Public destructor.
-NormalMapEffect::~NormalMapEffect()
-{
-}
+NormalMapEffect::NormalMapEffect(NormalMapEffect&&) noexcept = default;
+NormalMapEffect& NormalMapEffect::operator= (NormalMapEffect&&) noexcept = default;
+NormalMapEffect::~NormalMapEffect() = default;
 
 
 // IEffect methods

--- a/Src/PBREffect.cpp
+++ b/Src/PBREffect.cpp
@@ -521,25 +521,10 @@ PBREffect::PBREffect(_In_ ID3D12Device* device,
 }
 
 
-// Move constructor.
-PBREffect::PBREffect(PBREffect&& moveFrom) noexcept
-    : pImpl(std::move(moveFrom.pImpl))
-{
-}
+PBREffect::PBREffect(PBREffect&&) noexcept = default;
+PBREffect& PBREffect::operator= (PBREffect&&) noexcept = default;
+PBREffect::~PBREffect() = default;
 
-
-// Move assignment.
-PBREffect& PBREffect::operator= (PBREffect&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
-
-
-// Public destructor.
-PBREffect::~PBREffect()
-{
-}
 
 // IEffect methods.
 void PBREffect::Apply(_In_ ID3D12GraphicsCommandList* commandList)

--- a/Src/PBREffectFactory.cpp
+++ b/Src/PBREffectFactory.cpp
@@ -203,21 +203,11 @@ PBREffectFactory::PBREffectFactory(_In_ ID3D12DescriptorHeap* textureDescriptors
     pImpl = std::make_shared<Impl>(device.Get(), textureDescriptors, samplerDescriptors);
 }
 
-PBREffectFactory::~PBREffectFactory()
-{
-}
 
+PBREffectFactory::PBREffectFactory(PBREffectFactory&&) noexcept = default;
+PBREffectFactory& PBREffectFactory::operator= (PBREffectFactory&&) noexcept = default;
+PBREffectFactory::~PBREffectFactory() = default;
 
-PBREffectFactory::PBREffectFactory(PBREffectFactory&& moveFrom) noexcept
-    : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-PBREffectFactory& PBREffectFactory::operator= (PBREffectFactory&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
 
 std::shared_ptr<IEffect> PBREffectFactory::CreateEffect(
     const EffectInfo& info, 
@@ -230,11 +220,14 @@ std::shared_ptr<IEffect> PBREffectFactory::CreateEffect(
     return pImpl->CreateEffect(info, opaquePipelineState, alphaPipelineState, inputLayout, textureDescriptorOffset, samplerDescriptorOffset);
 }
 
+
 void PBREffectFactory::ReleaseCache()
 {
     pImpl->ReleaseCache();
 }
 
+
+// Properties.
 void PBREffectFactory::SetSharing(bool enabled) noexcept
 {
     pImpl->mSharing = enabled;

--- a/Src/PrimitiveBatch.cpp
+++ b/Src/PrimitiveBatch.cpp
@@ -248,25 +248,9 @@ PrimitiveBatchBase::PrimitiveBatchBase(_In_ ID3D12Device* device, size_t maxIndi
 }
 
 
-// Move constructor.
-PrimitiveBatchBase::PrimitiveBatchBase(PrimitiveBatchBase&& moveFrom) noexcept
-    : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-
-// Move assignment.
-PrimitiveBatchBase& PrimitiveBatchBase::operator= (PrimitiveBatchBase&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
-
-
-// Public destructor.
-PrimitiveBatchBase::~PrimitiveBatchBase()
-{
-}
+PrimitiveBatchBase::PrimitiveBatchBase(PrimitiveBatchBase&&) noexcept = default;
+PrimitiveBatchBase& PrimitiveBatchBase::operator= (PrimitiveBatchBase&&) noexcept = default;
+PrimitiveBatchBase::~PrimitiveBatchBase() = default;
 
 
 void PrimitiveBatchBase::Begin(_In_ ID3D12GraphicsCommandList* cmdList)

--- a/Src/ResourceUploadBatch.cpp
+++ b/Src/ResourceUploadBatch.cpp
@@ -1023,25 +1023,9 @@ ResourceUploadBatch::ResourceUploadBatch(_In_ ID3D12Device* device) noexcept(fal
 }
 
 
-// Public destructor.
-ResourceUploadBatch::~ResourceUploadBatch()
-{
-}
-
-
-// Move constructor.
-ResourceUploadBatch::ResourceUploadBatch(ResourceUploadBatch&& moveFrom) noexcept
-    : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-
-// Move assignment.
-ResourceUploadBatch& ResourceUploadBatch::operator= (ResourceUploadBatch&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
+ResourceUploadBatch::ResourceUploadBatch(ResourceUploadBatch&&) noexcept = default;
+ResourceUploadBatch& ResourceUploadBatch::operator= (ResourceUploadBatch&&) noexcept = default;
+ResourceUploadBatch::~ResourceUploadBatch() = default;
 
 
 void ResourceUploadBatch::Begin(D3D12_COMMAND_LIST_TYPE commandType)

--- a/Src/SkinnedEffect.cpp
+++ b/Src/SkinnedEffect.cpp
@@ -329,25 +329,9 @@ SkinnedEffect::SkinnedEffect(
 }
 
 
-// Move constructor.
-SkinnedEffect::SkinnedEffect(SkinnedEffect&& moveFrom) noexcept
-    : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-
-// Move assignment.
-SkinnedEffect& SkinnedEffect::operator= (SkinnedEffect&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
-
-
-// Public destructor.
-SkinnedEffect::~SkinnedEffect()
-{
-}
+SkinnedEffect::SkinnedEffect(SkinnedEffect&&) noexcept = default;
+SkinnedEffect& SkinnedEffect::operator= (SkinnedEffect&&) noexcept = default;
+SkinnedEffect::~SkinnedEffect() = default;
 
 
 // IEffect methods.

--- a/Src/SpriteBatch.cpp
+++ b/Src/SpriteBatch.cpp
@@ -1038,25 +1038,10 @@ SpriteBatch::SpriteBatch(ID3D12Device* device,
 }
 
 
-// Move constructor.
-SpriteBatch::SpriteBatch(SpriteBatch&& moveFrom) noexcept
-    : pImpl(std::move(moveFrom.pImpl))
-{
-}
+SpriteBatch::SpriteBatch(SpriteBatch&&) noexcept = default;
+SpriteBatch& SpriteBatch::operator= (SpriteBatch&&) noexcept = default;
+SpriteBatch::~SpriteBatch() = default;
 
-
-// Move assignment.
-SpriteBatch& SpriteBatch::operator= (SpriteBatch&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
-
-
-// Public destructor.
-SpriteBatch::~SpriteBatch()
-{
-}
 
 _Use_decl_annotations_
 void XM_CALLCONV SpriteBatch::Begin(

--- a/Src/SpriteFont.cpp
+++ b/Src/SpriteFont.cpp
@@ -427,26 +427,9 @@ SpriteFont::SpriteFont(D3D12_GPU_DESCRIPTOR_HANDLE texture, XMUINT2 textureSize,
 }
 
 
-// Move constructor.
-SpriteFont::SpriteFont(SpriteFont&& moveFrom) noexcept
-    : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-
-// Move assignment.
-SpriteFont& SpriteFont::operator= (SpriteFont&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
-
-
-// Public destructor.
-SpriteFont::~SpriteFont()
-{
-}
-
+SpriteFont::SpriteFont(SpriteFont&&) noexcept = default;
+SpriteFont& SpriteFont::operator= (SpriteFont&&) noexcept = default;
+SpriteFont::~SpriteFont() = default;
 
 // Wide-character / UTF-16LE
 void XM_CALLCONV SpriteFont::DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ wchar_t const* text, XMFLOAT2 const& position, FXMVECTOR color, float rotation, XMFLOAT2 const& origin, float scale, SpriteEffects effects, float layerDepth) const

--- a/Src/ToneMapPostProcess.cpp
+++ b/Src/ToneMapPostProcess.cpp
@@ -438,25 +438,9 @@ ToneMapPostProcess::ToneMapPostProcess(_In_ ID3D12Device* device, const RenderTa
 }
 
 
-// Move constructor.
-ToneMapPostProcess::ToneMapPostProcess(ToneMapPostProcess&& moveFrom) noexcept
-  : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-
-// Move assignment.
-ToneMapPostProcess& ToneMapPostProcess::operator= (ToneMapPostProcess&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
-
-
-// Public destructor.
-ToneMapPostProcess::~ToneMapPostProcess()
-{
-}
+ToneMapPostProcess::ToneMapPostProcess(ToneMapPostProcess&&) noexcept = default;
+ToneMapPostProcess& ToneMapPostProcess::operator= (ToneMapPostProcess&&) noexcept = default;
+ToneMapPostProcess::~ToneMapPostProcess() = default;
 
 
 // IPostProcess methods.


### PR DESCRIPTION
The pImpl code pattern used in this library dates back to VS 2013 which did not have support for ``=default`` or the auto-generation of move ctors/ops.

Care still needs to be taken due to pImpl, but the bodies of many of the functions can be replaced with ``=default``.