### PR TITLE
DepthReverseZ and DepthReadReverseZ CommonStates

### DIFF
--- a/Inc/CommonStates.h
+++ b/Inc/CommonStates.h
@@ -45,6 +45,8 @@ namespace DirectX
         static const D3D12_DEPTH_STENCIL_DESC DepthNone;
         static const D3D12_DEPTH_STENCIL_DESC DepthDefault;
         static const D3D12_DEPTH_STENCIL_DESC DepthRead;
+        static const D3D12_DEPTH_STENCIL_DESC DepthReverseZ;
+        static const D3D12_DEPTH_STENCIL_DESC DepthReadReverseZ;
 
         // Rasterizer states.
         static const D3D12_RASTERIZER_DESC CullNone;

--- a/Src/CommonStates.cpp
+++ b/Src/CommonStates.cpp
@@ -161,6 +161,50 @@ const D3D12_DEPTH_STENCIL_DESC CommonStates::DepthRead =
     } // BackFace
 };
 
+const D3D12_DEPTH_STENCIL_DESC CommonStates::DepthReverseZ =
+{
+    TRUE, // DepthEnable
+    D3D12_DEPTH_WRITE_MASK_ALL,
+    D3D12_COMPARISON_FUNC_GREATER_EQUAL, // DepthFunc
+    FALSE, // StencilEnable
+    D3D12_DEFAULT_STENCIL_READ_MASK,
+    D3D12_DEFAULT_STENCIL_WRITE_MASK,
+    {
+        D3D12_STENCIL_OP_KEEP, // StencilFailOp
+        D3D12_STENCIL_OP_KEEP, // StencilDepthFailOp
+        D3D12_STENCIL_OP_KEEP, // StencilPassOp
+        D3D12_COMPARISON_FUNC_ALWAYS // StencilFunc
+    }, // FrontFace
+    {
+        D3D12_STENCIL_OP_KEEP, // StencilFailOp
+        D3D12_STENCIL_OP_KEEP, // StencilDepthFailOp
+        D3D12_STENCIL_OP_KEEP, // StencilPassOp
+        D3D12_COMPARISON_FUNC_ALWAYS // StencilFunc
+    } // BackFace
+};
+
+const D3D12_DEPTH_STENCIL_DESC CommonStates::DepthReadReverseZ =
+{
+    TRUE, // DepthEnable
+    D3D12_DEPTH_WRITE_MASK_ZERO,
+    D3D12_COMPARISON_FUNC_GREATER_EQUAL, // DepthFunc
+    FALSE, // StencilEnable
+    D3D12_DEFAULT_STENCIL_READ_MASK,
+    D3D12_DEFAULT_STENCIL_WRITE_MASK,
+    {
+        D3D12_STENCIL_OP_KEEP, // StencilFailOp
+        D3D12_STENCIL_OP_KEEP, // StencilDepthFailOp
+        D3D12_STENCIL_OP_KEEP, // StencilPassOp
+        D3D12_COMPARISON_FUNC_ALWAYS // StencilFunc
+    }, // FrontFace
+    {
+        D3D12_STENCIL_OP_KEEP, // StencilFailOp
+        D3D12_STENCIL_OP_KEEP, // StencilDepthFailOp
+        D3D12_STENCIL_OP_KEEP, // StencilPassOp
+        D3D12_COMPARISON_FUNC_ALWAYS // StencilFunc
+    } // BackFace
+};
+
 
 // --------------------------------------------------------------------------
 // Rasterizer States


### PR DESCRIPTION
Add two more common states to make it easier to use [reversez](https://developer.nvidia.com/content/depth-precision-visualized).

> No need to change any of the Model or GeometricPrimitive rendering like was done for DX11 because you can just use the new reverse CommonStates for the EffectPiplineDescription.