### PR TITLE
Update CMake to use DXC from VCPKG

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-cmake_minimum_required (VERSION 3.11)
+cmake_minimum_required (VERSION 3.18)
 
 set(DIRECTXTK12_VERSION 1.4.9)
 
@@ -195,8 +195,9 @@ endif()
 
 if (NOT USE_PREBUILT_SHADERS)
     if (BUILD_DXIL_SHADERS AND VCPKG_TOOLCHAIN)
-        message("INFO: Using VCPKG for DirectXShaderCompiler.")
-        find_package(directx-dxc CONFIG REQUIRED)
+        message("INFO: Using VCPKG for DirectXShaderCompiler (${VCPKG_HOST_TRIPLET}).")
+        find_program(DIRECTX_DXC_TOOL DXC.EXE
+          REQUIRED NO_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH)
     endif()
     add_custom_command(
         OUTPUT "${COMPILED_SHADERS}/SpriteEffect_SpriteVertexShader.inc"
@@ -242,7 +243,7 @@ if(MSVC)
 endif()
 
 if (MINGW OR VCPKG_TOOLCHAIN)
-    message("INFO: Using VCPKG for DirectX-Headers and DirectXMath.")
+    message("INFO: Using VCPKG for DirectX-Headers and DirectXMath (${VCPKG_TARGET_TRIPLET}).")
     find_package(directx-headers CONFIG REQUIRED)
     find_package(directxmath CONFIG REQUIRED)
     target_link_libraries(${PROJECT_NAME} PRIVATE Microsoft::DirectX-Headers Microsoft::DirectXMath)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,12 +194,16 @@ else()
 endif()
 
 if (NOT USE_PREBUILT_SHADERS)
+    if (BUILD_DXIL_SHADERS AND VCPKG_TOOLCHAIN)
+        message("INFO: Using VCPKG for DirectXShaderCompiler.")
+        find_package(directx-dxc CONFIG REQUIRED)
+    endif()
     add_custom_command(
         OUTPUT "${COMPILED_SHADERS}/SpriteEffect_SpriteVertexShader.inc"
         MAIN_DEPENDENCY "${PROJECT_SOURCE_DIR}/Src/Shaders/CompileShaders.cmd"
         DEPENDS ${SHADER_SOURCES}
         COMMENT "Generating HLSL shaders..."
-        COMMAND ${CMAKE_COMMAND} -E env CompileShadersOutput="${COMPILED_SHADERS}" CompileShaders.cmd ARGS ${ShaderOpts} > "${COMPILED_SHADERS}/compileshaders.log"
+        COMMAND ${CMAKE_COMMAND} -E env CompileShadersOutput="${COMPILED_SHADERS}" $<$<BOOL:${DIRECTX_DXC_TOOL}>:DirectXShaderCompiler=${DIRECTX_DXC_TOOL}> CompileShaders.cmd ARGS ${ShaderOpts} > "${COMPILED_SHADERS}/compileshaders.log"
         WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/Src/Shaders"
         USES_TERMINAL)
 endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -112,6 +112,44 @@
       "hidden": true
     },
     {
+      "name": "X64_X86",
+      "hidden": true,
+      "cacheVariables": {
+        "VCPKG_TARGET_TRIPLET": "x86-windows",
+        "VCPKG_HOST_TRIPLET": "x64-windows"
+      }
+    },
+    {
+      "name": "X64_ARM64",
+      "hidden": true,
+      "cacheVariables": {
+        "VCPKG_TARGET_TRIPLET": "arm64-windows",
+        "VCPKG_HOST_TRIPLET": "x64-windows"
+      }
+    },
+    {
+      "name": "MinGW32",
+      "hidden": true,
+      "environment": {
+        "PATH": "$penv{PATH};c:/mingw32/bin"
+      },
+      "cacheVariables": {
+        "VCPKG_TARGET_TRIPLET": "x86-mingw-static",
+        "VCPKG_HOST_TRIPLET": "x64-mingw-static"
+      }
+    },
+    {
+      "name": "MinGW64",
+      "hidden": true,
+      "environment": {
+        "PATH": "$penv{PATH};c:/mingw64/bin"
+      },
+      "cacheVariables": {
+        "VCPKG_TARGET_TRIPLET": "x64-mingw-static",
+        "VCPKG_HOST_TRIPLET": "x64-mingw-static"
+      }
+    },
+    {
       "name": "XAudio2Redist",
       "cacheVariables": {
         "BUILD_XAUDIO_WIN10": false,
@@ -138,10 +176,10 @@
 
     { "name": "x64-Debug-VCPKG"    , "description": "MSVC for x64 (Debug)", "inherits": [ "base", "x64", "Debug", "MSVC", "VCPKG", "XAudio2Redist" ] },
     { "name": "x64-Release-VCPKG"  , "description": "MSVC for x64 (Release)", "inherits": [ "base", "x64", "Release", "MSVC", "VCPKG", "XAudio2Redist" ] },
-    { "name": "x86-Debug-VCPKG"    , "description": "MSVC for x86 (Debug)", "inherits": [ "base", "x86", "Debug", "MSVC", "VCPKG", "XAudio2Redist" ] },
-    { "name": "x86-Release-VCPKG"  , "description": "MSVC for x86 (Release)", "inherits": [ "base", "x86", "Release", "MSVC", "VCPKG", "XAudio2Redist" ] },
-    { "name": "arm64-Debug-VCPKG"  , "description": "MSVC for ARM64 (Debug)", "inherits": [ "base", "ARM64", "Debug", "MSVC", "VCPKG" ] },
-    { "name": "arm64-Release-VCPKG", "description": "MSVC for ARM64 (Release)", "inherits": [ "base", "ARM64", "Release", "MSVC", "VCPKG" ] },
+    { "name": "x86-Debug-VCPKG"    , "description": "MSVC for x86 (Debug)", "inherits": [ "base", "x86", "Debug", "MSVC", "VCPKG", "XAudio2Redist", "X64_X86" ] },
+    { "name": "x86-Release-VCPKG"  , "description": "MSVC for x86 (Release)", "inherits": [ "base", "x86", "Release", "MSVC", "VCPKG", "XAudio2Redist", "X64_X86" ] },
+    { "name": "arm64-Debug-VCPKG"  , "description": "MSVC for ARM64 (Debug)", "inherits": [ "base", "ARM64", "Debug", "MSVC", "VCPKG", "X64_ARM64" ] },
+    { "name": "arm64-Release-VCPKG", "description": "MSVC for ARM64 (Release)", "inherits": [ "base", "ARM64", "Release", "MSVC", "VCPKG", "X64_ARM64" ] },
 
     { "name": "x64-Debug-Clang"    , "description": "Clang/LLVM for x64 (Debug) for Windows 10", "inherits": [ "base", "x64", "Debug", "Clang" ] },
     { "name": "x64-Release-Clang"  , "description": "Clang/LLVM for x64 (Release) for Windows 10", "inherits": [ "base", "x64", "Release", "Clang" ] },
@@ -157,9 +195,9 @@
     { "name": "arm64-Debug-UWP-Clang"  , "description": "Clang/LLVM for AArch64 (Debug) for UWP", "inherits": [ "base", "ARM64", "Debug", "Clang", "UWP" ], "environment": { "CXXFLAGS": "--target=arm64-pc-windows-msvc" } },
     { "name": "arm64-Release-UWP-Clang", "description": "Clang/LLVM for AArch64 (Release) for UWP", "inherits": [ "base", "ARM64", "Release", "Clang", "UWP" ], "environment": { "CXXFLAGS": "--target=arm64-pc-windows-msvc" } },
 
-    { "name": "x64-Debug-MinGW"  , "description": "MinG-W64 (Debug)", "inherits": [ "base", "x64", "Debug", "GNUC", "VCPKG", "XAudio2Redist" ], "environment": { "PATH": "$penv{PATH};c:/mingw64/bin" } },
-    { "name": "x64-Release-MinGW", "description": "MinG-W64 (Release)", "inherits": [ "base", "x64", "Release", "GNUC", "VCPKG", "XAudio2Redist" ], "environment": { "PATH": "$penv{PATH};c:/mingw64/bin" } },
-    { "name": "x86-Debug-MinGW"  , "description": "MinG-W32 (Debug)", "inherits": [ "base", "x86", "Debug", "GNUC", "VCPKG", "XAudio2Redist" ], "environment": { "PATH": "$penv{PATH};c:/mingw32/bin" } },
-    { "name": "x86-Release-MinGW", "description": "MinG-W32 (Release)", "inherits": [ "base", "x86", "Release", "GNUC", "VCPKG", "XAudio2Redist" ], "environment": { "PATH": "$penv{PATH};c:/mingw32/bin" } }
+    { "name": "x64-Debug-MinGW"  , "description": "MinG-W64 (Debug)", "inherits": [ "base", "x64", "Debug", "GNUC", "VCPKG", "XAudio2Redist", "MinGW64" ] },
+    { "name": "x64-Release-MinGW", "description": "MinG-W64 (Release)", "inherits": [ "base", "x64", "Release", "GNUC", "VCPKG", "XAudio2Redist", "MinGW64" ] },
+    { "name": "x86-Debug-MinGW"  , "description": "MinG-W32 (Debug)", "inherits": [ "base", "x86", "Debug", "GNUC", "VCPKG", "XAudio2Redist", "MinGW32" ] },
+    { "name": "x86-Release-MinGW", "description": "MinG-W32 (Release)", "inherits": [ "base", "x86", "Release", "GNUC", "VCPKG", "XAudio2Redist", "MinGW32" ] }
   ]
 }

