### PR TITLE
WaveBank streaming updated to support Advanced Format (4Kn)

### DIFF
--- a/Audio/WaveBank.cpp
+++ b/Audio/WaveBank.cpp
@@ -444,6 +444,12 @@ bool WaveBank::IsStreamingBank() const noexcept
 }
 
 
+bool WaveBank::IsAdvancedFormat() const noexcept
+{
+    return (pImpl->mReader.GetWaveAlignment() == 4096);
+}
+
+
 size_t WaveBank::GetSampleSizeInBytes(unsigned int index) const noexcept
 {
     if (index >= pImpl->mReader.Count())

--- a/Audio/WaveBankReader.cpp
+++ b/Audio/WaveBankReader.cpp
@@ -1388,3 +1388,9 @@ HANDLE WaveBankReader::GetAsyncHandle() const noexcept
 {
     return (pImpl->m_data.dwFlags & BANKDATA::TYPE_STREAMING) ? pImpl->m_async : INVALID_HANDLE_VALUE;
 }
+
+
+uint32_t WaveBankReader::GetWaveAlignment() const noexcept
+{
+    return pImpl->m_data.dwAlignment;
+}

--- a/Audio/WaveBankReader.h
+++ b/Audio/WaveBankReader.h
@@ -62,6 +62,8 @@ namespace DirectX
 
         HANDLE GetAsyncHandle() const noexcept;
 
+        uint32_t GetWaveAlignment() const noexcept;
+
         struct Metadata
         {
             uint32_t    duration;

--- a/Inc/Audio.h
+++ b/Inc/Audio.h
@@ -333,6 +333,7 @@ namespace DirectX
         bool __cdecl IsPrepared() const noexcept;
         bool __cdecl IsInUse() const noexcept;
         bool __cdecl IsStreamingBank() const noexcept;
+        bool __cdecl IsAdvancedFormat() const noexcept;
 
         size_t __cdecl GetSampleSizeInBytes(unsigned int index) const noexcept;
         // Returns size of wave audio data


### PR DESCRIPTION
*DirectX Tool Kit for Audio* wavebank streaming updated to support Advanced Format (4Kn) format drives which have a 4096 sector size vs. the classic 2048 that worked for DVDs, older generation HDDs, and Advanced Format drives in 512e mode.
