### PR TITLE
Convert internal functions to use Internal namespace instead of leading underscore

### DIFF
--- a/Audio/WAVFileReader.cpp
+++ b/Audio/WAVFileReader.cpp
@@ -486,18 +486,16 @@ namespace
 
         // open the file
     #if (_WIN32_WINNT >= _WIN32_WINNT_WIN8)
-        ScopedHandle hFile(safe_handle(CreateFile2(szFileName,
-            GENERIC_READ,
-            FILE_SHARE_READ,
-            OPEN_EXISTING,
+        ScopedHandle hFile(safe_handle(CreateFile2(
+            szFileName,
+            GENERIC_READ, FILE_SHARE_READ, OPEN_EXISTING,
             nullptr)));
     #else
-        ScopedHandle hFile(safe_handle(CreateFileW(szFileName,
-            GENERIC_READ,
-            FILE_SHARE_READ,
+        ScopedHandle hFile(safe_handle(CreateFileW(
+            szFileName,
+            GENERIC_READ, FILE_SHARE_READ,
             nullptr,
-            OPEN_EXISTING,
-            FILE_ATTRIBUTE_NORMAL,
+            OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL,
             nullptr)));
     #endif
 

--- a/Audio/WaveBankReader.cpp
+++ b/Audio/WaveBankReader.cpp
@@ -519,19 +519,17 @@ HRESULT WaveBankReader::Impl::Open(const wchar_t* szFileName) noexcept(false)
     CREATEFILE2_EXTENDED_PARAMETERS params = { sizeof(CREATEFILE2_EXTENDED_PARAMETERS), 0, 0, 0, {}, nullptr };
     params.dwFileAttributes = FILE_ATTRIBUTE_NORMAL;
     params.dwFileFlags = FILE_FLAG_OVERLAPPED | FILE_FLAG_SEQUENTIAL_SCAN;
-    ScopedHandle hFile(safe_handle(CreateFile2(szFileName,
-                       GENERIC_READ,
-                       FILE_SHARE_READ,
-                       OPEN_EXISTING,
-                       &params)));
+    ScopedHandle hFile(safe_handle(CreateFile2(
+        szFileName,
+        GENERIC_READ, FILE_SHARE_READ, OPEN_EXISTING,
+        &params)));
 #else
-    ScopedHandle hFile(safe_handle(CreateFileW(szFileName,
-                       GENERIC_READ,
-                       FILE_SHARE_READ,
-                       nullptr,
-                       OPEN_EXISTING,
-                       FILE_FLAG_OVERLAPPED | FILE_FLAG_SEQUENTIAL_SCAN,
-                       nullptr)));
+    ScopedHandle hFile(safe_handle(CreateFileW(
+        szFileName,
+        GENERIC_READ, FILE_SHARE_READ,
+        nullptr,
+        OPEN_EXISTING, FILE_FLAG_OVERLAPPED | FILE_FLAG_SEQUENTIAL_SCAN,
+        nullptr)));
 #endif
 
     if (!hFile)
@@ -554,10 +552,14 @@ HRESULT WaveBankReader::Impl::Open(const wchar_t* szFileName) noexcept(false)
 
     DWORD bytes;
 #if (_WIN32_WINNT >= _WIN32_WINNT_WIN8)
+    std::ignore = wait;
+
     BOOL result = GetOverlappedResultEx(hFile.get(), &request, &bytes, INFINITE, FALSE);
 #else
     if (wait)
+    {
         std::ignore = WaitForSingleObject(m_event.get(), INFINITE);
+    }
 
     BOOL result = GetOverlappedResult(hFile.get(), &request, &bytes, FALSE);
 #endif
@@ -602,7 +604,9 @@ HRESULT WaveBankReader::Impl::Open(const wchar_t* szFileName) noexcept(false)
     result = GetOverlappedResultEx(hFile.get(), &request, &bytes, INFINITE, FALSE);
 #else
     if (wait)
+    {
         std::ignore = WaitForSingleObject(m_event.get(), INFINITE);
+    }
 
     result = GetOverlappedResult(hFile.get(), &request, &bytes, FALSE);
 #endif
@@ -686,7 +690,9 @@ HRESULT WaveBankReader::Impl::Open(const wchar_t* szFileName) noexcept(false)
             result = GetOverlappedResultEx(hFile.get(), &request, &bytes, INFINITE, FALSE);
         #else
             if (wait)
+            {
                 std::ignore = WaitForSingleObject(m_event.get(), INFINITE);
+            }
 
             result = GetOverlappedResult(hFile.get(), &request, &bytes, FALSE);
         #endif
@@ -737,7 +743,9 @@ HRESULT WaveBankReader::Impl::Open(const wchar_t* szFileName) noexcept(false)
     result = GetOverlappedResultEx(hFile.get(), &request, &bytes, INFINITE, FALSE);
 #else
     if (wait)
+    {
         std::ignore = WaitForSingleObject(m_event.get(), INFINITE);
+    }
 
     result = GetOverlappedResult(hFile.get(), &request, &bytes, FALSE);
 #endif
@@ -788,7 +796,9 @@ HRESULT WaveBankReader::Impl::Open(const wchar_t* szFileName) noexcept(false)
         result = GetOverlappedResultEx(hFile.get(), &request, &bytes, INFINITE, FALSE);
     #else
         if (wait)
+        {
             std::ignore = WaitForSingleObject(m_event.get(), INFINITE);
+        }
 
         result = GetOverlappedResult(hFile.get(), &request, &bytes, FALSE);
     #endif

--- a/Src/BinaryReader.cpp
+++ b/Src/BinaryReader.cpp
@@ -56,9 +56,17 @@ HRESULT BinaryReader::ReadEntireFile(
 
     // Open the file.
 #if (_WIN32_WINNT >= _WIN32_WINNT_WIN8)
-    ScopedHandle hFile(safe_handle(CreateFile2(fileName, GENERIC_READ, FILE_SHARE_READ, OPEN_EXISTING, nullptr)));
+    ScopedHandle hFile(safe_handle(CreateFile2(
+        fileName,
+        GENERIC_READ, FILE_SHARE_READ, OPEN_EXISTING,
+        nullptr)));
 #else
-    ScopedHandle hFile(safe_handle(CreateFileW(fileName, GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr)));
+    ScopedHandle hFile(safe_handle(CreateFileW(
+        fileName,
+        GENERIC_READ, FILE_SHARE_READ,
+        nullptr,
+        OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL,
+        nullptr)));
 #endif
 
     if (!hFile)

--- a/Src/LoaderHelpers.h
+++ b/Src/LoaderHelpers.h
@@ -366,19 +366,17 @@ namespace DirectX
 
             // open the file
         #if (_WIN32_WINNT >= _WIN32_WINNT_WIN8)
-            ScopedHandle hFile(safe_handle(CreateFile2(fileName,
-                               GENERIC_READ,
-                               FILE_SHARE_READ,
-                               OPEN_EXISTING,
-                               nullptr)));
+            ScopedHandle hFile(safe_handle(CreateFile2(
+                fileName,
+                GENERIC_READ, FILE_SHARE_READ, OPEN_EXISTING,
+                nullptr)));
         #else
-            ScopedHandle hFile(safe_handle(CreateFileW(fileName,
-                               GENERIC_READ,
-                               FILE_SHARE_READ,
-                               nullptr,
-                               OPEN_EXISTING,
-                               FILE_ATTRIBUTE_NORMAL,
-                               nullptr)));
+            ScopedHandle hFile(safe_handle(CreateFileW(
+                fileName,
+                GENERIC_READ, FILE_SHARE_READ,
+                nullptr,
+                OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL,
+                nullptr)));
         #endif
 
             if (!hFile)

--- a/Src/ScreenGrab.cpp
+++ b/Src/ScreenGrab.cpp
@@ -270,7 +270,10 @@ HRESULT DirectX::SaveDDSTextureToFile(
         return hr;
 
     // Create file
-    ScopedHandle hFile(safe_handle(CreateFile2(fileName, GENERIC_WRITE, 0, CREATE_ALWAYS, nullptr)));
+    ScopedHandle hFile(safe_handle(CreateFile2(
+        fileName,
+        GENERIC_WRITE, 0, CREATE_ALWAYS,
+        nullptr)));
     if (!hFile)
         return HRESULT_FROM_WIN32(GetLastError());
 
@@ -427,7 +430,10 @@ HRESULT DirectX::SaveDDSTextureToFile(
 //--------------------------------------------------------------------------------------
 namespace DirectX
 {
-    extern IWICImagingFactory2* _GetWIC() noexcept;
+    namespace Internal
+    {
+        extern IWICImagingFactory2* GetWIC() noexcept;
+    }
 }
 
 _Use_decl_annotations_
@@ -442,6 +448,8 @@ HRESULT DirectX::SaveWICTextureToFile(
     std::function<void(IPropertyBag2*)> setCustomProps,
     bool forceSRGB)
 {
+    using namespace DirectX::Internal;
+
     if (!fileName)
         return E_INVALIDARG;
 
@@ -534,7 +542,7 @@ HRESULT DirectX::SaveWICTextureToFile(
             return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
     }
 
-    auto pWIC = _GetWIC();
+    auto pWIC = GetWIC();
     if (!pWIC)
         return E_NOINTERFACE;
 

--- a/Src/XboxDDSTextureLoader.cpp
+++ b/Src/XboxDDSTextureLoader.cpp
@@ -85,10 +85,9 @@ namespace
         }
 
         // open the file
-        ScopedHandle hFile(safe_handle(CreateFile2(fileName,
-            GENERIC_READ,
-            FILE_SHARE_READ,
-            OPEN_EXISTING,
+        ScopedHandle hFile(safe_handle(CreateFile2(
+            fileName,
+            GENERIC_READ, FILE_SHARE_READ, OPEN_EXISTING,
             nullptr)));
 
         if (!hFile)

--- a/Src/d3dx12.h
+++ b/Src/d3dx12.h
@@ -2463,16 +2463,16 @@ template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, ty
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
 private:
-    D3D12_PIPELINE_STATE_SUBOBJECT_TYPE _Type;
-    InnerStructType _Inner;
+    D3D12_PIPELINE_STATE_SUBOBJECT_TYPE pssType;
+    InnerStructType pssInner;
 public:
-    CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT() noexcept : _Type(Type), _Inner(DefaultArg()) {}
-    CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT(InnerStructType const& i) noexcept : _Type(Type), _Inner(i) {}
-    CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT& operator=(InnerStructType const& i) noexcept { _Type = Type; _Inner = i; return *this; }
-    operator InnerStructType const&() const noexcept { return _Inner; }
-    operator InnerStructType&() noexcept { return _Inner; }
-    InnerStructType* operator&() noexcept { return &_Inner; }
-    InnerStructType const* operator&() const noexcept { return &_Inner; }
+    CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT() noexcept : pssType(Type), pssInner(DefaultArg()) {}
+    CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT(InnerStructType const& i) noexcept : pssType(Type), pssInner(i) {}
+    CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT& operator=(InnerStructType const& i) noexcept { pssType = Type; pssInner = i; return *this; }
+    operator InnerStructType const&() const noexcept { return pssInner; }
+    operator InnerStructType&() noexcept { return pssInner; }
+    InnerStructType* operator&() noexcept { return &pssInner; }
+    InnerStructType const* operator&() const noexcept { return &pssInner; }
 };
 #pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;


### PR DESCRIPTION
Per the C++ Standard:

> the identifiers that begin with an underscore followed by an uppercase letter are reserved;

I had this in my backlog for some time, but never got around to it until now. Clang v13 (which is in VS 2022 Update 1) has added a new warning for this case: ``-Wreserved-identifier``