### PR TITLE
Minor fix to DescriptorHeap::Increment() to return uint32_t.

### DIFF
--- a/Inc/DescriptorHeap.h
+++ b/Inc/DescriptorHeap.h
@@ -118,7 +118,7 @@ namespace DirectX
         size_t Count() const noexcept { return m_desc.NumDescriptors; }
         unsigned int Flags() const noexcept { return m_desc.Flags; }
         D3D12_DESCRIPTOR_HEAP_TYPE Type() const noexcept { return m_desc.Type; }
-        size_t Increment() const noexcept { return m_increment; }
+        uint32_t Increment() const noexcept { return m_increment; }
         ID3D12DescriptorHeap* Heap() const noexcept { return m_pHeap.Get(); }
 
         static void __cdecl DefaultDesc(


### PR DESCRIPTION
Returning size_t just means it has to be further cast to UINT when it's put into a D3DX12_CPU_DESCRIPTOR_HANDLE struct.