--- a/Src/Shaders/CompileShaders.cmd
+++ b/Src/Shaders/CompileShaders.cmd
@@ -46,6 +46,7 @@ if not exist %XBOXDXC% goto needgxdk
 goto continue
 
 :continuedxil
+if defined DirectXShaderCompiler goto dxcviaenv
 set PCDXC="%WindowsSdkVerBinPath%x86\dxc.exe"
 if exist %PCDXC% goto continue
 set PCDXC="%WindowsSdkBinPath%%WindowsSDKVersion%\x86\dxc.exe"
@@ -53,6 +54,11 @@ if exist %PCDXC% goto continue
 
 set PCDXC=dxc.exe
 goto continue
+
+:dxcviaenv
+set PCDXC="%DirectXShaderCompiler%"
+if exist %PCDXC% goto continue
+goto needdxil
 
 :continuepc
 set PCOPTS=
@@ -342,9 +348,13 @@ exit /b
 :needxdk
 echo ERROR: CompileShaders xbox requires the Microsoft Xbox One XDK
 echo        (try re-running from the XDK Command Prompt)
-exit /b
+exit /b 1
 
 :needgxdk
 echo ERROR: CompileShaders gxdk requires the Microsoft Gaming SDK
 echo        (try re-running from the Gaming GXDK Command Prompt)
-exit /b
+exit /b 1
+
+:needdxil
+echo ERROR: CompileShaders dxil requires DXC.EXE
+exit /b 1


### PR DESCRIPTION
VCPKG now has a [directx-dxc](https://github.com/microsoft/vcpkg/tree/master/ports/directx-dxc) port which provides the latest DXC.EXE compiler binary fetched from GitHub. This updates the *DirectX Tool Kit for DX12* CMakeLists to utilize this port when building with VCPKG.

> At the moment, the **directx-dxc** port only runs on x64-windows. It will find port for other target platforms by using the x64-windows host triplet as a 'tools' port. We do not use the CMake target from it, so this works fine.

> ARM64 native support is planned for the next update on GitHub of DXC.
