### PR TITLE
Add use of C++11 inline namespaces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,8 @@ option(USE_PREBUILT_SHADERS "Use externally built HLSL shaders" OFF)
 
 option(BUILD_DXIL_SHADERS "Use DXC Shader Model 6 for shaders" ON)
 
+option(BUILD_MIXED_DX11 "Support linking with DX11 version of toolkit" OFF)
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -51,39 +53,28 @@ set(LIBRARY_HEADERS
     Inc/DirectXHelpers.h
     Inc/Effects.h
     Inc/EffectPipelineStateDescription.h
-    Inc/GamePad.h
     Inc/GeometricPrimitive.h
     Inc/GraphicsMemory.h
-    Inc/Keyboard.h
     Inc/Model.h
-    Inc/Mouse.h
     Inc/PostProcess.h
     Inc/PrimitiveBatch.h
     Inc/RenderTargetState.h
     Inc/ResourceUploadBatch.h
     Inc/ScreenGrab.h
-    Inc/SimpleMath.h
-    Inc/SimpleMath.inl
     Inc/SpriteBatch.h
     Inc/SpriteFont.h
     Inc/VertexTypes.h
     Inc/WICTextureLoader.h)
 
 set(LIBRARY_SOURCES
-    Src/AlignedNew.h
     Src/AlphaTestEffect.cpp
     Src/BasicEffect.cpp
     Src/BasicPostProcess.cpp
-    Src/Bezier.h
-    Src/BinaryReader.cpp
-    Src/BinaryReader.h
     Src/BufferHelpers.cpp
     Src/CommonStates.cpp
     Src/d3dx12.h
-    Src/DDS.h
     Src/DDSTextureLoader.cpp
     Src/DebugEffect.cpp
-    Src/DemandCreate.h
     Src/DescriptorHeap.cpp
     Src/DirectXHelpers.cpp
     Src/DualPostProcess.cpp
@@ -94,60 +85,82 @@ set(LIBRARY_SOURCES
     Src/EffectPipelineStateDescription.cpp
     Src/EffectTextureFactory.cpp
     Src/EnvironmentMapEffect.cpp
-    Src/GamePad.cpp
     Src/GeometricPrimitive.cpp
-    Src/Geometry.h
-    Src/Geometry.cpp
     Src/GraphicsMemory.cpp
-    Src/Keyboard.cpp
     Src/LinearAllocator.cpp
     Src/LinearAllocator.h
-    Src/LoaderHelpers.h
     Src/Model.cpp
     Src/ModelLoadCMO.cpp
     Src/ModelLoadSDKMESH.cpp
     Src/ModelLoadVBO.cpp
-    Src/Mouse.cpp
     Src/NormalMapEffect.cpp
     Src/PBREffect.cpp
     Src/PBREffectFactory.cpp
     Src/pch.h
-    Src/PlatformHelpers.h
     Src/PrimitiveBatch.cpp
     Src/ResourceUploadBatch.cpp
     Src/ScreenGrab.cpp
-    Src/SDKMesh.h
-    Src/SharedResourcePool.h
-    Src/SimpleMath.cpp
     Src/SkinnedEffect.cpp
     Src/SpriteBatch.cpp
     Src/SpriteFont.cpp
-    Src/TeapotData.inc
     Src/ToneMapPostProcess.cpp
-    Src/vbo.h
     Src/VertexTypes.cpp
     Src/WICTextureLoader.cpp)
 
 set(SHADER_SOURCES
     Src/Shaders/AlphaTestEffect.fx
     Src/Shaders/BasicEffect.fx
-    Src/Shaders/Common.fxh
     Src/Shaders/DebugEffect.fx
     Src/Shaders/DualTextureEffect.fx
     Src/Shaders/EnvironmentMapEffect.fx
     Src/Shaders/GenerateMips.hlsl
-    Src/Shaders/Lighting.fxh
     Src/Shaders/NormalMapEffect.fx
-    Src/Shaders/PBRCommon.fxh
     Src/Shaders/PBREffect.fx
-    Src/Shaders/PixelPacking_Velocity.hlsli
     Src/Shaders/PostProcess.fx
     Src/Shaders/RootSig.fxh
     Src/Shaders/SkinnedEffect.fx
-    Src/Shaders/Skinning.fxh
     Src/Shaders/SpriteEffect.fx
+    Src/Shaders/ToneMap.fx)
+
+# These source files are identical in both DX11 and DX12 version.
+if (NOT BUILD_MIXED_DX11)
+    set(LIBRARY_HEADERS ${LIBRARY_HEADERS}
+      Inc/GamePad.h
+      Inc/Keyboard.h
+      Inc/Mouse.h
+      Inc/SimpleMath.h
+      Inc/SimpleMath.inl)
+
+    set(LIBRARY_SOURCES ${LIBRARY_SOURCES}
+      Src/BinaryReader.cpp
+      Src/GamePad.cpp
+      Src/Geometry.cpp
+      Src/Keyboard.cpp
+      Src/Mouse.cpp
+      Src/SimpleMath.cpp)
+endif()
+
+set(LIBRARY_SOURCES ${LIBRARY_SOURCES}
+    Src/AlignedNew.h
+    Src/Bezier.h
+    Src/BinaryReader.h
+    Src/DDS.h
+    Src/DemandCreate.h
+    Src/Geometry.h
+    Src/LoaderHelpers.h
+    Src/PlatformHelpers.h
+    Src/SDKMesh.h
+    Src/SharedResourcePool.h
+    Src/vbo.h
+    Src/TeapotData.inc)
+
+set(SHADER_SOURCES ${SHADER_SOURCES}
+    Src/Shaders/Common.fxh
+    Src/Shaders/Lighting.fxh
+    Src/Shaders/PBRCommon.fxh
+    Src/Shaders/PixelPacking_Velocity.hlsli
+    Src/Shaders/Skinning.fxh
     Src/Shaders/Structures.fxh
-    Src/Shaders/ToneMap.fx
     Src/Shaders/Utilities.fxh)
 
 if(MINGW)

--- a/Inc/CommonStates.h
+++ b/Inc/CommonStates.h
@@ -25,71 +25,74 @@
 
 namespace DirectX
 {
-    class CommonStates
+    inline namespace DX12
     {
-    public:
-        explicit CommonStates(_In_ ID3D12Device* device);
-
-        CommonStates(CommonStates&&) noexcept;
-        CommonStates& operator = (CommonStates&&) noexcept;
-
-        CommonStates(const CommonStates&) = delete;
-        CommonStates& operator = (const CommonStates&) = delete;
-
-        virtual ~CommonStates();
-
-        // Blend states.
-        static const D3D12_BLEND_DESC Opaque;
-        static const D3D12_BLEND_DESC AlphaBlend;
-        static const D3D12_BLEND_DESC Additive;
-        static const D3D12_BLEND_DESC NonPremultiplied;
-
-        // Depth stencil states.
-        static const D3D12_DEPTH_STENCIL_DESC DepthNone;
-        static const D3D12_DEPTH_STENCIL_DESC DepthDefault;
-        static const D3D12_DEPTH_STENCIL_DESC DepthRead;
-        static const D3D12_DEPTH_STENCIL_DESC DepthReverseZ;
-        static const D3D12_DEPTH_STENCIL_DESC DepthReadReverseZ;
-
-        // Rasterizer states.
-        static const D3D12_RASTERIZER_DESC CullNone;
-        static const D3D12_RASTERIZER_DESC CullClockwise;
-        static const D3D12_RASTERIZER_DESC CullCounterClockwise;
-        static const D3D12_RASTERIZER_DESC Wireframe;
-
-        // Static sampler states.
-        static const D3D12_STATIC_SAMPLER_DESC StaticPointWrap(unsigned int shaderRegister, D3D12_SHADER_VISIBILITY shaderVisibility = D3D12_SHADER_VISIBILITY_ALL, unsigned int registerSpace = 0) noexcept;
-        static const D3D12_STATIC_SAMPLER_DESC StaticPointClamp(unsigned int shaderRegister, D3D12_SHADER_VISIBILITY shaderVisibility = D3D12_SHADER_VISIBILITY_ALL, unsigned int registerSpace = 0) noexcept;
-        static const D3D12_STATIC_SAMPLER_DESC StaticLinearWrap(unsigned int shaderRegister, D3D12_SHADER_VISIBILITY shaderVisibility = D3D12_SHADER_VISIBILITY_ALL, unsigned int registerSpace = 0) noexcept;
-        static const D3D12_STATIC_SAMPLER_DESC StaticLinearClamp(unsigned int shaderRegister, D3D12_SHADER_VISIBILITY shaderVisibility = D3D12_SHADER_VISIBILITY_ALL, unsigned int registerSpace = 0) noexcept;
-        static const D3D12_STATIC_SAMPLER_DESC StaticAnisotropicWrap(unsigned int shaderRegister, D3D12_SHADER_VISIBILITY shaderVisibility = D3D12_SHADER_VISIBILITY_ALL, unsigned int registerSpace = 0) noexcept;
-        static const D3D12_STATIC_SAMPLER_DESC StaticAnisotropicClamp(unsigned int shaderRegister, D3D12_SHADER_VISIBILITY shaderVisibility = D3D12_SHADER_VISIBILITY_ALL, unsigned int registerSpace = 0) noexcept;
-
-        // Sampler states.
-        D3D12_GPU_DESCRIPTOR_HANDLE PointWrap() const;
-        D3D12_GPU_DESCRIPTOR_HANDLE PointClamp() const;
-        D3D12_GPU_DESCRIPTOR_HANDLE LinearWrap() const;
-        D3D12_GPU_DESCRIPTOR_HANDLE LinearClamp() const;
-        D3D12_GPU_DESCRIPTOR_HANDLE AnisotropicWrap() const;
-        D3D12_GPU_DESCRIPTOR_HANDLE AnisotropicClamp() const;
-
-        // These index into the heap returned by SamplerDescriptorHeap
-        enum class SamplerIndex
+        class CommonStates
         {
-            PointWrap,
-            PointClamp,
-            LinearWrap,
-            LinearClamp,
-            AnisotropicWrap,
-            AnisotropicClamp,
-            Count
+        public:
+            explicit CommonStates(_In_ ID3D12Device* device);
+
+            CommonStates(CommonStates&&) noexcept;
+            CommonStates& operator = (CommonStates&&) noexcept;
+
+            CommonStates(const CommonStates&) = delete;
+            CommonStates& operator = (const CommonStates&) = delete;
+
+            virtual ~CommonStates();
+
+            // Blend states.
+            static const D3D12_BLEND_DESC Opaque;
+            static const D3D12_BLEND_DESC AlphaBlend;
+            static const D3D12_BLEND_DESC Additive;
+            static const D3D12_BLEND_DESC NonPremultiplied;
+
+            // Depth stencil states.
+            static const D3D12_DEPTH_STENCIL_DESC DepthNone;
+            static const D3D12_DEPTH_STENCIL_DESC DepthDefault;
+            static const D3D12_DEPTH_STENCIL_DESC DepthRead;
+            static const D3D12_DEPTH_STENCIL_DESC DepthReverseZ;
+            static const D3D12_DEPTH_STENCIL_DESC DepthReadReverseZ;
+
+            // Rasterizer states.
+            static const D3D12_RASTERIZER_DESC CullNone;
+            static const D3D12_RASTERIZER_DESC CullClockwise;
+            static const D3D12_RASTERIZER_DESC CullCounterClockwise;
+            static const D3D12_RASTERIZER_DESC Wireframe;
+
+            // Static sampler states.
+            static const D3D12_STATIC_SAMPLER_DESC StaticPointWrap(unsigned int shaderRegister, D3D12_SHADER_VISIBILITY shaderVisibility = D3D12_SHADER_VISIBILITY_ALL, unsigned int registerSpace = 0) noexcept;
+            static const D3D12_STATIC_SAMPLER_DESC StaticPointClamp(unsigned int shaderRegister, D3D12_SHADER_VISIBILITY shaderVisibility = D3D12_SHADER_VISIBILITY_ALL, unsigned int registerSpace = 0) noexcept;
+            static const D3D12_STATIC_SAMPLER_DESC StaticLinearWrap(unsigned int shaderRegister, D3D12_SHADER_VISIBILITY shaderVisibility = D3D12_SHADER_VISIBILITY_ALL, unsigned int registerSpace = 0) noexcept;
+            static const D3D12_STATIC_SAMPLER_DESC StaticLinearClamp(unsigned int shaderRegister, D3D12_SHADER_VISIBILITY shaderVisibility = D3D12_SHADER_VISIBILITY_ALL, unsigned int registerSpace = 0) noexcept;
+            static const D3D12_STATIC_SAMPLER_DESC StaticAnisotropicWrap(unsigned int shaderRegister, D3D12_SHADER_VISIBILITY shaderVisibility = D3D12_SHADER_VISIBILITY_ALL, unsigned int registerSpace = 0) noexcept;
+            static const D3D12_STATIC_SAMPLER_DESC StaticAnisotropicClamp(unsigned int shaderRegister, D3D12_SHADER_VISIBILITY shaderVisibility = D3D12_SHADER_VISIBILITY_ALL, unsigned int registerSpace = 0) noexcept;
+
+            // Sampler states.
+            D3D12_GPU_DESCRIPTOR_HANDLE PointWrap() const;
+            D3D12_GPU_DESCRIPTOR_HANDLE PointClamp() const;
+            D3D12_GPU_DESCRIPTOR_HANDLE LinearWrap() const;
+            D3D12_GPU_DESCRIPTOR_HANDLE LinearClamp() const;
+            D3D12_GPU_DESCRIPTOR_HANDLE AnisotropicWrap() const;
+            D3D12_GPU_DESCRIPTOR_HANDLE AnisotropicClamp() const;
+
+            // These index into the heap returned by SamplerDescriptorHeap
+            enum class SamplerIndex
+            {
+                PointWrap,
+                PointClamp,
+                LinearWrap,
+                LinearClamp,
+                AnisotropicWrap,
+                AnisotropicClamp,
+                Count
+            };
+
+            ID3D12DescriptorHeap* Heap() const noexcept;
+
+        private:
+            class Impl;
+
+            std::unique_ptr<Impl> pImpl;
         };
-
-        ID3D12DescriptorHeap* Heap() const noexcept;
-
-    private:
-        class Impl;
-
-        std::unique_ptr<Impl> pImpl;
-    };
+    }
 }

--- a/Inc/DDSTextureLoader.h
+++ b/Inc/DDSTextureLoader.h
@@ -48,14 +48,17 @@ namespace DirectX
     };
 #endif
 
-    enum DDS_LOADER_FLAGS : uint32_t
+    inline namespace DX12
     {
-        DDS_LOADER_DEFAULT = 0,
-        DDS_LOADER_FORCE_SRGB = 0x1,
-        DDS_LOADER_IGNORE_SRGB = 0x2,
-        DDS_LOADER_MIP_AUTOGEN = 0x8,
-        DDS_LOADER_MIP_RESERVE = 0x10,
-    };
+        enum DDS_LOADER_FLAGS : uint32_t
+        {
+            DDS_LOADER_DEFAULT = 0,
+            DDS_LOADER_FORCE_SRGB = 0x1,
+            DDS_LOADER_IGNORE_SRGB = 0x2,
+            DDS_LOADER_MIP_AUTOGEN = 0x8,
+            DDS_LOADER_MIP_RESERVE = 0x10,
+        };
+    }
 
     // Standard version
     HRESULT __cdecl LoadDDSTextureFromMemory(
@@ -154,7 +157,10 @@ namespace DirectX
 #pragma clang diagnostic ignored "-Wdeprecated-dynamic-exception-spec"
 #endif
 
-    DEFINE_ENUM_FLAG_OPERATORS(DDS_LOADER_FLAGS);
+    inline namespace DX12
+    {
+        DEFINE_ENUM_FLAG_OPERATORS(DDS_LOADER_FLAGS);
+    }
 
 #ifdef __clang__
 #pragma clang diagnostic pop

--- a/Inc/DirectXHelpers.h
+++ b/Inc/DirectXHelpers.h
@@ -286,32 +286,35 @@ namespace DirectX
         std::vector<D3D12_RESOURCE_BARRIER> mBarriers;
     };
 
-    // Helper to check for power-of-2
-    template<typename T>
-    constexpr bool IsPowerOf2(T x) noexcept { return ((x != 0) && !(x & (x - 1))); }
-
-    // Helpers for aligning values by a power of 2
-    template<typename T>
-    inline T AlignDown(T size, size_t alignment) noexcept
+    inline namespace DX12
     {
-        if (alignment > 0)
-        {
-            assert(((alignment - 1) & alignment) == 0);
-            auto mask = static_cast<T>(alignment - 1);
-            return size & ~mask;
-        }
-        return size;
-    }
+        // Helper to check for power-of-2
+        template<typename T>
+        constexpr bool IsPowerOf2(T x) noexcept { return ((x != 0) && !(x & (x - 1))); }
 
-    template<typename T>
-    inline T AlignUp(T size, size_t alignment) noexcept
-    {
-        if (alignment > 0)
+        // Helpers for aligning values by a power of 2
+        template<typename T>
+        inline T AlignDown(T size, size_t alignment) noexcept
         {
-            assert(((alignment - 1) & alignment) == 0);
-            auto mask = static_cast<T>(alignment - 1);
-            return (size + mask) & ~mask;
+            if (alignment > 0)
+            {
+                assert(((alignment - 1) & alignment) == 0);
+                auto mask = static_cast<T>(alignment - 1);
+                return size & ~mask;
+            }
+            return size;
         }
-        return size;
+
+        template<typename T>
+        inline T AlignUp(T size, size_t alignment) noexcept
+        {
+            if (alignment > 0)
+            {
+                assert(((alignment - 1) & alignment) == 0);
+                auto mask = static_cast<T>(alignment - 1);
+                return (size + mask) & ~mask;
+            }
+            return size;
+        }
     }
 }

--- a/Inc/Effects.h
+++ b/Inc/Effects.h
@@ -36,892 +36,895 @@ namespace DirectX
     class DescriptorHeap;
     class ResourceUploadBatch;
 
-    //----------------------------------------------------------------------------------
-    // Abstract interface representing any effect which can be applied onto a D3D device context.
-    class IEffect
+    inline namespace DX12
     {
-    public:
-        virtual ~IEffect() = default;
-
-        IEffect(const IEffect&) = delete;
-        IEffect& operator=(const IEffect&) = delete;
-
-        virtual void __cdecl Apply(_In_ ID3D12GraphicsCommandList* commandList) = 0;
-
-    protected:
-        IEffect() = default;
-        IEffect(IEffect&&) = default;
-        IEffect& operator=(IEffect&&) = default;
-    };
-
-
-    // Abstract interface for effects with world, view, and projection matrices.
-    class IEffectMatrices
-    {
-    public:
-        virtual ~IEffectMatrices() = default;
-
-        IEffectMatrices(const IEffectMatrices&) = delete;
-        IEffectMatrices& operator=(const IEffectMatrices&) = delete;
-
-        virtual void XM_CALLCONV SetWorld(FXMMATRIX value) = 0;
-        virtual void XM_CALLCONV SetView(FXMMATRIX value) = 0;
-        virtual void XM_CALLCONV SetProjection(FXMMATRIX value) = 0;
-        virtual void XM_CALLCONV SetMatrices(FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection);
-
-    protected:
-        IEffectMatrices() = default;
-        IEffectMatrices(IEffectMatrices&&) = default;
-        IEffectMatrices& operator=(IEffectMatrices&&) = default;
-    };
-
-
-    // Abstract interface for effects which support directional lighting.
-    class IEffectLights
-    {
-    public:
-        virtual ~IEffectLights() = default;
-
-        IEffectLights(const IEffectLights&) = delete;
-        IEffectLights& operator=(const IEffectLights&) = delete;
-
-        virtual void XM_CALLCONV SetAmbientLightColor(FXMVECTOR value) = 0;
-
-        virtual void __cdecl SetLightEnabled(int whichLight, bool value) = 0;
-        virtual void XM_CALLCONV SetLightDirection(int whichLight, FXMVECTOR value) = 0;
-        virtual void XM_CALLCONV SetLightDiffuseColor(int whichLight, FXMVECTOR value) = 0;
-        virtual void XM_CALLCONV SetLightSpecularColor(int whichLight, FXMVECTOR value) = 0;
-
-        virtual void __cdecl EnableDefaultLighting() = 0;
-
-        static constexpr int MaxDirectionalLights = 3;
-
-    protected:
-        IEffectLights() = default;
-        IEffectLights(IEffectLights&&) = default;
-        IEffectLights& operator=(IEffectLights&&) = default;
-    };
-
-
-    // Abstract interface for effects which support fog.
-    class IEffectFog
-    {
-    public:
-        virtual ~IEffectFog() = default;
-
-        IEffectFog(const IEffectFog&) = delete;
-        IEffectFog& operator=(const IEffectFog&) = delete;
-
-        virtual void __cdecl SetFogStart(float value) = 0;
-        virtual void __cdecl SetFogEnd(float value) = 0;
-        virtual void XM_CALLCONV SetFogColor(FXMVECTOR value) = 0;
-
-    protected:
-        IEffectFog() = default;
-        IEffectFog(IEffectFog&&) = default;
-        IEffectFog& operator=(IEffectFog&&) = default;
-    };
-
-
-    // Abstract interface for effects which support skinning
-    class IEffectSkinning
-    {
-    public:
-        virtual ~IEffectSkinning() = default;
-
-        IEffectSkinning(const IEffectSkinning&) = delete;
-        IEffectSkinning& operator=(const IEffectSkinning&) = delete;
-
-        virtual void __cdecl SetBoneTransforms(_In_reads_(count) XMMATRIX const* value, size_t count) = 0;
-        virtual void __cdecl ResetBoneTransforms() = 0;
-
-        static constexpr int MaxBones = 72;
-
-    protected:
-        IEffectSkinning() = default;
-        IEffectSkinning(IEffectSkinning&&) = default;
-        IEffectSkinning& operator=(IEffectSkinning&&) = default;
-    };
-
-
-    //----------------------------------------------------------------------------------
-    namespace EffectFlags
-    {
-        constexpr uint32_t None = 0x00;
-        constexpr uint32_t Fog = 0x01;
-        constexpr uint32_t Lighting = 0x02;
-
-        constexpr uint32_t PerPixelLighting = 0x04 | Lighting;
-        // per pixel lighting implies lighting enabled
-
-        constexpr uint32_t VertexColor = 0x08;
-        constexpr uint32_t Texture = 0x10;
-        constexpr uint32_t Instancing = 0x20;
-
-        constexpr uint32_t Specular = 0x100;
-        // enable optional specular/specularMap feature
-
-        constexpr uint32_t Emissive = 0x200;
-        // enable optional emissive/emissiveMap feature
-
-        constexpr uint32_t Fresnel = 0x400;
-        // enable optional Fresnel feature
-
-        constexpr uint32_t Velocity = 0x800;
-        // enable optional velocity feature
-
-        constexpr uint32_t BiasedVertexNormals = 0x10000;
-        // compressed vertex normals need x2 bias
-    }
-
-
-    //----------------------------------------------------------------------------------
-    // Built-in shader supports optional texture mapping, vertex coloring, directional lighting, and fog.
-    class BasicEffect : public IEffect, public IEffectMatrices, public IEffectLights, public IEffectFog
-    {
-    public:
-        BasicEffect(_In_ ID3D12Device* device, uint32_t effectFlags, const EffectPipelineStateDescription& pipelineDescription);
-
-        BasicEffect(BasicEffect&&) noexcept;
-        BasicEffect& operator= (BasicEffect&&) noexcept;
-
-        BasicEffect(BasicEffect const&) = delete;
-        BasicEffect& operator= (BasicEffect const&) = delete;
-
-        ~BasicEffect() override;
-
-        // IEffect methods.
-        void __cdecl Apply(_In_ ID3D12GraphicsCommandList* commandList) override;
-
-        // Camera settings.
-        void XM_CALLCONV SetWorld(FXMMATRIX value) override;
-        void XM_CALLCONV SetView(FXMMATRIX value) override;
-        void XM_CALLCONV SetProjection(FXMMATRIX value) override;
-        void XM_CALLCONV SetMatrices(FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection) override;
-
-        // Material settings.
-        void XM_CALLCONV SetDiffuseColor(FXMVECTOR value);
-        void XM_CALLCONV SetEmissiveColor(FXMVECTOR value);
-        void XM_CALLCONV SetSpecularColor(FXMVECTOR value);
-        void __cdecl SetSpecularPower(float value);
-        void __cdecl DisableSpecular();
-        void __cdecl SetAlpha(float value);
-        void XM_CALLCONV SetColorAndAlpha(FXMVECTOR value);
-
-        // Light settings.
-        void XM_CALLCONV SetAmbientLightColor(FXMVECTOR value) override;
-
-        void __cdecl SetLightEnabled(int whichLight, bool value) override;
-        void XM_CALLCONV SetLightDirection(int whichLight, FXMVECTOR value) override;
-        void XM_CALLCONV SetLightDiffuseColor(int whichLight, FXMVECTOR value) override;
-        void XM_CALLCONV SetLightSpecularColor(int whichLight, FXMVECTOR value) override;
-
-        void __cdecl EnableDefaultLighting() override;
-
-        // Fog settings.
-        void __cdecl SetFogStart(float value) override;
-        void __cdecl SetFogEnd(float value) override;
-        void XM_CALLCONV SetFogColor(FXMVECTOR value) override;
-
-        // Texture setting.
-        void __cdecl SetTexture(D3D12_GPU_DESCRIPTOR_HANDLE srvDescriptor, D3D12_GPU_DESCRIPTOR_HANDLE samplerDescriptor);
-
-    private:
-        // Private implementation.
-        class Impl;
-
-        std::unique_ptr<Impl> pImpl;
-    };
-
-
-    // Built-in shader supports per-pixel alpha testing.
-    class AlphaTestEffect : public IEffect, public IEffectMatrices, public IEffectFog
-    {
-    public:
-        AlphaTestEffect(_In_ ID3D12Device* device, uint32_t effectFlags,
-            const EffectPipelineStateDescription& pipelineDescription,
-            D3D12_COMPARISON_FUNC alphaFunction = D3D12_COMPARISON_FUNC_GREATER);
-
-        AlphaTestEffect(AlphaTestEffect&&) noexcept;
-        AlphaTestEffect& operator= (AlphaTestEffect&&) noexcept;
-
-        AlphaTestEffect(AlphaTestEffect const&) = delete;
-        AlphaTestEffect& operator= (AlphaTestEffect const&) = delete;
-
-        ~AlphaTestEffect() override;
-
-        // IEffect methods.
-        void __cdecl Apply(_In_ ID3D12GraphicsCommandList* commandList) override;
-
-        // Camera settings.
-        void XM_CALLCONV SetWorld(FXMMATRIX value) override;
-        void XM_CALLCONV SetView(FXMMATRIX value) override;
-        void XM_CALLCONV SetProjection(FXMMATRIX value) override;
-        void XM_CALLCONV SetMatrices(FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection) override;
-
-        // Material settings.
-        void XM_CALLCONV SetDiffuseColor(FXMVECTOR value);
-        void __cdecl SetAlpha(float value);
-        void XM_CALLCONV SetColorAndAlpha(FXMVECTOR value);
-
-        // Fog settings.
-        void __cdecl SetFogStart(float value) override;
-        void __cdecl SetFogEnd(float value) override;
-        void XM_CALLCONV SetFogColor(FXMVECTOR value) override;
-
-        // Texture setting.
-        void __cdecl SetTexture(D3D12_GPU_DESCRIPTOR_HANDLE srvDescriptor, D3D12_GPU_DESCRIPTOR_HANDLE samplerDescriptor);
-
-        // Alpha test settings.
-        void __cdecl SetReferenceAlpha(int value);
-
-    private:
-        // Private implementation.
-        class Impl;
-
-        std::unique_ptr<Impl> pImpl;
-    };
-
-
-    // Built-in shader supports two layer multitexturing (eg. for lightmaps or detail textures).
-    class DualTextureEffect : public IEffect, public IEffectMatrices, public IEffectFog
-    {
-    public:
-        DualTextureEffect(_In_ ID3D12Device* device, uint32_t effectFlags,
-            const EffectPipelineStateDescription& pipelineDescription);
-
-        DualTextureEffect(DualTextureEffect&&) noexcept;
-        DualTextureEffect& operator= (DualTextureEffect&&) noexcept;
-
-        DualTextureEffect(DualTextureEffect const&) = delete;
-        DualTextureEffect& operator= (DualTextureEffect const&) = delete;
-
-        ~DualTextureEffect() override;
-
-        // IEffect methods.
-        void __cdecl Apply(_In_ ID3D12GraphicsCommandList* commandList) override;
-
-        // Camera settings.
-        void XM_CALLCONV SetWorld(FXMMATRIX value) override;
-        void XM_CALLCONV SetView(FXMMATRIX value) override;
-        void XM_CALLCONV SetProjection(FXMMATRIX value) override;
-        void XM_CALLCONV SetMatrices(FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection) override;
-
-        // Material settings.
-        void XM_CALLCONV SetDiffuseColor(FXMVECTOR value);
-        void __cdecl SetAlpha(float value);
-        void XM_CALLCONV SetColorAndAlpha(FXMVECTOR value);
-
-        // Fog settings.
-        void __cdecl SetFogStart(float value) override;
-        void __cdecl SetFogEnd(float value) override;
-        void XM_CALLCONV SetFogColor(FXMVECTOR value) override;
-
-        // Texture settings.
-        void __cdecl SetTexture(D3D12_GPU_DESCRIPTOR_HANDLE srvDescriptor, D3D12_GPU_DESCRIPTOR_HANDLE samplerDescriptor);
-        void __cdecl SetTexture2(D3D12_GPU_DESCRIPTOR_HANDLE srvDescriptor, D3D12_GPU_DESCRIPTOR_HANDLE samplerDescriptor);
-
-    private:
-        // Private implementation.
-        class Impl;
-
-        std::unique_ptr<Impl> pImpl;
-    };
-
-
-    // Built-in shader supports cubic environment mapping.
-    class EnvironmentMapEffect : public IEffect, public IEffectMatrices, public IEffectLights, public IEffectFog
-    {
-    public:
-        enum Mapping
+        //------------------------------------------------------------------------------
+        // Abstract interface representing any effect which can be applied onto a D3D device context.
+        class IEffect
         {
-            Mapping_Cube = 0,       // Cubic environment map
-            Mapping_Sphere,         // Spherical environment map
-            Mapping_DualParabola,   // Dual-parabola environment map (requires Feature Level 10.0)
+        public:
+            virtual ~IEffect() = default;
+
+            IEffect(const IEffect&) = delete;
+            IEffect& operator=(const IEffect&) = delete;
+
+            virtual void __cdecl Apply(_In_ ID3D12GraphicsCommandList* commandList) = 0;
+
+        protected:
+            IEffect() = default;
+            IEffect(IEffect&&) = default;
+            IEffect& operator=(IEffect&&) = default;
         };
 
-        EnvironmentMapEffect(_In_ ID3D12Device* device, uint32_t effectFlags,
-            const EffectPipelineStateDescription& pipelineDescription,
-            Mapping mapping = Mapping_Cube);
 
-        EnvironmentMapEffect(EnvironmentMapEffect&&) noexcept;
-        EnvironmentMapEffect& operator= (EnvironmentMapEffect&&) noexcept;
-
-        EnvironmentMapEffect(EnvironmentMapEffect const&) = delete;
-        EnvironmentMapEffect& operator= (EnvironmentMapEffect const&) = delete;
-
-        ~EnvironmentMapEffect() override;
-
-        // IEffect methods.
-        void __cdecl Apply(_In_ ID3D12GraphicsCommandList* commandList) override;
-
-        // Camera settings.
-        void XM_CALLCONV SetWorld(FXMMATRIX value) override;
-        void XM_CALLCONV SetView(FXMMATRIX value) override;
-        void XM_CALLCONV SetProjection(FXMMATRIX value) override;
-        void XM_CALLCONV SetMatrices(FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection) override;
-
-        // Material settings.
-        void XM_CALLCONV SetDiffuseColor(FXMVECTOR value);
-        void XM_CALLCONV SetEmissiveColor(FXMVECTOR value);
-        void __cdecl SetAlpha(float value);
-        void XM_CALLCONV SetColorAndAlpha(FXMVECTOR value);
-
-        // Light settings.
-        void XM_CALLCONV SetAmbientLightColor(FXMVECTOR value) override;
-
-        void __cdecl SetLightEnabled(int whichLight, bool value) override;
-        void XM_CALLCONV SetLightDirection(int whichLight, FXMVECTOR value) override;
-        void XM_CALLCONV SetLightDiffuseColor(int whichLight, FXMVECTOR value) override;
-
-        void __cdecl EnableDefaultLighting() override;
-
-        // Fog settings.
-        void __cdecl SetFogStart(float value) override;
-        void __cdecl SetFogEnd(float value) override;
-        void XM_CALLCONV SetFogColor(FXMVECTOR value) override;
-
-        // Texture setting.
-        void __cdecl SetTexture(D3D12_GPU_DESCRIPTOR_HANDLE texture, D3D12_GPU_DESCRIPTOR_HANDLE sampler);
-
-        // Environment map settings.
-        void __cdecl SetEnvironmentMap(D3D12_GPU_DESCRIPTOR_HANDLE texture, D3D12_GPU_DESCRIPTOR_HANDLE sampler);
-        void __cdecl SetEnvironmentMapAmount(float value);
-        void XM_CALLCONV SetEnvironmentMapSpecular(FXMVECTOR value);
-        void __cdecl SetFresnelFactor(float value);
-
-    private:
-        // Private implementation.
-        class Impl;
-
-        std::unique_ptr<Impl> pImpl;
-
-        // Unsupported interface methods.
-        void XM_CALLCONV SetLightSpecularColor(int whichLight, FXMVECTOR value) override;
-    };
-
-
-    // Built-in shader supports skinned animation.
-    class SkinnedEffect : public IEffect, public IEffectMatrices, public IEffectLights, public IEffectFog, public IEffectSkinning
-    {
-    public:
-        SkinnedEffect(_In_ ID3D12Device* device, uint32_t effectFlags,
-            const EffectPipelineStateDescription& pipelineDescription);
-
-        SkinnedEffect(SkinnedEffect&&) noexcept;
-        SkinnedEffect& operator= (SkinnedEffect&&) noexcept;
-
-        SkinnedEffect(SkinnedEffect const&) = delete;
-        SkinnedEffect& operator= (SkinnedEffect const&) = delete;
-
-        ~SkinnedEffect() override;
-
-        // IEffect methods.
-        void __cdecl Apply(_In_ ID3D12GraphicsCommandList* commandList) override;
-
-        // Camera settings.
-        void XM_CALLCONV SetWorld(FXMMATRIX value) override;
-        void XM_CALLCONV SetView(FXMMATRIX value) override;
-        void XM_CALLCONV SetProjection(FXMMATRIX value) override;
-        void XM_CALLCONV SetMatrices(FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection) override;
-
-        // Material settings.
-        void XM_CALLCONV SetDiffuseColor(FXMVECTOR value);
-        void XM_CALLCONV SetEmissiveColor(FXMVECTOR value);
-        void XM_CALLCONV SetSpecularColor(FXMVECTOR value);
-        void __cdecl SetSpecularPower(float value);
-        void __cdecl DisableSpecular();
-        void __cdecl SetAlpha(float value);
-        void XM_CALLCONV SetColorAndAlpha(FXMVECTOR value);
-
-        // Light settings.
-        void XM_CALLCONV SetAmbientLightColor(FXMVECTOR value) override;
-
-        void __cdecl SetLightEnabled(int whichLight, bool value) override;
-        void XM_CALLCONV SetLightDirection(int whichLight, FXMVECTOR value) override;
-        void XM_CALLCONV SetLightDiffuseColor(int whichLight, FXMVECTOR value) override;
-        void XM_CALLCONV SetLightSpecularColor(int whichLight, FXMVECTOR value) override;
-
-        void __cdecl EnableDefaultLighting() override;
-
-        // Fog settings.
-        void __cdecl SetFogStart(float value) override;
-        void __cdecl SetFogEnd(float value) override;
-        void XM_CALLCONV SetFogColor(FXMVECTOR value) override;
-
-        // Texture setting.
-        void __cdecl SetTexture(D3D12_GPU_DESCRIPTOR_HANDLE srvDescriptor, D3D12_GPU_DESCRIPTOR_HANDLE samplerDescriptor);
-
-        // Animation settings.
-        void __cdecl SetBoneTransforms(_In_reads_(count) XMMATRIX const* value, size_t count) override;
-        void __cdecl ResetBoneTransforms() override;
-
-    private:
-        // Private implementation.
-        class Impl;
-
-        std::unique_ptr<Impl> pImpl;
-    };
-
-
-    //----------------------------------------------------------------------------------
-    // Built-in shader extends BasicEffect with normal map and optional specular map
-    class NormalMapEffect : public IEffect, public IEffectMatrices, public IEffectLights, public IEffectFog
-    {
-    public:
-        NormalMapEffect(_In_ ID3D12Device* device, uint32_t effectFlags,
-            const EffectPipelineStateDescription& pipelineDescription) :
-            NormalMapEffect(device, effectFlags, pipelineDescription, false)
+        // Abstract interface for effects with world, view, and projection matrices.
+        class IEffectMatrices
         {
-        }
+        public:
+            virtual ~IEffectMatrices() = default;
 
-        NormalMapEffect(NormalMapEffect&&) noexcept;
-        NormalMapEffect& operator= (NormalMapEffect&&) noexcept;
+            IEffectMatrices(const IEffectMatrices&) = delete;
+            IEffectMatrices& operator=(const IEffectMatrices&) = delete;
 
-        NormalMapEffect(NormalMapEffect const&) = delete;
-        NormalMapEffect& operator= (NormalMapEffect const&) = delete;
+            virtual void XM_CALLCONV SetWorld(FXMMATRIX value) = 0;
+            virtual void XM_CALLCONV SetView(FXMMATRIX value) = 0;
+            virtual void XM_CALLCONV SetProjection(FXMMATRIX value) = 0;
+            virtual void XM_CALLCONV SetMatrices(FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection);
 
-        ~NormalMapEffect() override;
-
-        // IEffect methods.
-        void __cdecl Apply(_In_ ID3D12GraphicsCommandList* commandList) override;
-
-        // Camera settings.
-        void XM_CALLCONV SetWorld(FXMMATRIX value) override;
-        void XM_CALLCONV SetView(FXMMATRIX value) override;
-        void XM_CALLCONV SetProjection(FXMMATRIX value) override;
-        void XM_CALLCONV SetMatrices(FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection) override;
-
-        // Material settings.
-        void XM_CALLCONV SetDiffuseColor(FXMVECTOR value);
-        void XM_CALLCONV SetEmissiveColor(FXMVECTOR value);
-        void XM_CALLCONV SetSpecularColor(FXMVECTOR value);
-        void __cdecl SetSpecularPower(float value);
-        void __cdecl DisableSpecular();
-        void __cdecl SetAlpha(float value);
-        void XM_CALLCONV SetColorAndAlpha(FXMVECTOR value);
-
-        // Light settings.
-        void XM_CALLCONV SetAmbientLightColor(FXMVECTOR value) override;
-
-        void __cdecl SetLightEnabled(int whichLight, bool value) override;
-        void XM_CALLCONV SetLightDirection(int whichLight, FXMVECTOR value) override;
-        void XM_CALLCONV SetLightDiffuseColor(int whichLight, FXMVECTOR value) override;
-        void XM_CALLCONV SetLightSpecularColor(int whichLight, FXMVECTOR value) override;
-
-        void __cdecl EnableDefaultLighting() override;
-
-        // Fog settings.
-        void __cdecl SetFogStart(float value) override;
-        void __cdecl SetFogEnd(float value) override;
-        void XM_CALLCONV SetFogColor(FXMVECTOR value) override;
-
-        // Texture setting - albedo, normal and specular intensity
-        void __cdecl SetTexture(D3D12_GPU_DESCRIPTOR_HANDLE srvDescriptor, D3D12_GPU_DESCRIPTOR_HANDLE samplerDescriptor);
-        void __cdecl SetNormalTexture(D3D12_GPU_DESCRIPTOR_HANDLE srvDescriptor);
-        void __cdecl SetSpecularTexture(D3D12_GPU_DESCRIPTOR_HANDLE srvDescriptor);
-
-    protected:
-        // Private implementation.
-        class Impl;
-
-        std::unique_ptr<Impl> pImpl;
-
-        NormalMapEffect(_In_ ID3D12Device* device, uint32_t effectFlags,
-            const EffectPipelineStateDescription& pipelineDescription, bool skinningEnabled);
-    };
-
-    class SkinnedNormalMapEffect : public NormalMapEffect, public IEffectSkinning
-    {
-    public:
-        SkinnedNormalMapEffect(_In_ ID3D12Device* device, uint32_t effectFlags,
-            const EffectPipelineStateDescription& pipelineDescription) :
-            NormalMapEffect(device, effectFlags, pipelineDescription, true)
-        {
-        }
-
-        SkinnedNormalMapEffect(SkinnedNormalMapEffect&&) = default;
-        SkinnedNormalMapEffect& operator= (SkinnedNormalMapEffect&&) = default;
-
-        SkinnedNormalMapEffect(SkinnedNormalMapEffect const&) = delete;
-        SkinnedNormalMapEffect& operator= (SkinnedNormalMapEffect const&) = delete;
-
-        // Animation settings.
-        void __cdecl SetBoneTransforms(_In_reads_(count) XMMATRIX const* value, size_t count) override;
-        void __cdecl ResetBoneTransforms() override;
-    };
-
-
-    //----------------------------------------------------------------------------------
-    // Built-in shader for Physically-Based Rendering (Roughness/Metalness) with Image-based lighting
-    class PBREffect : public IEffect, public IEffectMatrices, public IEffectLights
-    {
-    public:
-        PBREffect(_In_ ID3D12Device* device, uint32_t effectFlags,
-            const EffectPipelineStateDescription& pipelineDescription) :
-            PBREffect(device, effectFlags, pipelineDescription, false)
-        {
-        }
-
-        PBREffect(PBREffect&&) noexcept;
-        PBREffect& operator= (PBREffect&&) noexcept;
-
-        PBREffect(PBREffect const&) = delete;
-        PBREffect& operator= (PBREffect const&) = delete;
-
-        ~PBREffect() override;
-
-        // IEffect methods.
-        void __cdecl Apply(_In_ ID3D12GraphicsCommandList* commandList) override;
-
-        // Camera settings.
-        void XM_CALLCONV SetWorld(FXMMATRIX value) override;
-        void XM_CALLCONV SetView(FXMMATRIX value) override;
-        void XM_CALLCONV SetProjection(FXMMATRIX value) override;
-        void XM_CALLCONV SetMatrices(FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection) override;
-
-        // Light settings.
-        void __cdecl SetLightEnabled(int whichLight, bool value) override;
-        void XM_CALLCONV SetLightDirection(int whichLight, FXMVECTOR value) override;
-        void XM_CALLCONV SetLightDiffuseColor(int whichLight, FXMVECTOR value) override;
-
-        void __cdecl EnableDefaultLighting() override;
-
-        // PBR Settings.
-        void __cdecl SetAlpha(float value);
-        void XM_CALLCONV SetConstantAlbedo(FXMVECTOR value);
-        void __cdecl SetConstantMetallic(float value);
-        void __cdecl SetConstantRoughness(float value);
-
-        // Texture settings.
-        void __cdecl SetAlbedoTexture(D3D12_GPU_DESCRIPTOR_HANDLE srvDescriptor, D3D12_GPU_DESCRIPTOR_HANDLE samplerDescriptor);
-        void __cdecl SetNormalTexture(D3D12_GPU_DESCRIPTOR_HANDLE srvDescriptor);
-        void __cdecl SetRMATexture(D3D12_GPU_DESCRIPTOR_HANDLE srvDescriptor);
-
-        void __cdecl SetEmissiveTexture(D3D12_GPU_DESCRIPTOR_HANDLE srvDescriptor);
-
-        void __cdecl SetSurfaceTextures(
-            D3D12_GPU_DESCRIPTOR_HANDLE albedo,
-            D3D12_GPU_DESCRIPTOR_HANDLE normal,
-            D3D12_GPU_DESCRIPTOR_HANDLE roughnessMetallicAmbientOcclusion,
-            D3D12_GPU_DESCRIPTOR_HANDLE sampler);
-
-        void __cdecl SetIBLTextures(
-            D3D12_GPU_DESCRIPTOR_HANDLE radiance,
-            int numRadianceMips,
-            D3D12_GPU_DESCRIPTOR_HANDLE irradiance,
-            D3D12_GPU_DESCRIPTOR_HANDLE sampler);
-
-        // Render target size, required for velocity buffer output.
-        void __cdecl SetRenderTargetSizeInPixels(int width, int height);
-
-    protected:
-        // Private implementation.
-        class Impl;
-
-        std::unique_ptr<Impl> pImpl;
-
-        PBREffect(_In_ ID3D12Device* device, uint32_t effectFlags,
-            const EffectPipelineStateDescription& pipelineDescription, bool skinningEnabled);
-
-        // Unsupported interface methods.
-        void XM_CALLCONV SetAmbientLightColor(FXMVECTOR value) override;
-        void XM_CALLCONV SetLightSpecularColor(int whichLight, FXMVECTOR value) override;
-    };
-
-    class SkinnedPBREffect : public PBREffect, public IEffectSkinning
-    {
-    public:
-        SkinnedPBREffect(_In_ ID3D12Device* device, uint32_t effectFlags,
-            const EffectPipelineStateDescription& pipelineDescription) :
-            PBREffect(device, effectFlags, pipelineDescription, true)
-        {
-        }
-
-        SkinnedPBREffect(SkinnedPBREffect&&) = default;
-        SkinnedPBREffect& operator= (SkinnedPBREffect&&) = default;
-
-        SkinnedPBREffect(SkinnedPBREffect const&) = delete;
-        SkinnedPBREffect& operator= (SkinnedPBREffect const&) = delete;
-
-        // Animation settings.
-        void __cdecl SetBoneTransforms(_In_reads_(count) XMMATRIX const* value, size_t count) override;
-        void __cdecl ResetBoneTransforms() override;
-    };
-
-
-    //----------------------------------------------------------------------------------
-    // Built-in shader for debug visualization of normals, tangents, etc.
-    class DebugEffect : public IEffect, public IEffectMatrices
-    {
-    public:
-        enum Mode
-        {
-            Mode_Default = 0,   // Hemispherical ambient lighting
-            Mode_Normals,       // RGB normals
-            Mode_Tangents,      // RGB tangents
-            Mode_BiTangents,    // RGB bi-tangents
+        protected:
+            IEffectMatrices() = default;
+            IEffectMatrices(IEffectMatrices&&) = default;
+            IEffectMatrices& operator=(IEffectMatrices&&) = default;
         };
 
-        DebugEffect(_In_ ID3D12Device* device, uint32_t effectFlags,
-            const EffectPipelineStateDescription& pipelineDescription,
-            Mode debugMode = Mode_Default);
 
-        DebugEffect(DebugEffect&&) noexcept;
-        DebugEffect& operator= (DebugEffect&&) noexcept;
-
-        DebugEffect(DebugEffect const&) = delete;
-        DebugEffect& operator= (DebugEffect const&) = delete;
-
-        ~DebugEffect() override;
-
-        // IEffect methods.
-        void __cdecl Apply(_In_ ID3D12GraphicsCommandList* commandList) override;
-
-        // Camera settings.
-        void XM_CALLCONV SetWorld(FXMMATRIX value) override;
-        void XM_CALLCONV SetView(FXMMATRIX value) override;
-        void XM_CALLCONV SetProjection(FXMMATRIX value) override;
-        void XM_CALLCONV SetMatrices(FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection) override;
-
-        // Debug Settings.
-        void XM_CALLCONV SetHemisphericalAmbientColor(FXMVECTOR upper, FXMVECTOR lower);
-        void __cdecl SetAlpha(float value);
-
-    private:
-        // Private implementation.
-        class Impl;
-
-        std::unique_ptr<Impl> pImpl;
-    };
-
-
-    //----------------------------------------------------------------------------------
-    // Abstract interface to factory texture resources
-    class IEffectTextureFactory
-    {
-    public:
-        virtual ~IEffectTextureFactory() = default;
-
-        IEffectTextureFactory(const IEffectTextureFactory&) = delete;
-        IEffectTextureFactory& operator=(const IEffectTextureFactory&) = delete;
-
-        virtual size_t __cdecl CreateTexture(_In_z_ const wchar_t* name, int descriptorIndex) = 0;
-
-    protected:
-        IEffectTextureFactory() = default;
-        IEffectTextureFactory(IEffectTextureFactory&&) = default;
-        IEffectTextureFactory& operator=(IEffectTextureFactory&&) = default;
-    };
-
-
-    // Factory for sharing texture resources
-    class EffectTextureFactory : public IEffectTextureFactory
-    {
-    public:
-        EffectTextureFactory(
-            _In_ ID3D12Device* device,
-            ResourceUploadBatch& resourceUploadBatch,
-            _In_ ID3D12DescriptorHeap* descriptorHeap) noexcept(false);
-
-        EffectTextureFactory(
-            _In_ ID3D12Device* device,
-            ResourceUploadBatch& resourceUploadBatch,
-            _In_ size_t numDescriptors,
-            _In_ D3D12_DESCRIPTOR_HEAP_FLAGS descriptorHeapFlags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE) noexcept(false);
-
-        EffectTextureFactory(EffectTextureFactory&&) noexcept;
-        EffectTextureFactory& operator= (EffectTextureFactory&&) noexcept;
-
-        EffectTextureFactory(EffectTextureFactory const&) = delete;
-        EffectTextureFactory& operator= (EffectTextureFactory const&) = delete;
-
-        ~EffectTextureFactory() override;
-
-        size_t __cdecl CreateTexture(_In_z_ const wchar_t* name, int descriptorIndex) override;
-
-        ID3D12DescriptorHeap* __cdecl Heap() const noexcept;
-
-        // Shorthand accessors for the descriptor heap
-        D3D12_CPU_DESCRIPTOR_HANDLE __cdecl GetCpuDescriptorHandle(size_t index) const;
-        D3D12_GPU_DESCRIPTOR_HANDLE __cdecl GetGpuDescriptorHandle(size_t index) const;
-
-        // How many textures are there in this factory?
-        size_t __cdecl ResourceCount() const noexcept;
-
-        // Get a resource in a specific slot (note: increases reference count on resource)
-        void __cdecl GetResource(size_t slot, _Out_ ID3D12Resource** resource, _Out_opt_ bool* isCubeMap = nullptr);
-
-        // Settings.
-        void __cdecl ReleaseCache();
-
-        void __cdecl SetSharing(bool enabled) noexcept;
-
-        void __cdecl EnableForceSRGB(bool forceSRGB) noexcept;
-        void __cdecl EnableAutoGenMips(bool generateMips) noexcept;
-
-        void __cdecl SetDirectory(_In_opt_z_ const wchar_t* path) noexcept;
-
-    private:
-        // Private implementation
-        class Impl;
-
-        std::unique_ptr<Impl> pImpl;
-    };
-
-
-    //----------------------------------------------------------------------------------
-    // Abstract interface to factory for sharing effects
-    class IEffectFactory
-    {
-    public:
-        virtual ~IEffectFactory() = default;
-
-        IEffectFactory(const IEffectFactory&) = delete;
-        IEffectFactory& operator=(const IEffectFactory&) = delete;
-
-        struct EffectInfo
+        // Abstract interface for effects which support directional lighting.
+        class IEffectLights
         {
-            std::wstring        name;
-            bool                perVertexColor;
-            bool                enableSkinning;
-            bool                enableDualTexture;
-            bool                enableNormalMaps;
-            bool                biasedVertexNormals;
-            float               specularPower;
-            float               alphaValue;
-            XMFLOAT3            ambientColor;
-            XMFLOAT3            diffuseColor;
-            XMFLOAT3            specularColor;
-            XMFLOAT3            emissiveColor;
-            int                 diffuseTextureIndex;
-            int                 specularTextureIndex;
-            int                 normalTextureIndex;
-            int                 emissiveTextureIndex;
-            int                 samplerIndex;
-            int                 samplerIndex2;
+        public:
+            virtual ~IEffectLights() = default;
 
-            EffectInfo() noexcept
-                : perVertexColor(false)
-                , enableSkinning(false)
-                , enableDualTexture(false)
-                , enableNormalMaps(false)
-                , biasedVertexNormals(false)
-                , specularPower(0)
-                , alphaValue(0)
-                , ambientColor(0, 0, 0)
-                , diffuseColor(0, 0, 0)
-                , specularColor(0, 0, 0)
-                , emissiveColor(0, 0, 0)
-                , diffuseTextureIndex(-1)
-                , specularTextureIndex(-1)
-                , normalTextureIndex(-1)
-                , emissiveTextureIndex(-1)
-                , samplerIndex(-1)
-                , samplerIndex2(-1)
+            IEffectLights(const IEffectLights&) = delete;
+            IEffectLights& operator=(const IEffectLights&) = delete;
+
+            virtual void XM_CALLCONV SetAmbientLightColor(FXMVECTOR value) = 0;
+
+            virtual void __cdecl SetLightEnabled(int whichLight, bool value) = 0;
+            virtual void XM_CALLCONV SetLightDirection(int whichLight, FXMVECTOR value) = 0;
+            virtual void XM_CALLCONV SetLightDiffuseColor(int whichLight, FXMVECTOR value) = 0;
+            virtual void XM_CALLCONV SetLightSpecularColor(int whichLight, FXMVECTOR value) = 0;
+
+            virtual void __cdecl EnableDefaultLighting() = 0;
+
+            static constexpr int MaxDirectionalLights = 3;
+
+        protected:
+            IEffectLights() = default;
+            IEffectLights(IEffectLights&&) = default;
+            IEffectLights& operator=(IEffectLights&&) = default;
+        };
+
+
+        // Abstract interface for effects which support fog.
+        class IEffectFog
+        {
+        public:
+            virtual ~IEffectFog() = default;
+
+            IEffectFog(const IEffectFog&) = delete;
+            IEffectFog& operator=(const IEffectFog&) = delete;
+
+            virtual void __cdecl SetFogStart(float value) = 0;
+            virtual void __cdecl SetFogEnd(float value) = 0;
+            virtual void XM_CALLCONV SetFogColor(FXMVECTOR value) = 0;
+
+        protected:
+            IEffectFog() = default;
+            IEffectFog(IEffectFog&&) = default;
+            IEffectFog& operator=(IEffectFog&&) = default;
+        };
+
+
+        // Abstract interface for effects which support skinning
+        class IEffectSkinning
+        {
+        public:
+            virtual ~IEffectSkinning() = default;
+
+            IEffectSkinning(const IEffectSkinning&) = delete;
+            IEffectSkinning& operator=(const IEffectSkinning&) = delete;
+
+            virtual void __cdecl SetBoneTransforms(_In_reads_(count) XMMATRIX const* value, size_t count) = 0;
+            virtual void __cdecl ResetBoneTransforms() = 0;
+
+            static constexpr int MaxBones = 72;
+
+        protected:
+            IEffectSkinning() = default;
+            IEffectSkinning(IEffectSkinning&&) = default;
+            IEffectSkinning& operator=(IEffectSkinning&&) = default;
+        };
+
+
+        //------------------------------------------------------------------------------
+        namespace EffectFlags
+        {
+            constexpr uint32_t None = 0x00;
+            constexpr uint32_t Fog = 0x01;
+            constexpr uint32_t Lighting = 0x02;
+
+            constexpr uint32_t PerPixelLighting = 0x04 | Lighting;
+            // per pixel lighting implies lighting enabled
+
+            constexpr uint32_t VertexColor = 0x08;
+            constexpr uint32_t Texture = 0x10;
+            constexpr uint32_t Instancing = 0x20;
+
+            constexpr uint32_t Specular = 0x100;
+            // enable optional specular/specularMap feature
+
+            constexpr uint32_t Emissive = 0x200;
+            // enable optional emissive/emissiveMap feature
+
+            constexpr uint32_t Fresnel = 0x400;
+            // enable optional Fresnel feature
+
+            constexpr uint32_t Velocity = 0x800;
+            // enable optional velocity feature
+
+            constexpr uint32_t BiasedVertexNormals = 0x10000;
+            // compressed vertex normals need x2 bias
+        }
+
+
+        //------------------------------------------------------------------------------
+        // Built-in shader supports optional texture mapping, vertex coloring, directional lighting, and fog.
+        class BasicEffect : public IEffect, public IEffectMatrices, public IEffectLights, public IEffectFog
+        {
+        public:
+            BasicEffect(_In_ ID3D12Device* device, uint32_t effectFlags, const EffectPipelineStateDescription& pipelineDescription);
+
+            BasicEffect(BasicEffect&&) noexcept;
+            BasicEffect& operator= (BasicEffect&&) noexcept;
+
+            BasicEffect(BasicEffect const&) = delete;
+            BasicEffect& operator= (BasicEffect const&) = delete;
+
+            ~BasicEffect() override;
+
+            // IEffect methods.
+            void __cdecl Apply(_In_ ID3D12GraphicsCommandList* commandList) override;
+
+            // Camera settings.
+            void XM_CALLCONV SetWorld(FXMMATRIX value) override;
+            void XM_CALLCONV SetView(FXMMATRIX value) override;
+            void XM_CALLCONV SetProjection(FXMMATRIX value) override;
+            void XM_CALLCONV SetMatrices(FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection) override;
+
+            // Material settings.
+            void XM_CALLCONV SetDiffuseColor(FXMVECTOR value);
+            void XM_CALLCONV SetEmissiveColor(FXMVECTOR value);
+            void XM_CALLCONV SetSpecularColor(FXMVECTOR value);
+            void __cdecl SetSpecularPower(float value);
+            void __cdecl DisableSpecular();
+            void __cdecl SetAlpha(float value);
+            void XM_CALLCONV SetColorAndAlpha(FXMVECTOR value);
+
+            // Light settings.
+            void XM_CALLCONV SetAmbientLightColor(FXMVECTOR value) override;
+
+            void __cdecl SetLightEnabled(int whichLight, bool value) override;
+            void XM_CALLCONV SetLightDirection(int whichLight, FXMVECTOR value) override;
+            void XM_CALLCONV SetLightDiffuseColor(int whichLight, FXMVECTOR value) override;
+            void XM_CALLCONV SetLightSpecularColor(int whichLight, FXMVECTOR value) override;
+
+            void __cdecl EnableDefaultLighting() override;
+
+            // Fog settings.
+            void __cdecl SetFogStart(float value) override;
+            void __cdecl SetFogEnd(float value) override;
+            void XM_CALLCONV SetFogColor(FXMVECTOR value) override;
+
+            // Texture setting.
+            void __cdecl SetTexture(D3D12_GPU_DESCRIPTOR_HANDLE srvDescriptor, D3D12_GPU_DESCRIPTOR_HANDLE samplerDescriptor);
+
+        private:
+            // Private implementation.
+            class Impl;
+
+            std::unique_ptr<Impl> pImpl;
+        };
+
+
+        // Built-in shader supports per-pixel alpha testing.
+        class AlphaTestEffect : public IEffect, public IEffectMatrices, public IEffectFog
+        {
+        public:
+            AlphaTestEffect(_In_ ID3D12Device* device, uint32_t effectFlags,
+                const EffectPipelineStateDescription& pipelineDescription,
+                D3D12_COMPARISON_FUNC alphaFunction = D3D12_COMPARISON_FUNC_GREATER);
+
+            AlphaTestEffect(AlphaTestEffect&&) noexcept;
+            AlphaTestEffect& operator= (AlphaTestEffect&&) noexcept;
+
+            AlphaTestEffect(AlphaTestEffect const&) = delete;
+            AlphaTestEffect& operator= (AlphaTestEffect const&) = delete;
+
+            ~AlphaTestEffect() override;
+
+            // IEffect methods.
+            void __cdecl Apply(_In_ ID3D12GraphicsCommandList* commandList) override;
+
+            // Camera settings.
+            void XM_CALLCONV SetWorld(FXMMATRIX value) override;
+            void XM_CALLCONV SetView(FXMMATRIX value) override;
+            void XM_CALLCONV SetProjection(FXMMATRIX value) override;
+            void XM_CALLCONV SetMatrices(FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection) override;
+
+            // Material settings.
+            void XM_CALLCONV SetDiffuseColor(FXMVECTOR value);
+            void __cdecl SetAlpha(float value);
+            void XM_CALLCONV SetColorAndAlpha(FXMVECTOR value);
+
+            // Fog settings.
+            void __cdecl SetFogStart(float value) override;
+            void __cdecl SetFogEnd(float value) override;
+            void XM_CALLCONV SetFogColor(FXMVECTOR value) override;
+
+            // Texture setting.
+            void __cdecl SetTexture(D3D12_GPU_DESCRIPTOR_HANDLE srvDescriptor, D3D12_GPU_DESCRIPTOR_HANDLE samplerDescriptor);
+
+            // Alpha test settings.
+            void __cdecl SetReferenceAlpha(int value);
+
+        private:
+            // Private implementation.
+            class Impl;
+
+            std::unique_ptr<Impl> pImpl;
+        };
+
+
+        // Built-in shader supports two layer multitexturing (eg. for lightmaps or detail textures).
+        class DualTextureEffect : public IEffect, public IEffectMatrices, public IEffectFog
+        {
+        public:
+            DualTextureEffect(_In_ ID3D12Device* device, uint32_t effectFlags,
+                const EffectPipelineStateDescription& pipelineDescription);
+
+            DualTextureEffect(DualTextureEffect&&) noexcept;
+            DualTextureEffect& operator= (DualTextureEffect&&) noexcept;
+
+            DualTextureEffect(DualTextureEffect const&) = delete;
+            DualTextureEffect& operator= (DualTextureEffect const&) = delete;
+
+            ~DualTextureEffect() override;
+
+            // IEffect methods.
+            void __cdecl Apply(_In_ ID3D12GraphicsCommandList* commandList) override;
+
+            // Camera settings.
+            void XM_CALLCONV SetWorld(FXMMATRIX value) override;
+            void XM_CALLCONV SetView(FXMMATRIX value) override;
+            void XM_CALLCONV SetProjection(FXMMATRIX value) override;
+            void XM_CALLCONV SetMatrices(FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection) override;
+
+            // Material settings.
+            void XM_CALLCONV SetDiffuseColor(FXMVECTOR value);
+            void __cdecl SetAlpha(float value);
+            void XM_CALLCONV SetColorAndAlpha(FXMVECTOR value);
+
+            // Fog settings.
+            void __cdecl SetFogStart(float value) override;
+            void __cdecl SetFogEnd(float value) override;
+            void XM_CALLCONV SetFogColor(FXMVECTOR value) override;
+
+            // Texture settings.
+            void __cdecl SetTexture(D3D12_GPU_DESCRIPTOR_HANDLE srvDescriptor, D3D12_GPU_DESCRIPTOR_HANDLE samplerDescriptor);
+            void __cdecl SetTexture2(D3D12_GPU_DESCRIPTOR_HANDLE srvDescriptor, D3D12_GPU_DESCRIPTOR_HANDLE samplerDescriptor);
+
+        private:
+            // Private implementation.
+            class Impl;
+
+            std::unique_ptr<Impl> pImpl;
+        };
+
+
+        // Built-in shader supports cubic environment mapping.
+        class EnvironmentMapEffect : public IEffect, public IEffectMatrices, public IEffectLights, public IEffectFog
+        {
+        public:
+            enum Mapping
+            {
+                Mapping_Cube = 0,       // Cubic environment map
+                Mapping_Sphere,         // Spherical environment map
+                Mapping_DualParabola,   // Dual-parabola environment map (requires Feature Level 10.0)
+            };
+
+            EnvironmentMapEffect(_In_ ID3D12Device* device, uint32_t effectFlags,
+                const EffectPipelineStateDescription& pipelineDescription,
+                Mapping mapping = Mapping_Cube);
+
+            EnvironmentMapEffect(EnvironmentMapEffect&&) noexcept;
+            EnvironmentMapEffect& operator= (EnvironmentMapEffect&&) noexcept;
+
+            EnvironmentMapEffect(EnvironmentMapEffect const&) = delete;
+            EnvironmentMapEffect& operator= (EnvironmentMapEffect const&) = delete;
+
+            ~EnvironmentMapEffect() override;
+
+            // IEffect methods.
+            void __cdecl Apply(_In_ ID3D12GraphicsCommandList* commandList) override;
+
+            // Camera settings.
+            void XM_CALLCONV SetWorld(FXMMATRIX value) override;
+            void XM_CALLCONV SetView(FXMMATRIX value) override;
+            void XM_CALLCONV SetProjection(FXMMATRIX value) override;
+            void XM_CALLCONV SetMatrices(FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection) override;
+
+            // Material settings.
+            void XM_CALLCONV SetDiffuseColor(FXMVECTOR value);
+            void XM_CALLCONV SetEmissiveColor(FXMVECTOR value);
+            void __cdecl SetAlpha(float value);
+            void XM_CALLCONV SetColorAndAlpha(FXMVECTOR value);
+
+            // Light settings.
+            void XM_CALLCONV SetAmbientLightColor(FXMVECTOR value) override;
+
+            void __cdecl SetLightEnabled(int whichLight, bool value) override;
+            void XM_CALLCONV SetLightDirection(int whichLight, FXMVECTOR value) override;
+            void XM_CALLCONV SetLightDiffuseColor(int whichLight, FXMVECTOR value) override;
+
+            void __cdecl EnableDefaultLighting() override;
+
+            // Fog settings.
+            void __cdecl SetFogStart(float value) override;
+            void __cdecl SetFogEnd(float value) override;
+            void XM_CALLCONV SetFogColor(FXMVECTOR value) override;
+
+            // Texture setting.
+            void __cdecl SetTexture(D3D12_GPU_DESCRIPTOR_HANDLE texture, D3D12_GPU_DESCRIPTOR_HANDLE sampler);
+
+            // Environment map settings.
+            void __cdecl SetEnvironmentMap(D3D12_GPU_DESCRIPTOR_HANDLE texture, D3D12_GPU_DESCRIPTOR_HANDLE sampler);
+            void __cdecl SetEnvironmentMapAmount(float value);
+            void XM_CALLCONV SetEnvironmentMapSpecular(FXMVECTOR value);
+            void __cdecl SetFresnelFactor(float value);
+
+        private:
+            // Private implementation.
+            class Impl;
+
+            std::unique_ptr<Impl> pImpl;
+
+            // Unsupported interface methods.
+            void XM_CALLCONV SetLightSpecularColor(int whichLight, FXMVECTOR value) override;
+        };
+
+
+        // Built-in shader supports skinned animation.
+        class SkinnedEffect : public IEffect, public IEffectMatrices, public IEffectLights, public IEffectFog, public IEffectSkinning
+        {
+        public:
+            SkinnedEffect(_In_ ID3D12Device* device, uint32_t effectFlags,
+                const EffectPipelineStateDescription& pipelineDescription);
+
+            SkinnedEffect(SkinnedEffect&&) noexcept;
+            SkinnedEffect& operator= (SkinnedEffect&&) noexcept;
+
+            SkinnedEffect(SkinnedEffect const&) = delete;
+            SkinnedEffect& operator= (SkinnedEffect const&) = delete;
+
+            ~SkinnedEffect() override;
+
+            // IEffect methods.
+            void __cdecl Apply(_In_ ID3D12GraphicsCommandList* commandList) override;
+
+            // Camera settings.
+            void XM_CALLCONV SetWorld(FXMMATRIX value) override;
+            void XM_CALLCONV SetView(FXMMATRIX value) override;
+            void XM_CALLCONV SetProjection(FXMMATRIX value) override;
+            void XM_CALLCONV SetMatrices(FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection) override;
+
+            // Material settings.
+            void XM_CALLCONV SetDiffuseColor(FXMVECTOR value);
+            void XM_CALLCONV SetEmissiveColor(FXMVECTOR value);
+            void XM_CALLCONV SetSpecularColor(FXMVECTOR value);
+            void __cdecl SetSpecularPower(float value);
+            void __cdecl DisableSpecular();
+            void __cdecl SetAlpha(float value);
+            void XM_CALLCONV SetColorAndAlpha(FXMVECTOR value);
+
+            // Light settings.
+            void XM_CALLCONV SetAmbientLightColor(FXMVECTOR value) override;
+
+            void __cdecl SetLightEnabled(int whichLight, bool value) override;
+            void XM_CALLCONV SetLightDirection(int whichLight, FXMVECTOR value) override;
+            void XM_CALLCONV SetLightDiffuseColor(int whichLight, FXMVECTOR value) override;
+            void XM_CALLCONV SetLightSpecularColor(int whichLight, FXMVECTOR value) override;
+
+            void __cdecl EnableDefaultLighting() override;
+
+            // Fog settings.
+            void __cdecl SetFogStart(float value) override;
+            void __cdecl SetFogEnd(float value) override;
+            void XM_CALLCONV SetFogColor(FXMVECTOR value) override;
+
+            // Texture setting.
+            void __cdecl SetTexture(D3D12_GPU_DESCRIPTOR_HANDLE srvDescriptor, D3D12_GPU_DESCRIPTOR_HANDLE samplerDescriptor);
+
+            // Animation settings.
+            void __cdecl SetBoneTransforms(_In_reads_(count) XMMATRIX const* value, size_t count) override;
+            void __cdecl ResetBoneTransforms() override;
+
+        private:
+            // Private implementation.
+            class Impl;
+
+            std::unique_ptr<Impl> pImpl;
+        };
+
+
+        //------------------------------------------------------------------------------
+        // Built-in shader extends BasicEffect with normal map and optional specular map
+        class NormalMapEffect : public IEffect, public IEffectMatrices, public IEffectLights, public IEffectFog
+        {
+        public:
+            NormalMapEffect(_In_ ID3D12Device* device, uint32_t effectFlags,
+                const EffectPipelineStateDescription& pipelineDescription) :
+                NormalMapEffect(device, effectFlags, pipelineDescription, false)
             {
             }
+
+            NormalMapEffect(NormalMapEffect&&) noexcept;
+            NormalMapEffect& operator= (NormalMapEffect&&) noexcept;
+
+            NormalMapEffect(NormalMapEffect const&) = delete;
+            NormalMapEffect& operator= (NormalMapEffect const&) = delete;
+
+            ~NormalMapEffect() override;
+
+            // IEffect methods.
+            void __cdecl Apply(_In_ ID3D12GraphicsCommandList* commandList) override;
+
+            // Camera settings.
+            void XM_CALLCONV SetWorld(FXMMATRIX value) override;
+            void XM_CALLCONV SetView(FXMMATRIX value) override;
+            void XM_CALLCONV SetProjection(FXMMATRIX value) override;
+            void XM_CALLCONV SetMatrices(FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection) override;
+
+            // Material settings.
+            void XM_CALLCONV SetDiffuseColor(FXMVECTOR value);
+            void XM_CALLCONV SetEmissiveColor(FXMVECTOR value);
+            void XM_CALLCONV SetSpecularColor(FXMVECTOR value);
+            void __cdecl SetSpecularPower(float value);
+            void __cdecl DisableSpecular();
+            void __cdecl SetAlpha(float value);
+            void XM_CALLCONV SetColorAndAlpha(FXMVECTOR value);
+
+            // Light settings.
+            void XM_CALLCONV SetAmbientLightColor(FXMVECTOR value) override;
+
+            void __cdecl SetLightEnabled(int whichLight, bool value) override;
+            void XM_CALLCONV SetLightDirection(int whichLight, FXMVECTOR value) override;
+            void XM_CALLCONV SetLightDiffuseColor(int whichLight, FXMVECTOR value) override;
+            void XM_CALLCONV SetLightSpecularColor(int whichLight, FXMVECTOR value) override;
+
+            void __cdecl EnableDefaultLighting() override;
+
+            // Fog settings.
+            void __cdecl SetFogStart(float value) override;
+            void __cdecl SetFogEnd(float value) override;
+            void XM_CALLCONV SetFogColor(FXMVECTOR value) override;
+
+            // Texture setting - albedo, normal and specular intensity
+            void __cdecl SetTexture(D3D12_GPU_DESCRIPTOR_HANDLE srvDescriptor, D3D12_GPU_DESCRIPTOR_HANDLE samplerDescriptor);
+            void __cdecl SetNormalTexture(D3D12_GPU_DESCRIPTOR_HANDLE srvDescriptor);
+            void __cdecl SetSpecularTexture(D3D12_GPU_DESCRIPTOR_HANDLE srvDescriptor);
+
+        protected:
+            // Private implementation.
+            class Impl;
+
+            std::unique_ptr<Impl> pImpl;
+
+            NormalMapEffect(_In_ ID3D12Device* device, uint32_t effectFlags,
+                const EffectPipelineStateDescription& pipelineDescription, bool skinningEnabled);
         };
 
-        virtual std::shared_ptr<IEffect> __cdecl CreateEffect(
-            const EffectInfo& info,
-            const EffectPipelineStateDescription& opaquePipelineState,
-            const EffectPipelineStateDescription& alphaPipelineState,
-            const D3D12_INPUT_LAYOUT_DESC& inputLayout,
-            int textureDescriptorOffset = 0,
-            int samplerDescriptorOffset = 0) = 0;
+        class SkinnedNormalMapEffect : public NormalMapEffect, public IEffectSkinning
+        {
+        public:
+            SkinnedNormalMapEffect(_In_ ID3D12Device* device, uint32_t effectFlags,
+                const EffectPipelineStateDescription& pipelineDescription) :
+                NormalMapEffect(device, effectFlags, pipelineDescription, true)
+            {
+            }
 
-    protected:
-        IEffectFactory() = default;
-        IEffectFactory(IEffectFactory&&) = default;
-        IEffectFactory& operator=(IEffectFactory&&) = default;
-    };
+            SkinnedNormalMapEffect(SkinnedNormalMapEffect&&) = default;
+            SkinnedNormalMapEffect& operator= (SkinnedNormalMapEffect&&) = default;
 
+            SkinnedNormalMapEffect(SkinnedNormalMapEffect const&) = delete;
+            SkinnedNormalMapEffect& operator= (SkinnedNormalMapEffect const&) = delete;
 
-    // Factory for sharing effects
-    class EffectFactory : public IEffectFactory
-    {
-    public:
-        EffectFactory(_In_ ID3D12Device* device);
-        EffectFactory(
-            _In_ ID3D12DescriptorHeap* textureDescriptors,
-            _In_ ID3D12DescriptorHeap* samplerDescriptors);
-
-        EffectFactory(EffectFactory&&) noexcept;
-        EffectFactory& operator= (EffectFactory&&) noexcept;
-
-        EffectFactory(EffectFactory const&) = delete;
-        EffectFactory& operator= (EffectFactory const&) = delete;
-
-        ~EffectFactory() override;
-
-        // IEffectFactory methods.
-        virtual std::shared_ptr<IEffect> __cdecl CreateEffect(
-            const EffectInfo& info,
-            const EffectPipelineStateDescription& opaquePipelineState,
-            const EffectPipelineStateDescription& alphaPipelineState,
-            const D3D12_INPUT_LAYOUT_DESC& inputLayout,
-            int textureDescriptorOffset = 0,
-            int samplerDescriptorOffset = 0) override;
-
-        // Settings.
-        void __cdecl ReleaseCache();
-
-        void __cdecl SetSharing(bool enabled) noexcept;
-
-        void __cdecl EnablePerPixelLighting(bool enabled) noexcept;
-
-        void __cdecl EnableNormalMapEffect(bool enabled) noexcept;
-
-        void __cdecl EnableFogging(bool enabled) noexcept;
-
-        void __cdecl EnableInstancing(bool enabled) noexcept;
-
-    private:
-        // Private implementation.
-        class Impl;
-
-        std::shared_ptr<Impl> pImpl;
-    };
+            // Animation settings.
+            void __cdecl SetBoneTransforms(_In_reads_(count) XMMATRIX const* value, size_t count) override;
+            void __cdecl ResetBoneTransforms() override;
+        };
 
 
-    // Factory for Physically Based Rendering (PBR)
-    class PBREffectFactory : public IEffectFactory
-    {
-    public:
-        PBREffectFactory(_In_ ID3D12Device* device) noexcept(false);
-        PBREffectFactory(
-            _In_ ID3D12DescriptorHeap* textureDescriptors,
-            _In_ ID3D12DescriptorHeap* samplerDescriptors) noexcept(false);
+        //------------------------------------------------------------------------------
+        // Built-in shader for Physically-Based Rendering (Roughness/Metalness) with Image-based lighting
+        class PBREffect : public IEffect, public IEffectMatrices, public IEffectLights
+        {
+        public:
+            PBREffect(_In_ ID3D12Device* device, uint32_t effectFlags,
+                const EffectPipelineStateDescription& pipelineDescription) :
+                PBREffect(device, effectFlags, pipelineDescription, false)
+            {
+            }
 
-        PBREffectFactory(PBREffectFactory&&) noexcept;
-        PBREffectFactory& operator= (PBREffectFactory&&) noexcept;
+            PBREffect(PBREffect&&) noexcept;
+            PBREffect& operator= (PBREffect&&) noexcept;
 
-        PBREffectFactory(PBREffectFactory const&) = delete;
-        PBREffectFactory& operator= (PBREffectFactory const&) = delete;
+            PBREffect(PBREffect const&) = delete;
+            PBREffect& operator= (PBREffect const&) = delete;
 
-        ~PBREffectFactory() override;
+            ~PBREffect() override;
 
-        // IEffectFactory methods.
-        virtual std::shared_ptr<IEffect> __cdecl CreateEffect(
-            const EffectInfo& info,
-            const EffectPipelineStateDescription& opaquePipelineState,
-            const EffectPipelineStateDescription& alphaPipelineState,
-            const D3D12_INPUT_LAYOUT_DESC& inputLayout,
-            int textureDescriptorOffset = 0,
-            int samplerDescriptorOffset = 0) override;
+            // IEffect methods.
+            void __cdecl Apply(_In_ ID3D12GraphicsCommandList* commandList) override;
 
-        // Settings.
-        void __cdecl ReleaseCache();
+            // Camera settings.
+            void XM_CALLCONV SetWorld(FXMMATRIX value) override;
+            void XM_CALLCONV SetView(FXMMATRIX value) override;
+            void XM_CALLCONV SetProjection(FXMMATRIX value) override;
+            void XM_CALLCONV SetMatrices(FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection) override;
 
-        void __cdecl SetSharing(bool enabled) noexcept;
+            // Light settings.
+            void __cdecl SetLightEnabled(int whichLight, bool value) override;
+            void XM_CALLCONV SetLightDirection(int whichLight, FXMVECTOR value) override;
+            void XM_CALLCONV SetLightDiffuseColor(int whichLight, FXMVECTOR value) override;
 
-        void __cdecl EnableInstancing(bool enabled) noexcept;
+            void __cdecl EnableDefaultLighting() override;
 
-    private:
-        // Private implementation.
-        class Impl;
+            // PBR Settings.
+            void __cdecl SetAlpha(float value);
+            void XM_CALLCONV SetConstantAlbedo(FXMVECTOR value);
+            void __cdecl SetConstantMetallic(float value);
+            void __cdecl SetConstantRoughness(float value);
 
-        std::shared_ptr<Impl> pImpl;
-    };
+            // Texture settings.
+            void __cdecl SetAlbedoTexture(D3D12_GPU_DESCRIPTOR_HANDLE srvDescriptor, D3D12_GPU_DESCRIPTOR_HANDLE samplerDescriptor);
+            void __cdecl SetNormalTexture(D3D12_GPU_DESCRIPTOR_HANDLE srvDescriptor);
+            void __cdecl SetRMATexture(D3D12_GPU_DESCRIPTOR_HANDLE srvDescriptor);
+
+            void __cdecl SetEmissiveTexture(D3D12_GPU_DESCRIPTOR_HANDLE srvDescriptor);
+
+            void __cdecl SetSurfaceTextures(
+                D3D12_GPU_DESCRIPTOR_HANDLE albedo,
+                D3D12_GPU_DESCRIPTOR_HANDLE normal,
+                D3D12_GPU_DESCRIPTOR_HANDLE roughnessMetallicAmbientOcclusion,
+                D3D12_GPU_DESCRIPTOR_HANDLE sampler);
+
+            void __cdecl SetIBLTextures(
+                D3D12_GPU_DESCRIPTOR_HANDLE radiance,
+                int numRadianceMips,
+                D3D12_GPU_DESCRIPTOR_HANDLE irradiance,
+                D3D12_GPU_DESCRIPTOR_HANDLE sampler);
+
+            // Render target size, required for velocity buffer output.
+            void __cdecl SetRenderTargetSizeInPixels(int width, int height);
+
+        protected:
+            // Private implementation.
+            class Impl;
+
+            std::unique_ptr<Impl> pImpl;
+
+            PBREffect(_In_ ID3D12Device* device, uint32_t effectFlags,
+                const EffectPipelineStateDescription& pipelineDescription, bool skinningEnabled);
+
+            // Unsupported interface methods.
+            void XM_CALLCONV SetAmbientLightColor(FXMVECTOR value) override;
+            void XM_CALLCONV SetLightSpecularColor(int whichLight, FXMVECTOR value) override;
+        };
+
+        class SkinnedPBREffect : public PBREffect, public IEffectSkinning
+        {
+        public:
+            SkinnedPBREffect(_In_ ID3D12Device* device, uint32_t effectFlags,
+                const EffectPipelineStateDescription& pipelineDescription) :
+                PBREffect(device, effectFlags, pipelineDescription, true)
+            {
+            }
+
+            SkinnedPBREffect(SkinnedPBREffect&&) = default;
+            SkinnedPBREffect& operator= (SkinnedPBREffect&&) = default;
+
+            SkinnedPBREffect(SkinnedPBREffect const&) = delete;
+            SkinnedPBREffect& operator= (SkinnedPBREffect const&) = delete;
+
+            // Animation settings.
+            void __cdecl SetBoneTransforms(_In_reads_(count) XMMATRIX const* value, size_t count) override;
+            void __cdecl ResetBoneTransforms() override;
+        };
+
+
+        //------------------------------------------------------------------------------
+        // Built-in shader for debug visualization of normals, tangents, etc.
+        class DebugEffect : public IEffect, public IEffectMatrices
+        {
+        public:
+            enum Mode
+            {
+                Mode_Default = 0,   // Hemispherical ambient lighting
+                Mode_Normals,       // RGB normals
+                Mode_Tangents,      // RGB tangents
+                Mode_BiTangents,    // RGB bi-tangents
+            };
+
+            DebugEffect(_In_ ID3D12Device* device, uint32_t effectFlags,
+                const EffectPipelineStateDescription& pipelineDescription,
+                Mode debugMode = Mode_Default);
+
+            DebugEffect(DebugEffect&&) noexcept;
+            DebugEffect& operator= (DebugEffect&&) noexcept;
+
+            DebugEffect(DebugEffect const&) = delete;
+            DebugEffect& operator= (DebugEffect const&) = delete;
+
+            ~DebugEffect() override;
+
+            // IEffect methods.
+            void __cdecl Apply(_In_ ID3D12GraphicsCommandList* commandList) override;
+
+            // Camera settings.
+            void XM_CALLCONV SetWorld(FXMMATRIX value) override;
+            void XM_CALLCONV SetView(FXMMATRIX value) override;
+            void XM_CALLCONV SetProjection(FXMMATRIX value) override;
+            void XM_CALLCONV SetMatrices(FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection) override;
+
+            // Debug Settings.
+            void XM_CALLCONV SetHemisphericalAmbientColor(FXMVECTOR upper, FXMVECTOR lower);
+            void __cdecl SetAlpha(float value);
+
+        private:
+            // Private implementation.
+            class Impl;
+
+            std::unique_ptr<Impl> pImpl;
+        };
+
+
+        //------------------------------------------------------------------------------
+        // Abstract interface to factory texture resources
+        class IEffectTextureFactory
+        {
+        public:
+            virtual ~IEffectTextureFactory() = default;
+
+            IEffectTextureFactory(const IEffectTextureFactory&) = delete;
+            IEffectTextureFactory& operator=(const IEffectTextureFactory&) = delete;
+
+            virtual size_t __cdecl CreateTexture(_In_z_ const wchar_t* name, int descriptorIndex) = 0;
+
+        protected:
+            IEffectTextureFactory() = default;
+            IEffectTextureFactory(IEffectTextureFactory&&) = default;
+            IEffectTextureFactory& operator=(IEffectTextureFactory&&) = default;
+        };
+
+
+        // Factory for sharing texture resources
+        class EffectTextureFactory : public IEffectTextureFactory
+        {
+        public:
+            EffectTextureFactory(
+                _In_ ID3D12Device* device,
+                ResourceUploadBatch& resourceUploadBatch,
+                _In_ ID3D12DescriptorHeap* descriptorHeap) noexcept(false);
+
+            EffectTextureFactory(
+                _In_ ID3D12Device* device,
+                ResourceUploadBatch& resourceUploadBatch,
+                _In_ size_t numDescriptors,
+                _In_ D3D12_DESCRIPTOR_HEAP_FLAGS descriptorHeapFlags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE) noexcept(false);
+
+            EffectTextureFactory(EffectTextureFactory&&) noexcept;
+            EffectTextureFactory& operator= (EffectTextureFactory&&) noexcept;
+
+            EffectTextureFactory(EffectTextureFactory const&) = delete;
+            EffectTextureFactory& operator= (EffectTextureFactory const&) = delete;
+
+            ~EffectTextureFactory() override;
+
+            size_t __cdecl CreateTexture(_In_z_ const wchar_t* name, int descriptorIndex) override;
+
+            ID3D12DescriptorHeap* __cdecl Heap() const noexcept;
+
+            // Shorthand accessors for the descriptor heap
+            D3D12_CPU_DESCRIPTOR_HANDLE __cdecl GetCpuDescriptorHandle(size_t index) const;
+            D3D12_GPU_DESCRIPTOR_HANDLE __cdecl GetGpuDescriptorHandle(size_t index) const;
+
+            // How many textures are there in this factory?
+            size_t __cdecl ResourceCount() const noexcept;
+
+            // Get a resource in a specific slot (note: increases reference count on resource)
+            void __cdecl GetResource(size_t slot, _Out_ ID3D12Resource** resource, _Out_opt_ bool* isCubeMap = nullptr);
+
+            // Settings.
+            void __cdecl ReleaseCache();
+
+            void __cdecl SetSharing(bool enabled) noexcept;
+
+            void __cdecl EnableForceSRGB(bool forceSRGB) noexcept;
+            void __cdecl EnableAutoGenMips(bool generateMips) noexcept;
+
+            void __cdecl SetDirectory(_In_opt_z_ const wchar_t* path) noexcept;
+
+        private:
+            // Private implementation
+            class Impl;
+
+            std::unique_ptr<Impl> pImpl;
+        };
+
+
+        //------------------------------------------------------------------------------
+        // Abstract interface to factory for sharing effects
+        class IEffectFactory
+        {
+        public:
+            virtual ~IEffectFactory() = default;
+
+            IEffectFactory(const IEffectFactory&) = delete;
+            IEffectFactory& operator=(const IEffectFactory&) = delete;
+
+            struct EffectInfo
+            {
+                std::wstring        name;
+                bool                perVertexColor;
+                bool                enableSkinning;
+                bool                enableDualTexture;
+                bool                enableNormalMaps;
+                bool                biasedVertexNormals;
+                float               specularPower;
+                float               alphaValue;
+                XMFLOAT3            ambientColor;
+                XMFLOAT3            diffuseColor;
+                XMFLOAT3            specularColor;
+                XMFLOAT3            emissiveColor;
+                int                 diffuseTextureIndex;
+                int                 specularTextureIndex;
+                int                 normalTextureIndex;
+                int                 emissiveTextureIndex;
+                int                 samplerIndex;
+                int                 samplerIndex2;
+
+                EffectInfo() noexcept
+                    : perVertexColor(false)
+                    , enableSkinning(false)
+                    , enableDualTexture(false)
+                    , enableNormalMaps(false)
+                    , biasedVertexNormals(false)
+                    , specularPower(0)
+                    , alphaValue(0)
+                    , ambientColor(0, 0, 0)
+                    , diffuseColor(0, 0, 0)
+                    , specularColor(0, 0, 0)
+                    , emissiveColor(0, 0, 0)
+                    , diffuseTextureIndex(-1)
+                    , specularTextureIndex(-1)
+                    , normalTextureIndex(-1)
+                    , emissiveTextureIndex(-1)
+                    , samplerIndex(-1)
+                    , samplerIndex2(-1)
+                {
+                }
+            };
+
+            virtual std::shared_ptr<IEffect> __cdecl CreateEffect(
+                const EffectInfo& info,
+                const EffectPipelineStateDescription& opaquePipelineState,
+                const EffectPipelineStateDescription& alphaPipelineState,
+                const D3D12_INPUT_LAYOUT_DESC& inputLayout,
+                int textureDescriptorOffset = 0,
+                int samplerDescriptorOffset = 0) = 0;
+
+        protected:
+            IEffectFactory() = default;
+            IEffectFactory(IEffectFactory&&) = default;
+            IEffectFactory& operator=(IEffectFactory&&) = default;
+        };
+
+
+        // Factory for sharing effects
+        class EffectFactory : public IEffectFactory
+        {
+        public:
+            EffectFactory(_In_ ID3D12Device* device);
+            EffectFactory(
+                _In_ ID3D12DescriptorHeap* textureDescriptors,
+                _In_ ID3D12DescriptorHeap* samplerDescriptors);
+
+            EffectFactory(EffectFactory&&) noexcept;
+            EffectFactory& operator= (EffectFactory&&) noexcept;
+
+            EffectFactory(EffectFactory const&) = delete;
+            EffectFactory& operator= (EffectFactory const&) = delete;
+
+            ~EffectFactory() override;
+
+            // IEffectFactory methods.
+            virtual std::shared_ptr<IEffect> __cdecl CreateEffect(
+                const EffectInfo& info,
+                const EffectPipelineStateDescription& opaquePipelineState,
+                const EffectPipelineStateDescription& alphaPipelineState,
+                const D3D12_INPUT_LAYOUT_DESC& inputLayout,
+                int textureDescriptorOffset = 0,
+                int samplerDescriptorOffset = 0) override;
+
+            // Settings.
+            void __cdecl ReleaseCache();
+
+            void __cdecl SetSharing(bool enabled) noexcept;
+
+            void __cdecl EnablePerPixelLighting(bool enabled) noexcept;
+
+            void __cdecl EnableNormalMapEffect(bool enabled) noexcept;
+
+            void __cdecl EnableFogging(bool enabled) noexcept;
+
+            void __cdecl EnableInstancing(bool enabled) noexcept;
+
+        private:
+            // Private implementation.
+            class Impl;
+
+            std::shared_ptr<Impl> pImpl;
+        };
+
+
+        // Factory for Physically Based Rendering (PBR)
+        class PBREffectFactory : public IEffectFactory
+        {
+        public:
+            PBREffectFactory(_In_ ID3D12Device* device) noexcept(false);
+            PBREffectFactory(
+                _In_ ID3D12DescriptorHeap* textureDescriptors,
+                _In_ ID3D12DescriptorHeap* samplerDescriptors) noexcept(false);
+
+            PBREffectFactory(PBREffectFactory&&) noexcept;
+            PBREffectFactory& operator= (PBREffectFactory&&) noexcept;
+
+            PBREffectFactory(PBREffectFactory const&) = delete;
+            PBREffectFactory& operator= (PBREffectFactory const&) = delete;
+
+            ~PBREffectFactory() override;
+
+            // IEffectFactory methods.
+            virtual std::shared_ptr<IEffect> __cdecl CreateEffect(
+                const EffectInfo& info,
+                const EffectPipelineStateDescription& opaquePipelineState,
+                const EffectPipelineStateDescription& alphaPipelineState,
+                const D3D12_INPUT_LAYOUT_DESC& inputLayout,
+                int textureDescriptorOffset = 0,
+                int samplerDescriptorOffset = 0) override;
+
+            // Settings.
+            void __cdecl ReleaseCache();
+
+            void __cdecl SetSharing(bool enabled) noexcept;
+
+            void __cdecl EnableInstancing(bool enabled) noexcept;
+
+        private:
+            // Private implementation.
+            class Impl;
+
+            std::shared_ptr<Impl> pImpl;
+        };
+    }
 }

--- a/Inc/GeometricPrimitive.h
+++ b/Inc/GeometricPrimitive.h
@@ -19,76 +19,80 @@
 
 namespace DirectX
 {
-    class IEffect;
     class ResourceUploadBatch;
 
-    class GeometricPrimitive
+    inline namespace DX12
     {
-    public:
-        GeometricPrimitive(GeometricPrimitive&&) = default;
-        GeometricPrimitive& operator= (GeometricPrimitive&&) = default;
+        class IEffect;
 
-        GeometricPrimitive(GeometricPrimitive const&) = delete;
-        GeometricPrimitive& operator= (GeometricPrimitive const&) = delete;
+        class GeometricPrimitive
+        {
+        public:
+            GeometricPrimitive(GeometricPrimitive&&) = default;
+            GeometricPrimitive& operator= (GeometricPrimitive&&) = default;
 
-        virtual ~GeometricPrimitive();
+            GeometricPrimitive(GeometricPrimitive const&) = delete;
+            GeometricPrimitive& operator= (GeometricPrimitive const&) = delete;
 
-        using VertexType = VertexPositionNormalTexture;
-        using VertexCollection = std::vector<VertexType>;
-        using IndexCollection = std::vector<uint16_t>;
+            virtual ~GeometricPrimitive();
 
-        // Factory methods.
-        static std::unique_ptr<GeometricPrimitive> __cdecl CreateCube(float size = 1, bool rhcoords = true, _In_opt_ ID3D12Device* device = nullptr);
-        static std::unique_ptr<GeometricPrimitive> __cdecl CreateBox(const XMFLOAT3& size, bool rhcoords = true, bool invertn = false, _In_opt_ ID3D12Device* device = nullptr);
-        static std::unique_ptr<GeometricPrimitive> __cdecl CreateSphere(float diameter = 1, size_t tessellation = 16, bool rhcoords = true, bool invertn = false, _In_opt_ ID3D12Device* device = nullptr);
-        static std::unique_ptr<GeometricPrimitive> __cdecl CreateGeoSphere(float diameter = 1, size_t tessellation = 3, bool rhcoords = true, _In_opt_ ID3D12Device* device = nullptr);
-        static std::unique_ptr<GeometricPrimitive> __cdecl CreateCylinder(float height = 1, float diameter = 1, size_t tessellation = 32, bool rhcoords = true, _In_opt_ ID3D12Device* device = nullptr);
-        static std::unique_ptr<GeometricPrimitive> __cdecl CreateCone(float diameter = 1, float height = 1, size_t tessellation = 32, bool rhcoords = true, _In_opt_ ID3D12Device* device = nullptr);
-        static std::unique_ptr<GeometricPrimitive> __cdecl CreateTorus(float diameter = 1, float thickness = 0.333f, size_t tessellation = 32, bool rhcoords = true, _In_opt_ ID3D12Device* device = nullptr);
-        static std::unique_ptr<GeometricPrimitive> __cdecl CreateTetrahedron(float size = 1, bool rhcoords = true, _In_opt_ ID3D12Device* device = nullptr);
-        static std::unique_ptr<GeometricPrimitive> __cdecl CreateOctahedron(float size = 1, bool rhcoords = true, _In_opt_ ID3D12Device* device = nullptr);
-        static std::unique_ptr<GeometricPrimitive> __cdecl CreateDodecahedron(float size = 1, bool rhcoords = true, _In_opt_ ID3D12Device* device = nullptr);
-        static std::unique_ptr<GeometricPrimitive> __cdecl CreateIcosahedron(float size = 1, bool rhcoords = true, _In_opt_ ID3D12Device* device = nullptr);
-        static std::unique_ptr<GeometricPrimitive> __cdecl CreateTeapot(float size = 1, size_t tessellation = 8, bool rhcoords = true, _In_opt_ ID3D12Device* device = nullptr);
-        static std::unique_ptr<GeometricPrimitive> __cdecl CreateCustom(const VertexCollection& vertices, const IndexCollection& indices, _In_opt_ ID3D12Device* device = nullptr);
+            using VertexType = VertexPositionNormalTexture;
+            using VertexCollection = std::vector<VertexType>;
+            using IndexCollection = std::vector<uint16_t>;
 
-        static void __cdecl CreateCube(VertexCollection& vertices, IndexCollection& indices, float size = 1, bool rhcoords = true);
-        static void __cdecl CreateBox(VertexCollection& vertices, IndexCollection& indices, const XMFLOAT3& size, bool rhcoords = true, bool invertn = false);
-        static void __cdecl CreateSphere(VertexCollection& vertices, IndexCollection& indices, float diameter = 1, size_t tessellation = 16, bool rhcoords = true, bool invertn = false);
-        static void __cdecl CreateGeoSphere(VertexCollection& vertices, IndexCollection& indices, float diameter = 1, size_t tessellation = 3, bool rhcoords = true);
-        static void __cdecl CreateCylinder(VertexCollection& vertices, IndexCollection& indices, float height = 1, float diameter = 1, size_t tessellation = 32, bool rhcoords = true);
-        static void __cdecl CreateCone(VertexCollection& vertices, IndexCollection& indices, float diameter = 1, float height = 1, size_t tessellation = 32, bool rhcoords = true);
-        static void __cdecl CreateTorus(VertexCollection& vertices, IndexCollection& indices, float diameter = 1, float thickness = 0.333f, size_t tessellation = 32, bool rhcoords = true);
-        static void __cdecl CreateTetrahedron(VertexCollection& vertices, IndexCollection& indices, float size = 1, bool rhcoords = true);
-        static void __cdecl CreateOctahedron(VertexCollection& vertices, IndexCollection& indices, float size = 1, bool rhcoords = true);
-        static void __cdecl CreateDodecahedron(VertexCollection& vertices, IndexCollection& indices, float size = 1, bool rhcoords = true);
-        static void __cdecl CreateIcosahedron(VertexCollection& vertices, IndexCollection& indices, float size = 1, bool rhcoords = true);
-        static void __cdecl CreateTeapot(VertexCollection& vertices, IndexCollection& indices, float size = 1, size_t tessellation = 8, bool rhcoords = true);
+            // Factory methods.
+            static std::unique_ptr<GeometricPrimitive> __cdecl CreateCube(float size = 1, bool rhcoords = true, _In_opt_ ID3D12Device* device = nullptr);
+            static std::unique_ptr<GeometricPrimitive> __cdecl CreateBox(const XMFLOAT3& size, bool rhcoords = true, bool invertn = false, _In_opt_ ID3D12Device* device = nullptr);
+            static std::unique_ptr<GeometricPrimitive> __cdecl CreateSphere(float diameter = 1, size_t tessellation = 16, bool rhcoords = true, bool invertn = false, _In_opt_ ID3D12Device* device = nullptr);
+            static std::unique_ptr<GeometricPrimitive> __cdecl CreateGeoSphere(float diameter = 1, size_t tessellation = 3, bool rhcoords = true, _In_opt_ ID3D12Device* device = nullptr);
+            static std::unique_ptr<GeometricPrimitive> __cdecl CreateCylinder(float height = 1, float diameter = 1, size_t tessellation = 32, bool rhcoords = true, _In_opt_ ID3D12Device* device = nullptr);
+            static std::unique_ptr<GeometricPrimitive> __cdecl CreateCone(float diameter = 1, float height = 1, size_t tessellation = 32, bool rhcoords = true, _In_opt_ ID3D12Device* device = nullptr);
+            static std::unique_ptr<GeometricPrimitive> __cdecl CreateTorus(float diameter = 1, float thickness = 0.333f, size_t tessellation = 32, bool rhcoords = true, _In_opt_ ID3D12Device* device = nullptr);
+            static std::unique_ptr<GeometricPrimitive> __cdecl CreateTetrahedron(float size = 1, bool rhcoords = true, _In_opt_ ID3D12Device* device = nullptr);
+            static std::unique_ptr<GeometricPrimitive> __cdecl CreateOctahedron(float size = 1, bool rhcoords = true, _In_opt_ ID3D12Device* device = nullptr);
+            static std::unique_ptr<GeometricPrimitive> __cdecl CreateDodecahedron(float size = 1, bool rhcoords = true, _In_opt_ ID3D12Device* device = nullptr);
+            static std::unique_ptr<GeometricPrimitive> __cdecl CreateIcosahedron(float size = 1, bool rhcoords = true, _In_opt_ ID3D12Device* device = nullptr);
+            static std::unique_ptr<GeometricPrimitive> __cdecl CreateTeapot(float size = 1, size_t tessellation = 8, bool rhcoords = true, _In_opt_ ID3D12Device* device = nullptr);
+            static std::unique_ptr<GeometricPrimitive> __cdecl CreateCustom(const VertexCollection& vertices, const IndexCollection& indices, _In_opt_ ID3D12Device* device = nullptr);
 
-        // Load VB/IB resources for static geometry.
-        void __cdecl LoadStaticBuffers(
-            _In_ ID3D12Device* device,
-            ResourceUploadBatch& resourceUploadBatch);
+            static void __cdecl CreateCube(VertexCollection& vertices, IndexCollection& indices, float size = 1, bool rhcoords = true);
+            static void __cdecl CreateBox(VertexCollection& vertices, IndexCollection& indices, const XMFLOAT3& size, bool rhcoords = true, bool invertn = false);
+            static void __cdecl CreateSphere(VertexCollection& vertices, IndexCollection& indices, float diameter = 1, size_t tessellation = 16, bool rhcoords = true, bool invertn = false);
+            static void __cdecl CreateGeoSphere(VertexCollection& vertices, IndexCollection& indices, float diameter = 1, size_t tessellation = 3, bool rhcoords = true);
+            static void __cdecl CreateCylinder(VertexCollection& vertices, IndexCollection& indices, float height = 1, float diameter = 1, size_t tessellation = 32, bool rhcoords = true);
+            static void __cdecl CreateCone(VertexCollection& vertices, IndexCollection& indices, float diameter = 1, float height = 1, size_t tessellation = 32, bool rhcoords = true);
+            static void __cdecl CreateTorus(VertexCollection& vertices, IndexCollection& indices, float diameter = 1, float thickness = 0.333f, size_t tessellation = 32, bool rhcoords = true);
+            static void __cdecl CreateTetrahedron(VertexCollection& vertices, IndexCollection& indices, float size = 1, bool rhcoords = true);
+            static void __cdecl CreateOctahedron(VertexCollection& vertices, IndexCollection& indices, float size = 1, bool rhcoords = true);
+            static void __cdecl CreateDodecahedron(VertexCollection& vertices, IndexCollection& indices, float size = 1, bool rhcoords = true);
+            static void __cdecl CreateIcosahedron(VertexCollection& vertices, IndexCollection& indices, float size = 1, bool rhcoords = true);
+            static void __cdecl CreateTeapot(VertexCollection& vertices, IndexCollection& indices, float size = 1, size_t tessellation = 8, bool rhcoords = true);
 
-        // Transition VB/IB resources for static geometry.
-        void __cdecl Transition(
-            _In_ ID3D12GraphicsCommandList* commandList,
-            D3D12_RESOURCE_STATES stateBeforeVB,
-            D3D12_RESOURCE_STATES stateAfterVB,
-            D3D12_RESOURCE_STATES stateBeforeIB,
-            D3D12_RESOURCE_STATES stateAfterIB);
+            // Load VB/IB resources for static geometry.
+            void __cdecl LoadStaticBuffers(
+                _In_ ID3D12Device* device,
+                ResourceUploadBatch& resourceUploadBatch);
 
-        // Draw the primitive.
-        void __cdecl Draw(_In_ ID3D12GraphicsCommandList* commandList) const;
+            // Transition VB/IB resources for static geometry.
+            void __cdecl Transition(
+                _In_ ID3D12GraphicsCommandList* commandList,
+                D3D12_RESOURCE_STATES stateBeforeVB,
+                D3D12_RESOURCE_STATES stateAfterVB,
+                D3D12_RESOURCE_STATES stateBeforeIB,
+                D3D12_RESOURCE_STATES stateAfterIB);
 
-        void __cdecl DrawInstanced(_In_ ID3D12GraphicsCommandList* commandList, uint32_t instanceCount, uint32_t startInstanceLocation = 0) const;
+            // Draw the primitive.
+            void __cdecl Draw(_In_ ID3D12GraphicsCommandList* commandList) const;
 
-    private:
-        GeometricPrimitive() noexcept(false);
+            void __cdecl DrawInstanced(_In_ ID3D12GraphicsCommandList* commandList, uint32_t instanceCount, uint32_t startInstanceLocation = 0) const;
 
-        // Private implementation.
-        class Impl;
+        private:
+            GeometricPrimitive() noexcept(false);
 
-        std::unique_ptr<Impl> pImpl;
-    };
+            // Private implementation.
+            class Impl;
+
+            std::unique_ptr<Impl> pImpl;
+        };
+    }
 }

--- a/Inc/GraphicsMemory.h
+++ b/Inc/GraphicsMemory.h
@@ -29,155 +29,158 @@ namespace DirectX
 {
     class LinearAllocatorPage;
 
+    inline namespace DX12
+    {
     // Works a little like a smart pointer. The memory will only be fenced by the GPU once the pointer
     // has been invalidated or the user explicitly marks it for fencing.
-    class GraphicsResource
-    {
-    public:
-        GraphicsResource() noexcept;
-        GraphicsResource(
-            _In_ LinearAllocatorPage* page,
-            _In_ D3D12_GPU_VIRTUAL_ADDRESS gpuAddress,
-            _In_ ID3D12Resource* resource,
-            _In_ void* memory,
-            _In_ size_t offset,
-            _In_ size_t size) noexcept;
-
-        GraphicsResource(GraphicsResource&& other) noexcept;
-        GraphicsResource&& operator= (GraphicsResource&&) noexcept;
-
-        GraphicsResource(const GraphicsResource&) = delete;
-        GraphicsResource& operator= (const GraphicsResource&) = delete;
-
-        ~GraphicsResource();
-
-        D3D12_GPU_VIRTUAL_ADDRESS GpuAddress() const noexcept { return mGpuAddress; }
-        ID3D12Resource* Resource() const noexcept { return mResource; }
-        void* Memory() const noexcept { return mMemory; }
-        size_t ResourceOffset() const noexcept { return mBufferOffset; }
-        size_t Size() const noexcept { return mSize; }
-
-        explicit operator bool() const noexcept { return mResource != nullptr; }
-
-        // Clear the pointer. Using operator -> will produce bad results.
-        void __cdecl Reset() noexcept;
-        void __cdecl Reset(GraphicsResource&&) noexcept;
-
-    private:
-        LinearAllocatorPage*        mPage;
-        D3D12_GPU_VIRTUAL_ADDRESS   mGpuAddress;
-        ID3D12Resource*             mResource;
-        void*                       mMemory;
-        size_t                      mBufferOffset;
-        size_t                      mSize;
-    };
-
-    class SharedGraphicsResource
-    {
-    public:
-        SharedGraphicsResource() noexcept;
-
-        SharedGraphicsResource(SharedGraphicsResource&&) noexcept;
-        SharedGraphicsResource&& operator= (SharedGraphicsResource&&) noexcept;
-
-        SharedGraphicsResource(GraphicsResource&&);
-        SharedGraphicsResource&& operator= (GraphicsResource&&);
-
-        SharedGraphicsResource(const SharedGraphicsResource&) noexcept;
-        SharedGraphicsResource& operator= (const SharedGraphicsResource&) noexcept;
-
-        SharedGraphicsResource(const GraphicsResource&) = delete;
-        SharedGraphicsResource& operator= (const GraphicsResource&) = delete;
-
-        ~SharedGraphicsResource();
-
-        D3D12_GPU_VIRTUAL_ADDRESS GpuAddress() const noexcept { return mSharedResource->GpuAddress(); }
-        ID3D12Resource* Resource() const noexcept { return mSharedResource->Resource(); }
-        void* Memory() const noexcept { return mSharedResource->Memory(); }
-        size_t ResourceOffset() const noexcept { return mSharedResource->ResourceOffset(); }
-        size_t Size() const noexcept { return mSharedResource->Size(); }
-
-        explicit operator bool() const noexcept { return mSharedResource != nullptr; }
-
-        bool operator == (const SharedGraphicsResource& other) const noexcept { return mSharedResource.get() == other.mSharedResource.get(); }
-        bool operator != (const SharedGraphicsResource& other) const noexcept { return mSharedResource.get() != other.mSharedResource.get(); }
-
-        // Clear the pointer. Using operator -> will produce bad results.
-        void __cdecl Reset() noexcept;
-        void __cdecl Reset(GraphicsResource&&);
-        void __cdecl Reset(SharedGraphicsResource&&) noexcept;
-        void __cdecl Reset(const SharedGraphicsResource& resource) noexcept;
-
-    private:
-        std::shared_ptr<GraphicsResource> mSharedResource;
-    };
-
-    //----------------------------------------------------------------------------------
-    struct GraphicsMemoryStatistics
-    {
-        size_t committedMemory;     // Bytes of memory currently committed/in-flight
-        size_t totalMemory;         // Total bytes of memory used by the allocators
-        size_t totalPages;          // Total page count
-        size_t peakCommitedMemory;  // Peak commited memory value since last reset
-        size_t peakTotalMemory;     // Peak total bytes
-        size_t peakTotalPages;      // Peak total page count
-    };
-
-    //----------------------------------------------------------------------------------
-    class GraphicsMemory
-    {
-    public:
-        explicit GraphicsMemory(_In_ ID3D12Device* device);
-
-        GraphicsMemory(GraphicsMemory&&) noexcept;
-        GraphicsMemory& operator= (GraphicsMemory&&) noexcept;
-
-        GraphicsMemory(GraphicsMemory const&) = delete;
-        GraphicsMemory& operator=(GraphicsMemory const&) = delete;
-
-        virtual ~GraphicsMemory();
-
-        // Make sure to keep the GraphicsResource handle alive as long as you need to access
-        // the memory on the CPU. For example, do not simply cache GpuAddress() and discard
-        // the GraphicsResource object, or your memory may be overwritten later.
-        GraphicsResource __cdecl Allocate(size_t size, size_t alignment = 16);
-
-        // Special overload of Allocate that aligns to D3D12 constant buffer alignment requirements
-        template<typename T> GraphicsResource AllocateConstant()
+        class GraphicsResource
         {
-            constexpr size_t alignment = D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT;
-            constexpr size_t alignedSize = (sizeof(T) + alignment - 1) & ~(alignment - 1);
-            return Allocate(alignedSize, alignment);
-        }
-        template<typename T> GraphicsResource AllocateConstant(const T& setData)
+        public:
+            GraphicsResource() noexcept;
+            GraphicsResource(
+                _In_ LinearAllocatorPage* page,
+                _In_ D3D12_GPU_VIRTUAL_ADDRESS gpuAddress,
+                _In_ ID3D12Resource* resource,
+                _In_ void* memory,
+                _In_ size_t offset,
+                _In_ size_t size) noexcept;
+
+            GraphicsResource(GraphicsResource&& other) noexcept;
+            GraphicsResource&& operator= (GraphicsResource&&) noexcept;
+
+            GraphicsResource(const GraphicsResource&) = delete;
+            GraphicsResource& operator= (const GraphicsResource&) = delete;
+
+            ~GraphicsResource();
+
+            D3D12_GPU_VIRTUAL_ADDRESS GpuAddress() const noexcept { return mGpuAddress; }
+            ID3D12Resource* Resource() const noexcept { return mResource; }
+            void* Memory() const noexcept { return mMemory; }
+            size_t ResourceOffset() const noexcept { return mBufferOffset; }
+            size_t Size() const noexcept { return mSize; }
+
+            explicit operator bool() const noexcept { return mResource != nullptr; }
+
+            // Clear the pointer. Using operator -> will produce bad results.
+            void __cdecl Reset() noexcept;
+            void __cdecl Reset(GraphicsResource&&) noexcept;
+
+        private:
+            LinearAllocatorPage*        mPage;
+            D3D12_GPU_VIRTUAL_ADDRESS   mGpuAddress;
+            ID3D12Resource*             mResource;
+            void*                       mMemory;
+            size_t                      mBufferOffset;
+            size_t                      mSize;
+        };
+
+        class SharedGraphicsResource
         {
-            GraphicsResource alloc = AllocateConstant<T>();
-            memcpy(alloc.Memory(), &setData, sizeof(T));
-            return alloc;
-        }
+        public:
+            SharedGraphicsResource() noexcept;
 
-        // Submits all the pending one-shot memory to the GPU.
-        // The memory will be recycled once the GPU is done with it.
-        void __cdecl Commit(_In_ ID3D12CommandQueue* commandQueue);
+            SharedGraphicsResource(SharedGraphicsResource&&) noexcept;
+            SharedGraphicsResource&& operator= (SharedGraphicsResource&&) noexcept;
 
-        // This frees up any unused memory.
-        // If you want to make sure all memory is reclaimed, idle the GPU before calling this.
-        // It is not recommended that you call this unless absolutely necessary (e.g. your
-        // memory budget changes at run-time, or perhaps you're changing levels in your game.)
-        void __cdecl GarbageCollect();
+            SharedGraphicsResource(GraphicsResource&&);
+            SharedGraphicsResource&& operator= (GraphicsResource&&);
 
-        // Memory statistics
-        GraphicsMemoryStatistics __cdecl GetStatistics();
-        void __cdecl ResetStatistics();
+            SharedGraphicsResource(const SharedGraphicsResource&) noexcept;
+            SharedGraphicsResource& operator= (const SharedGraphicsResource&) noexcept;
 
-        // Singleton
-        // Should only use nullptr for single GPU scenarios; mGPU requires a specific device
-        static GraphicsMemory& __cdecl Get(_In_opt_ ID3D12Device* device = nullptr);
+            SharedGraphicsResource(const GraphicsResource&) = delete;
+            SharedGraphicsResource& operator= (const GraphicsResource&) = delete;
 
-    private:
-        // Private implementation.
-        class Impl;
+            ~SharedGraphicsResource();
 
-        std::unique_ptr<Impl> pImpl;
-    };
+            D3D12_GPU_VIRTUAL_ADDRESS GpuAddress() const noexcept { return mSharedResource->GpuAddress(); }
+            ID3D12Resource* Resource() const noexcept { return mSharedResource->Resource(); }
+            void* Memory() const noexcept { return mSharedResource->Memory(); }
+            size_t ResourceOffset() const noexcept { return mSharedResource->ResourceOffset(); }
+            size_t Size() const noexcept { return mSharedResource->Size(); }
+
+            explicit operator bool() const noexcept { return mSharedResource != nullptr; }
+
+            bool operator == (const SharedGraphicsResource& other) const noexcept { return mSharedResource.get() == other.mSharedResource.get(); }
+            bool operator != (const SharedGraphicsResource& other) const noexcept { return mSharedResource.get() != other.mSharedResource.get(); }
+
+            // Clear the pointer. Using operator -> will produce bad results.
+            void __cdecl Reset() noexcept;
+            void __cdecl Reset(GraphicsResource&&);
+            void __cdecl Reset(SharedGraphicsResource&&) noexcept;
+            void __cdecl Reset(const SharedGraphicsResource& resource) noexcept;
+
+        private:
+            std::shared_ptr<GraphicsResource> mSharedResource;
+        };
+
+        //------------------------------------------------------------------------------
+        struct GraphicsMemoryStatistics
+        {
+            size_t committedMemory;     // Bytes of memory currently committed/in-flight
+            size_t totalMemory;         // Total bytes of memory used by the allocators
+            size_t totalPages;          // Total page count
+            size_t peakCommitedMemory;  // Peak commited memory value since last reset
+            size_t peakTotalMemory;     // Peak total bytes
+            size_t peakTotalPages;      // Peak total page count
+        };
+
+        //------------------------------------------------------------------------------
+        class GraphicsMemory
+        {
+        public:
+            explicit GraphicsMemory(_In_ ID3D12Device* device);
+
+            GraphicsMemory(GraphicsMemory&&) noexcept;
+            GraphicsMemory& operator= (GraphicsMemory&&) noexcept;
+
+            GraphicsMemory(GraphicsMemory const&) = delete;
+            GraphicsMemory& operator=(GraphicsMemory const&) = delete;
+
+            virtual ~GraphicsMemory();
+
+            // Make sure to keep the GraphicsResource handle alive as long as you need to access
+            // the memory on the CPU. For example, do not simply cache GpuAddress() and discard
+            // the GraphicsResource object, or your memory may be overwritten later.
+            GraphicsResource __cdecl Allocate(size_t size, size_t alignment = 16);
+
+            // Special overload of Allocate that aligns to D3D12 constant buffer alignment requirements
+            template<typename T> GraphicsResource AllocateConstant()
+            {
+                constexpr size_t alignment = D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT;
+                constexpr size_t alignedSize = (sizeof(T) + alignment - 1) & ~(alignment - 1);
+                return Allocate(alignedSize, alignment);
+            }
+            template<typename T> GraphicsResource AllocateConstant(const T& setData)
+            {
+                GraphicsResource alloc = AllocateConstant<T>();
+                memcpy(alloc.Memory(), &setData, sizeof(T));
+                return alloc;
+            }
+
+            // Submits all the pending one-shot memory to the GPU.
+            // The memory will be recycled once the GPU is done with it.
+            void __cdecl Commit(_In_ ID3D12CommandQueue* commandQueue);
+
+            // This frees up any unused memory.
+            // If you want to make sure all memory is reclaimed, idle the GPU before calling this.
+            // It is not recommended that you call this unless absolutely necessary (e.g. your
+            // memory budget changes at run-time, or perhaps you're changing levels in your game.)
+            void __cdecl GarbageCollect();
+
+            // Memory statistics
+            GraphicsMemoryStatistics __cdecl GetStatistics();
+            void __cdecl ResetStatistics();
+
+            // Singleton
+            // Should only use nullptr for single GPU scenarios; mGPU requires a specific device
+            static GraphicsMemory& __cdecl Get(_In_opt_ ID3D12Device* device = nullptr);
+
+        private:
+            // Private implementation.
+            class Impl;
+
+            std::unique_ptr<Impl> pImpl;
+        };
+    }
 }

--- a/Inc/Model.h
+++ b/Inc/Model.h
@@ -48,148 +48,556 @@
 
 namespace DirectX
 {
-    class IEffect;
-    class IEffectFactory;
-    class ModelMesh;
-
-    //----------------------------------------------------------------------------------
-    // Model loading options
-    enum ModelLoaderFlags : uint32_t
+    inline namespace DX12
     {
-        ModelLoader_Default = 0x0,
-        ModelLoader_MaterialColorsSRGB = 0x1,
-        ModelLoader_AllowLargeModels = 0x2,
-        ModelLoader_IncludeBones = 0x4,
-        ModelLoader_DisableSkinning = 0x8,
-    };
+        class IEffect;
+        class IEffectFactory;
+        class ModelMesh;
 
-    //----------------------------------------------------------------------------------
-    // Frame hierarchy for rigid body and skeletal animation
-    struct ModelBone
-    {
-        ModelBone() noexcept :
-            parentIndex(c_Invalid),
-            childIndex(c_Invalid),
-            siblingIndex(c_Invalid)
+        //------------------------------------------------------------------------------
+        // Model loading options
+        enum ModelLoaderFlags : uint32_t
         {
-        }
+            ModelLoader_Default = 0x0,
+            ModelLoader_MaterialColorsSRGB = 0x1,
+            ModelLoader_AllowLargeModels = 0x2,
+            ModelLoader_IncludeBones = 0x4,
+            ModelLoader_DisableSkinning = 0x8,
+        };
 
-        ModelBone(uint32_t parent, uint32_t child, uint32_t sibling) noexcept :
-            parentIndex(parent),
-            childIndex(child),
-            siblingIndex(sibling)
+        //------------------------------------------------------------------------------
+        // Frame hierarchy for rigid body and skeletal animation
+        struct ModelBone
         {
-        }
-
-        uint32_t            parentIndex;
-        uint32_t            childIndex;
-        uint32_t            siblingIndex;
-        std::wstring        name;
-
-        using Collection = std::vector<ModelBone>;
-
-        static constexpr uint32_t c_Invalid = uint32_t(-1);
-
-        struct aligned_deleter { void operator()(void* p) noexcept { _aligned_free(p); } };
-
-        using TransformArray = std::unique_ptr<XMMATRIX[], aligned_deleter>;
-
-        static TransformArray MakeArray(size_t count)
-        {
-            void* temp = _aligned_malloc(sizeof(XMMATRIX) * count, 16);
-            if (!temp)
-                throw std::bad_alloc();
-            return TransformArray(static_cast<XMMATRIX*>(temp));
-        }
-    };
-
-    //----------------------------------------------------------------------------------
-    // Each mesh part is a submesh with a single effect
-    class ModelMeshPart
-    {
-    public:
-        ModelMeshPart(uint32_t partIndex) noexcept;
-
-        ModelMeshPart(ModelMeshPart&&) = default;
-        ModelMeshPart& operator= (ModelMeshPart&&) = default;
-
-        ModelMeshPart(ModelMeshPart const&) = default;
-        ModelMeshPart& operator= (ModelMeshPart const&) = default;
-
-        virtual ~ModelMeshPart();
-
-        using Collection = std::vector<std::unique_ptr<ModelMeshPart>>;
-        using DrawCallback = std::function<void(_In_ ID3D12GraphicsCommandList* commandList, const ModelMeshPart& part)>;
-        using InputLayoutCollection = std::vector<D3D12_INPUT_ELEMENT_DESC>;
-
-        uint32_t                                                partIndex;      // Unique index assigned per-part in a model.
-        uint32_t                                                materialIndex;  // Index of the material spec to use
-        uint32_t                                                indexCount;
-        uint32_t                                                startIndex;
-        int32_t                                                 vertexOffset;
-        uint32_t                                                vertexStride;
-        uint32_t                                                vertexCount;
-        uint32_t                                                indexBufferSize;
-        uint32_t                                                vertexBufferSize;
-        D3D_PRIMITIVE_TOPOLOGY                                  primitiveType;
-        DXGI_FORMAT                                             indexFormat;
-        SharedGraphicsResource                                  indexBuffer;
-        SharedGraphicsResource                                  vertexBuffer;
-        Microsoft::WRL::ComPtr<ID3D12Resource>                  staticIndexBuffer;
-        Microsoft::WRL::ComPtr<ID3D12Resource>                  staticVertexBuffer;
-        std::shared_ptr<InputLayoutCollection>                  vbDecl;
-
-        // Draw mesh part
-        void __cdecl Draw(_In_ ID3D12GraphicsCommandList* commandList) const;
-
-        void __cdecl DrawInstanced(_In_ ID3D12GraphicsCommandList* commandList, uint32_t instanceCount, uint32_t startInstance = 0) const;
-
-        //
-        // Utilities for drawing multiple mesh parts
-        //
-
-        // Draw the mesh
-        static void __cdecl DrawMeshParts(_In_ ID3D12GraphicsCommandList* commandList, const Collection& meshParts);
-
-        // Draw the mesh with an effect
-        static void __cdecl DrawMeshParts(_In_ ID3D12GraphicsCommandList* commandList, const Collection& meshParts, _In_ IEffect* effect);
-
-        // Draw the mesh with a callback for each mesh part
-        static void __cdecl DrawMeshParts(_In_ ID3D12GraphicsCommandList* commandList, const Collection& meshParts, DrawCallback callback);
-
-        // Draw the mesh with a range of effects that mesh parts will index into.
-        // Effects can be any IEffect pointer type (including smart pointer). Value or reference types will not compile.
-        // The iterator passed to this method should have random access capabilities for best performance.
-        template<typename TEffectIterator, typename TEffectIteratorCategory = typename TEffectIterator::iterator_category>
-        static void DrawMeshParts(
-            _In_ ID3D12GraphicsCommandList* commandList,
-            const Collection& meshParts,
-            TEffectIterator partEffects)
-        {
-            // This assert is here to prevent accidental use of containers that would cause undesirable performance penalties.
-            static_assert(
-                std::is_base_of<std::random_access_iterator_tag, TEffectIteratorCategory>::value,
-                "Providing an iterator without random access capabilities -- such as from std::list -- is not supported.");
-
-            for (const auto& it : meshParts)
+            ModelBone() noexcept :
+                parentIndex(c_Invalid),
+                childIndex(c_Invalid),
+                siblingIndex(c_Invalid)
             {
-                auto part = it.get();
-                assert(part != nullptr);
-
-                // Get the effect at the location specified by the part's material
-                TEffectIterator effect_iterator = partEffects;
-                std::advance(effect_iterator, part->partIndex);
-
-                // Apply the effect and draw
-                (*effect_iterator)->Apply(commandList);
-                part->Draw(commandList);
             }
-        }
 
-        template<typename TEffectIterator, typename TEffectIteratorCategory = typename TEffectIterator::iterator_category>
-        static void XM_CALLCONV DrawMeshParts(
+            ModelBone(uint32_t parent, uint32_t child, uint32_t sibling) noexcept :
+                parentIndex(parent),
+                childIndex(child),
+                siblingIndex(sibling)
+            {
+            }
+
+            uint32_t            parentIndex;
+            uint32_t            childIndex;
+            uint32_t            siblingIndex;
+            std::wstring        name;
+
+            using Collection = std::vector<ModelBone>;
+
+            static constexpr uint32_t c_Invalid = uint32_t(-1);
+
+            struct aligned_deleter { void operator()(void* p) noexcept { _aligned_free(p); } };
+
+            using TransformArray = std::unique_ptr<XMMATRIX[], aligned_deleter>;
+
+            static TransformArray MakeArray(size_t count)
+            {
+                void* temp = _aligned_malloc(sizeof(XMMATRIX) * count, 16);
+                if (!temp)
+                    throw std::bad_alloc();
+                return TransformArray(static_cast<XMMATRIX*>(temp));
+            }
+        };
+
+        //------------------------------------------------------------------------------
+        // Each mesh part is a submesh with a single effect
+        class ModelMeshPart
+        {
+        public:
+            ModelMeshPart(uint32_t partIndex) noexcept;
+
+            ModelMeshPart(ModelMeshPart&&) = default;
+            ModelMeshPart& operator= (ModelMeshPart&&) = default;
+
+            ModelMeshPart(ModelMeshPart const&) = default;
+            ModelMeshPart& operator= (ModelMeshPart const&) = default;
+
+            virtual ~ModelMeshPart();
+
+            using Collection = std::vector<std::unique_ptr<ModelMeshPart>>;
+            using DrawCallback = std::function<void(_In_ ID3D12GraphicsCommandList* commandList, const ModelMeshPart& part)>;
+            using InputLayoutCollection = std::vector<D3D12_INPUT_ELEMENT_DESC>;
+
+            uint32_t                                                partIndex;      // Unique index assigned per-part in a model.
+            uint32_t                                                materialIndex;  // Index of the material spec to use
+            uint32_t                                                indexCount;
+            uint32_t                                                startIndex;
+            int32_t                                                 vertexOffset;
+            uint32_t                                                vertexStride;
+            uint32_t                                                vertexCount;
+            uint32_t                                                indexBufferSize;
+            uint32_t                                                vertexBufferSize;
+            D3D_PRIMITIVE_TOPOLOGY                                  primitiveType;
+            DXGI_FORMAT                                             indexFormat;
+            SharedGraphicsResource                                  indexBuffer;
+            SharedGraphicsResource                                  vertexBuffer;
+            Microsoft::WRL::ComPtr<ID3D12Resource>                  staticIndexBuffer;
+            Microsoft::WRL::ComPtr<ID3D12Resource>                  staticVertexBuffer;
+            std::shared_ptr<InputLayoutCollection>                  vbDecl;
+
+            // Draw mesh part
+            void __cdecl Draw(_In_ ID3D12GraphicsCommandList* commandList) const;
+
+            void __cdecl DrawInstanced(_In_ ID3D12GraphicsCommandList* commandList, uint32_t instanceCount, uint32_t startInstance = 0) const;
+
+            //
+            // Utilities for drawing multiple mesh parts
+            //
+
+            // Draw the mesh
+            static void __cdecl DrawMeshParts(_In_ ID3D12GraphicsCommandList* commandList, const Collection& meshParts);
+
+            // Draw the mesh with an effect
+            static void __cdecl DrawMeshParts(_In_ ID3D12GraphicsCommandList* commandList, const Collection& meshParts, _In_ IEffect* effect);
+
+            // Draw the mesh with a callback for each mesh part
+            static void __cdecl DrawMeshParts(_In_ ID3D12GraphicsCommandList* commandList, const Collection& meshParts, DrawCallback callback);
+
+            // Draw the mesh with a range of effects that mesh parts will index into.
+            // Effects can be any IEffect pointer type (including smart pointer). Value or reference types will not compile.
+            // The iterator passed to this method should have random access capabilities for best performance.
+            template<typename TEffectIterator, typename TEffectIteratorCategory = typename TEffectIterator::iterator_category>
+            static void DrawMeshParts(
+                _In_ ID3D12GraphicsCommandList* commandList,
+                const Collection& meshParts,
+                TEffectIterator partEffects)
+            {
+                // This assert is here to prevent accidental use of containers that would cause undesirable performance penalties.
+                static_assert(
+                    std::is_base_of<std::random_access_iterator_tag, TEffectIteratorCategory>::value,
+                    "Providing an iterator without random access capabilities -- such as from std::list -- is not supported.");
+
+                for (const auto& it : meshParts)
+                {
+                    auto part = it.get();
+                    assert(part != nullptr);
+
+                    // Get the effect at the location specified by the part's material
+                    TEffectIterator effect_iterator = partEffects;
+                    std::advance(effect_iterator, part->partIndex);
+
+                    // Apply the effect and draw
+                    (*effect_iterator)->Apply(commandList);
+                    part->Draw(commandList);
+                }
+            }
+
+            template<typename TEffectIterator, typename TEffectIteratorCategory = typename TEffectIterator::iterator_category>
+            static void XM_CALLCONV DrawMeshParts(
+                _In_ ID3D12GraphicsCommandList* commandList,
+                const Collection& meshParts,
+                FXMMATRIX world,
+                TEffectIterator partEffects)
+            {
+                // This assert is here to prevent accidental use of containers that would cause undesirable performance penalties.
+                static_assert(
+                    std::is_base_of<std::random_access_iterator_tag, TEffectIteratorCategory>::value,
+                    "Providing an iterator without random access capabilities -- such as from std::list -- is not supported.");
+
+                for (const auto& it : meshParts)
+                {
+                    auto part = it.get();
+                    assert(part != nullptr);
+
+                    // Get the effect at the location specified by the part's material
+                    TEffectIterator effect_iterator = partEffects;
+                    std::advance(effect_iterator, part->partIndex);
+
+                    auto imatrices = dynamic_cast<IEffectMatrices*>((*effect_iterator).get());
+                    if (imatrices)
+                    {
+                        imatrices->SetWorld(world);
+                    }
+
+                    // Apply the effect and draw
+                    (*effect_iterator)->Apply(commandList);
+                    part->Draw(commandList);
+                }
+            }
+
+            template<typename TEffectIterator, typename TEffectIteratorCategory = typename TEffectIterator::iterator_category>
+            static void XM_CALLCONV DrawSkinnedMeshParts(
+                _In_ ID3D12GraphicsCommandList* commandList,
+                const ModelMesh& mesh,
+                const Collection& meshParts,
+                size_t nbones,
+                _In_reads_(nbones) const XMMATRIX* boneTransforms,
+                FXMMATRIX world,
+                TEffectIterator partEffects);
+        };
+
+
+        //------------------------------------------------------------------------------
+        // A mesh consists of one or more model mesh parts
+        class ModelMesh
+        {
+        public:
+            ModelMesh() noexcept;
+
+            ModelMesh(ModelMesh&&) = default;
+            ModelMesh& operator= (ModelMesh&&) = default;
+
+            ModelMesh(ModelMesh const&) = default;
+            ModelMesh& operator= (ModelMesh const&) = default;
+
+            virtual ~ModelMesh();
+
+            BoundingSphere              boundingSphere;
+            BoundingBox                 boundingBox;
+            ModelMeshPart::Collection   opaqueMeshParts;
+            ModelMeshPart::Collection   alphaMeshParts;
+            uint32_t                    boneIndex;
+            std::vector<uint32_t>       boneInfluences;
+            std::wstring                name;
+
+            using Collection = std::vector<std::shared_ptr<ModelMesh>>;
+
+            // Draw the mesh
+            void __cdecl DrawOpaque(_In_ ID3D12GraphicsCommandList* commandList) const;
+            void __cdecl DrawAlpha(_In_ ID3D12GraphicsCommandList* commandList) const;
+
+            // Draw the mesh with an effect
+            void __cdecl DrawOpaque(_In_ ID3D12GraphicsCommandList* commandList, _In_ IEffect* effect) const;
+            void __cdecl DrawAlpha(_In_ ID3D12GraphicsCommandList* commandList, _In_ IEffect* effect) const;
+
+            // Draw the mesh with a callback for each mesh part
+            void __cdecl DrawOpaque(_In_ ID3D12GraphicsCommandList* commandList, ModelMeshPart::DrawCallback callback) const;
+            void __cdecl DrawAlpha(_In_ ID3D12GraphicsCommandList* commandList, ModelMeshPart::DrawCallback callback) const;
+
+            // Draw the mesh with a range of effects that mesh parts will index into.
+            // TEffectPtr can be any IEffect pointer type (including smart pointer). Value or reference types will not compile.
+            template<typename TEffectIterator, typename TEffectIteratorCategory = typename TEffectIterator::iterator_category>
+            void DrawOpaque(_In_ ID3D12GraphicsCommandList* commandList, TEffectIterator effects) const
+            {
+                ModelMeshPart::DrawMeshParts<TEffectIterator, TEffectIteratorCategory>(commandList, opaqueMeshParts, effects);
+            }
+            template<typename TEffectIterator, typename TEffectIteratorCategory = typename TEffectIterator::iterator_category>
+            void DrawAlpha(_In_ ID3D12GraphicsCommandList* commandList, TEffectIterator effects) const
+            {
+                ModelMeshPart::DrawMeshParts<TEffectIterator, TEffectIteratorCategory>(commandList, alphaMeshParts, effects);
+            }
+
+            // Draw rigid-body with bones.
+            template<typename TEffectIterator, typename TEffectIteratorCategory = typename TEffectIterator::iterator_category>
+            void XM_CALLCONV DrawOpaque(
+                _In_ ID3D12GraphicsCommandList* commandList,
+                size_t nbones,
+                _In_reads_(nbones) const XMMATRIX* boneTransforms,
+                FXMMATRIX world,
+                TEffectIterator effects) const
+            {
+                assert(nbones > 0 && boneTransforms != nullptr);
+                XMMATRIX local;
+                if (boneIndex != ModelBone::c_Invalid && boneIndex < nbones)
+                {
+                    local = XMMatrixMultiply(boneTransforms[boneIndex], world);
+                }
+                else
+                {
+                    local = world;
+                }
+
+                ModelMeshPart::DrawMeshParts<TEffectIterator, TEffectIteratorCategory>(commandList, opaqueMeshParts, local, effects);
+            }
+
+            template<typename TEffectIterator, typename TEffectIteratorCategory = typename TEffectIterator::iterator_category>
+            void XM_CALLCONV DrawAlpha(
+                _In_ ID3D12GraphicsCommandList* commandList,
+                size_t nbones,
+                _In_reads_(nbones) const XMMATRIX* boneTransforms,
+                FXMMATRIX world,
+                TEffectIterator effects) const
+            {
+                assert(nbones > 0 && boneTransforms != nullptr);
+                XMMATRIX local;
+                if (boneIndex != ModelBone::c_Invalid && boneIndex < nbones)
+                {
+                    local = XMMatrixMultiply(boneTransforms[boneIndex], world);
+                }
+                else
+                {
+                    local = world;
+                }
+
+                ModelMeshPart::DrawMeshParts<TEffectIterator, TEffectIteratorCategory>(commandList, alphaMeshParts, local, effects);
+            }
+
+            // Draw using skinning given bone transform array.
+            template<typename TEffectIterator, typename TEffectIteratorCategory = typename TEffectIterator::iterator_category>
+            void XM_CALLCONV DrawSkinnedOpaque(
+                _In_ ID3D12GraphicsCommandList* commandList,
+                size_t nbones,
+                _In_reads_(nbones) const XMMATRIX* boneTransforms,
+                FXMMATRIX world,
+                TEffectIterator effects) const
+            {
+                ModelMeshPart::DrawSkinnedMeshParts<TEffectIterator, TEffectIteratorCategory>(commandList, *this, opaqueMeshParts,
+                    nbones, boneTransforms, world, effects);
+            }
+
+            template<typename TEffectIterator, typename TEffectIteratorCategory = typename TEffectIterator::iterator_category>
+            void XM_CALLCONV DrawSkinnedAlpha(
+                _In_ ID3D12GraphicsCommandList* commandList,
+                size_t nbones,
+                _In_reads_(nbones) const XMMATRIX* boneTransforms,
+                FXMMATRIX world,
+                TEffectIterator effects) const
+            {
+                ModelMeshPart::DrawSkinnedMeshParts<TEffectIterator, TEffectIteratorCategory>(commandList, *this, alphaMeshParts,
+                    nbones, boneTransforms, world, effects);
+            }
+        };
+
+
+        //------------------------------------------------------------------------------
+        // A model consists of one or more meshes
+        class Model
+        {
+        public:
+            Model() noexcept;
+
+            Model(Model&&) = default;
+            Model& operator= (Model&&) = default;
+
+            Model(Model const& other);
+            Model& operator= (Model const& rhs);
+
+            virtual ~Model();
+
+            using EffectCollection = std::vector<std::shared_ptr<IEffect>>;
+            using ModelMaterialInfo = IEffectFactory::EffectInfo;
+            using ModelMaterialInfoCollection = std::vector<ModelMaterialInfo>;
+            using TextureCollection = std::vector<std::wstring>;
+
+            // The Model::Draw* functions use variadic templates and perfect-forwarding in order to support future
+            // overloads to the ModelMesh::Draw* family of functions. This means that a new ModelMesh overload can be
+            // added, removed or altered, but the Model routines will still remain compatible. The correct ModelMesh
+            // overload will be selected by the compiler depending on the arguments you provide to the Model method.
+
+            // Draw all the meshes in the model.
+            template<typename... TForwardArgs> void DrawOpaque(_In_ ID3D12GraphicsCommandList* commandList, TForwardArgs&&... args) const
+            {
+                // Draw opaque parts
+                for (const auto& it : meshes)
+                {
+                    auto mesh = it.get();
+                    assert(mesh != nullptr);
+
+                    mesh->DrawOpaque(commandList, std::forward<TForwardArgs>(args)...);
+                }
+            }
+
+            template<typename... TForwardArgs> void DrawAlpha(_In_ ID3D12GraphicsCommandList* commandList, TForwardArgs&&... args) const
+            {
+                // Draw alpha parts
+                for (const auto& it : meshes)
+                {
+                    auto mesh = it.get();
+                    assert(mesh != nullptr);
+
+                    mesh->DrawAlpha(commandList, std::forward<TForwardArgs>(args)...);
+                }
+            }
+
+            template<typename... TForwardArgs> void Draw(_In_ ID3D12GraphicsCommandList* commandList, TForwardArgs&&... args) const
+            {
+                DrawOpaque(commandList, args...);
+                DrawAlpha(commandList, std::forward<TForwardArgs>(args)...);
+            }
+
+            // Draw mesh using skinning given bone transform array.
+            template<typename... TForwardArgs> void DrawSkinnedOpaque(_In_ ID3D12GraphicsCommandList* commandList, TForwardArgs&&... args) const
+            {
+                // Draw opaque parts
+                for (const auto& it : meshes)
+                {
+                    auto mesh = it.get();
+                    assert(mesh != nullptr);
+
+                    mesh->DrawSkinnedOpaque(commandList, std::forward<TForwardArgs>(args)...);
+                }
+            }
+
+            template<typename... TForwardArgs> void DrawSkinnedAlpha(_In_ ID3D12GraphicsCommandList* commandList, TForwardArgs&&... args) const
+            {
+                // Draw alpha parts
+                for (const auto& it : meshes)
+                {
+                    auto mesh = it.get();
+                    assert(mesh != nullptr);
+
+                    mesh->DrawSkinnedAlpha(commandList, std::forward<TForwardArgs>(args)...);
+                }
+            }
+
+            template<typename... TForwardArgs> void DrawSkinned(_In_ ID3D12GraphicsCommandList* commandList, TForwardArgs&&... args) const
+            {
+                DrawSkinnedOpaque(commandList, args...);
+                DrawSkinnedAlpha(commandList, std::forward<TForwardArgs>(args)...);
+            }
+
+            // Load texture resources into an existing Effect Texture Factory
+            int __cdecl LoadTextures(IEffectTextureFactory& texFactory, int destinationDescriptorOffset = 0) const;
+
+            // Load texture resources into a new Effect Texture Factory
+            std::unique_ptr<EffectTextureFactory> __cdecl LoadTextures(
+                _In_ ID3D12Device* device,
+                ResourceUploadBatch& resourceUploadBatch,
+                _In_opt_z_ const wchar_t* texturesPath = nullptr,
+                D3D12_DESCRIPTOR_HEAP_FLAGS flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE) const;
+
+            // Load VB/IB resources for static geometry
+            void __cdecl LoadStaticBuffers(
+                _In_ ID3D12Device* device,
+                ResourceUploadBatch& resourceUploadBatch,
+                bool keepMemory = false);
+
+            // Create effects using the default effect factory
+            EffectCollection __cdecl CreateEffects(
+                const EffectPipelineStateDescription& opaquePipelineState,
+                const EffectPipelineStateDescription& alphaPipelineState,
+                _In_ ID3D12DescriptorHeap* textureDescriptorHeap,
+                _In_ ID3D12DescriptorHeap* samplerDescriptorHeap,
+                int textureDescriptorOffset = 0,
+                int samplerDescriptorOffset = 0) const;
+
+            // Create effects using a custom effect factory
+            EffectCollection __cdecl CreateEffects(
+                IEffectFactory& fxFactory,
+                const EffectPipelineStateDescription& opaquePipelineState,
+                const EffectPipelineStateDescription& alphaPipelineState,
+                int textureDescriptorOffset = 0,
+                int samplerDescriptorOffset = 0) const;
+
+            // Compute bone positions based on heirarchy and transform matrices
+            void __cdecl CopyAbsoluteBoneTransformsTo(
+                size_t nbones,
+                _Out_writes_(nbones) XMMATRIX* boneTransforms) const;
+
+            void __cdecl CopyAbsoluteBoneTransforms(
+                size_t nbones,
+                _In_reads_(nbones) const XMMATRIX* inBoneTransforms,
+                _Out_writes_(nbones) XMMATRIX* outBoneTransforms) const;
+
+            // Set bone matrices to a set of relative tansforms
+            void __cdecl CopyBoneTransformsFrom(
+                size_t nbones,
+                _In_reads_(nbones) const XMMATRIX* boneTransforms);
+
+            // Copies the relative bone matrices to a transform array
+            void __cdecl CopyBoneTransformsTo(
+                size_t nbones,
+                _Out_writes_(nbones) XMMATRIX* boneTransforms) const;
+
+            // Loads a model from a Visual Studio Starter Kit .CMO file
+            static std::unique_ptr<Model> __cdecl CreateFromCMO(
+                _In_opt_ ID3D12Device* device,
+                _In_reads_bytes_(dataSize) const uint8_t* meshData, _In_ size_t dataSize,
+                ModelLoaderFlags flags = ModelLoader_Default,
+                _Out_opt_ size_t* animsOffset = nullptr);
+            static std::unique_ptr<Model> __cdecl CreateFromCMO(
+                _In_opt_ ID3D12Device* device,
+                _In_z_ const wchar_t* szFileName,
+                ModelLoaderFlags flags = ModelLoader_Default,
+                _Out_opt_ size_t* animsOffset = nullptr);
+
+            // Loads a model from a DirectX SDK .SDKMESH file
+            static std::unique_ptr<Model> __cdecl CreateFromSDKMESH(
+                _In_opt_ ID3D12Device* device,
+                _In_reads_bytes_(dataSize) const uint8_t* meshData, _In_ size_t dataSize,
+                ModelLoaderFlags flags = ModelLoader_Default);
+            static std::unique_ptr<Model> __cdecl CreateFromSDKMESH(
+                _In_opt_ ID3D12Device* device,
+                _In_z_ const wchar_t* szFileName,
+                ModelLoaderFlags flags = ModelLoader_Default);
+
+            // Loads a model from a .VBO file
+            static std::unique_ptr<Model> __cdecl CreateFromVBO(
+                _In_opt_ ID3D12Device* device,
+                _In_reads_bytes_(dataSize) const uint8_t* meshData, _In_ size_t dataSize,
+                ModelLoaderFlags flags = ModelLoader_Default);
+            static std::unique_ptr<Model> __cdecl CreateFromVBO(
+                _In_opt_ ID3D12Device* device,
+                _In_z_ const wchar_t* szFileName,
+                ModelLoaderFlags flags = ModelLoader_Default);
+
+            // Utility function for getting a GPU descriptor for a mesh part/material index. If there is no texture the
+            // descriptor will be zero.
+            D3D12_GPU_DESCRIPTOR_HANDLE __cdecl GetGpuTextureHandleForMaterialIndex(uint32_t materialIndex, _In_ ID3D12DescriptorHeap* heap, _In_ size_t descriptorSize, _In_ size_t descriptorOffset) const
+            {
+                D3D12_GPU_DESCRIPTOR_HANDLE handle = {};
+
+                if (materialIndex >= materials.size())
+                    return handle;
+
+                const int textureIndex = materials[materialIndex].diffuseTextureIndex;
+                if (textureIndex == -1)
+                    return handle;
+
+            #if defined(_MSC_VER) || !defined(_WIN32)
+                handle = heap->GetGPUDescriptorHandleForHeapStart();
+            #else
+                std::ignore = heap->GetGPUDescriptorHandleForHeapStart(&handle);
+            #endif
+                handle.ptr += static_cast<UINT64>(descriptorSize * (UINT64(textureIndex) + UINT64(descriptorOffset)));
+
+                return handle;
+            }
+
+            // Utility function for updating the matrices in a list of effects. This will SetWorld, SetView and SetProjection
+            // on any effect in the list that derives from IEffectMatrices.
+            static void XM_CALLCONV UpdateEffectMatrices(
+                EffectCollection& effects,
+                FXMMATRIX world,
+                CXMMATRIX view,
+                CXMMATRIX proj);
+
+            // Utility function to transition VB/IB resources for static geometry.
+            void __cdecl Transition(
+                _In_ ID3D12GraphicsCommandList* commandList,
+                D3D12_RESOURCE_STATES stateBeforeVB,
+                D3D12_RESOURCE_STATES stateAfterVB,
+                D3D12_RESOURCE_STATES stateBeforeIB,
+                D3D12_RESOURCE_STATES stateAfterIB);
+
+            ModelMesh::Collection           meshes;
+            ModelMaterialInfoCollection     materials;
+            TextureCollection               textureNames;
+            ModelBone::Collection           bones;
+            ModelBone::TransformArray       boneMatrices;
+            ModelBone::TransformArray       invBindPoseMatrices;
+            std::wstring                    name;
+
+        private:
+            std::shared_ptr<IEffect> __cdecl CreateEffectForMeshPart(
+                IEffectFactory& fxFactory,
+                const EffectPipelineStateDescription& opaquePipelineState,
+                const EffectPipelineStateDescription& alphaPipelineState,
+                int textureDescriptorOffset,
+                int samplerDescriptorOffset,
+                _In_ const ModelMeshPart* part) const;
+
+            void __cdecl ComputeAbsolute(uint32_t index,
+                CXMMATRIX local, size_t nbones,
+                _In_reads_(nbones) const XMMATRIX* inBoneTransforms,
+                _Inout_updates_(nbones) XMMATRIX* outBoneTransforms,
+                size_t& visited) const;
+        };
+
+
+        template<typename TEffectIterator, typename TEffectIteratorCategory>
+        void XM_CALLCONV ModelMeshPart::DrawSkinnedMeshParts(
             _In_ ID3D12GraphicsCommandList* commandList,
-            const Collection& meshParts,
+            const ModelMesh& mesh,
+            const ModelMeshPart::Collection& meshParts,
+            size_t nbones,
+            _In_reads_(nbones) const XMMATRIX* boneTransforms,
             FXMMATRIX world,
             TEffectIterator partEffects)
         {
@@ -198,9 +606,13 @@ namespace DirectX
                 std::is_base_of<std::random_access_iterator_tag, TEffectIteratorCategory>::value,
                 "Providing an iterator without random access capabilities -- such as from std::list -- is not supported.");
 
-            for (const auto& it : meshParts)
+            assert(nbones > 0 && boneTransforms != nullptr);
+
+            ModelBone::TransformArray temp;
+
+            for (const auto& mit : meshParts)
             {
-                auto part = it.get();
+                auto part = mit.get();
                 assert(part != nullptr);
 
                 // Get the effect at the location specified by the part's material
@@ -213,477 +625,68 @@ namespace DirectX
                     imatrices->SetWorld(world);
                 }
 
+                auto iskinning = dynamic_cast<IEffectSkinning*>((*effect_iterator).get());
+                if (iskinning)
+                {
+                    if (mesh.boneInfluences.empty())
+                    {
+                        // Direct-mapping of vertex bone indices to our master bone array
+                        iskinning->SetBoneTransforms(boneTransforms, nbones);
+                    }
+                    else
+                    {
+                        if (!temp)
+                        {
+                            // Create the influence mapped bones on-demand.
+                            temp = ModelBone::MakeArray(IEffectSkinning::MaxBones);
+
+                            size_t count = 0;
+                            for (auto it : mesh.boneInfluences)
+                            {
+                                ++count;
+                                if (count > IEffectSkinning::MaxBones)
+                                {
+                                    throw std::runtime_error("Too many bones for skinning");
+                                }
+
+                                if (it >= nbones)
+                                {
+                                    throw std::runtime_error("Invalid bone influence index");
+                                }
+
+                                temp[count - 1] = boneTransforms[it];
+                            }
+
+                            assert(count == mesh.boneInfluences.size());
+                        }
+
+                        iskinning->SetBoneTransforms(temp.get(), mesh.boneInfluences.size());
+                    }
+                }
+                else if (imatrices)
+                {
+                    // Fallback for if we encounter a non-skinning effect in the model
+                    XMMATRIX bm = (mesh.boneIndex != ModelBone::c_Invalid && mesh.boneIndex < nbones)
+                        ? boneTransforms[mesh.boneIndex] : XMMatrixIdentity();
+
+                    imatrices->SetWorld(XMMatrixMultiply(bm, world));
+                }
+
                 // Apply the effect and draw
                 (*effect_iterator)->Apply(commandList);
                 part->Draw(commandList);
             }
         }
 
-        template<typename TEffectIterator, typename TEffectIteratorCategory = typename TEffectIterator::iterator_category>
-        static void XM_CALLCONV DrawSkinnedMeshParts(
-            _In_ ID3D12GraphicsCommandList* commandList,
-            const ModelMesh& mesh,
-            const Collection& meshParts,
-            size_t nbones,
-            _In_reads_(nbones) const XMMATRIX* boneTransforms,
-            FXMMATRIX world,
-            TEffectIterator partEffects);
-    };
-
-
-    //----------------------------------------------------------------------------------
-    // A mesh consists of one or more model mesh parts
-    class ModelMesh
-    {
-    public:
-        ModelMesh() noexcept;
-
-        ModelMesh(ModelMesh&&) = default;
-        ModelMesh& operator= (ModelMesh&&) = default;
-
-        ModelMesh(ModelMesh const&) = default;
-        ModelMesh& operator= (ModelMesh const&) = default;
-
-        virtual ~ModelMesh();
-
-        BoundingSphere              boundingSphere;
-        BoundingBox                 boundingBox;
-        ModelMeshPart::Collection   opaqueMeshParts;
-        ModelMeshPart::Collection   alphaMeshParts;
-        uint32_t                    boneIndex;
-        std::vector<uint32_t>       boneInfluences;
-        std::wstring                name;
-
-        using Collection = std::vector<std::shared_ptr<ModelMesh>>;
-
-        // Draw the mesh
-        void __cdecl DrawOpaque(_In_ ID3D12GraphicsCommandList* commandList) const;
-        void __cdecl DrawAlpha(_In_ ID3D12GraphicsCommandList* commandList) const;
-
-        // Draw the mesh with an effect
-        void __cdecl DrawOpaque(_In_ ID3D12GraphicsCommandList* commandList, _In_ IEffect* effect) const;
-        void __cdecl DrawAlpha(_In_ ID3D12GraphicsCommandList* commandList, _In_ IEffect* effect) const;
-
-        // Draw the mesh with a callback for each mesh part
-        void __cdecl DrawOpaque(_In_ ID3D12GraphicsCommandList* commandList, ModelMeshPart::DrawCallback callback) const;
-        void __cdecl DrawAlpha(_In_ ID3D12GraphicsCommandList* commandList, ModelMeshPart::DrawCallback callback) const;
-
-        // Draw the mesh with a range of effects that mesh parts will index into.
-        // TEffectPtr can be any IEffect pointer type (including smart pointer). Value or reference types will not compile.
-        template<typename TEffectIterator, typename TEffectIteratorCategory = typename TEffectIterator::iterator_category>
-        void DrawOpaque(_In_ ID3D12GraphicsCommandList* commandList, TEffectIterator effects) const
-        {
-            ModelMeshPart::DrawMeshParts<TEffectIterator, TEffectIteratorCategory>(commandList, opaqueMeshParts, effects);
-        }
-        template<typename TEffectIterator, typename TEffectIteratorCategory = typename TEffectIterator::iterator_category>
-        void DrawAlpha(_In_ ID3D12GraphicsCommandList* commandList, TEffectIterator effects) const
-        {
-            ModelMeshPart::DrawMeshParts<TEffectIterator, TEffectIteratorCategory>(commandList, alphaMeshParts, effects);
-        }
-
-        // Draw rigid-body with bones.
-        template<typename TEffectIterator, typename TEffectIteratorCategory = typename TEffectIterator::iterator_category>
-        void XM_CALLCONV DrawOpaque(
-            _In_ ID3D12GraphicsCommandList* commandList,
-            size_t nbones,
-            _In_reads_(nbones) const XMMATRIX* boneTransforms,
-            FXMMATRIX world,
-            TEffectIterator effects) const
-        {
-            assert(nbones > 0 && boneTransforms != nullptr);
-            XMMATRIX local;
-            if (boneIndex != ModelBone::c_Invalid && boneIndex < nbones)
-            {
-                local = XMMatrixMultiply(boneTransforms[boneIndex], world);
-            }
-            else
-            {
-                local = world;
-            }
-
-            ModelMeshPart::DrawMeshParts<TEffectIterator, TEffectIteratorCategory>(commandList, opaqueMeshParts, local, effects);
-        }
-
-        template<typename TEffectIterator, typename TEffectIteratorCategory = typename TEffectIterator::iterator_category>
-        void XM_CALLCONV DrawAlpha(
-            _In_ ID3D12GraphicsCommandList* commandList,
-            size_t nbones,
-            _In_reads_(nbones) const XMMATRIX* boneTransforms,
-            FXMMATRIX world,
-            TEffectIterator effects) const
-        {
-            assert(nbones > 0 && boneTransforms != nullptr);
-            XMMATRIX local;
-            if (boneIndex != ModelBone::c_Invalid && boneIndex < nbones)
-            {
-                local = XMMatrixMultiply(boneTransforms[boneIndex], world);
-            }
-            else
-            {
-                local = world;
-            }
-
-            ModelMeshPart::DrawMeshParts<TEffectIterator, TEffectIteratorCategory>(commandList, alphaMeshParts, local, effects);
-        }
-
-        // Draw using skinning given bone transform array.
-        template<typename TEffectIterator, typename TEffectIteratorCategory = typename TEffectIterator::iterator_category>
-        void XM_CALLCONV DrawSkinnedOpaque(
-            _In_ ID3D12GraphicsCommandList* commandList,
-            size_t nbones,
-            _In_reads_(nbones) const XMMATRIX* boneTransforms,
-            FXMMATRIX world,
-            TEffectIterator effects) const
-        {
-            ModelMeshPart::DrawSkinnedMeshParts<TEffectIterator, TEffectIteratorCategory>(commandList, *this, opaqueMeshParts,
-                nbones, boneTransforms, world, effects);
-        }
-
-        template<typename TEffectIterator, typename TEffectIteratorCategory = typename TEffectIterator::iterator_category>
-        void XM_CALLCONV DrawSkinnedAlpha(
-            _In_ ID3D12GraphicsCommandList* commandList,
-            size_t nbones,
-            _In_reads_(nbones) const XMMATRIX* boneTransforms,
-            FXMMATRIX world,
-            TEffectIterator effects) const
-        {
-            ModelMeshPart::DrawSkinnedMeshParts<TEffectIterator, TEffectIteratorCategory>(commandList, *this, alphaMeshParts,
-                nbones, boneTransforms, world, effects);
-        }
-    };
-
-
-    //----------------------------------------------------------------------------------
-    // A model consists of one or more meshes
-    class Model
-    {
-    public:
-        Model() noexcept;
-
-        Model(Model&&) = default;
-        Model& operator= (Model&&) = default;
-
-        Model(Model const& other);
-        Model& operator= (Model const& rhs);
-
-        virtual ~Model();
-
-        using EffectCollection = std::vector<std::shared_ptr<IEffect>>;
-        using ModelMaterialInfo = IEffectFactory::EffectInfo;
-        using ModelMaterialInfoCollection = std::vector<ModelMaterialInfo>;
-        using TextureCollection = std::vector<std::wstring>;
-
-        // The Model::Draw* functions use variadic templates and perfect-forwarding in order to support future
-        // overloads to the ModelMesh::Draw* family of functions. This means that a new ModelMesh overload can be
-        // added, removed or altered, but the Model routines will still remain compatible. The correct ModelMesh
-        // overload will be selected by the compiler depending on the arguments you provide to the Model method.
-
-        // Draw all the meshes in the model.
-        template<typename... TForwardArgs> void DrawOpaque(_In_ ID3D12GraphicsCommandList* commandList, TForwardArgs&&... args) const
-        {
-            // Draw opaque parts
-            for (const auto& it : meshes)
-            {
-                auto mesh = it.get();
-                assert(mesh != nullptr);
-
-                mesh->DrawOpaque(commandList, std::forward<TForwardArgs>(args)...);
-            }
-        }
-
-        template<typename... TForwardArgs> void DrawAlpha(_In_ ID3D12GraphicsCommandList* commandList, TForwardArgs&&... args) const
-        {
-            // Draw alpha parts
-            for (const auto& it : meshes)
-            {
-                auto mesh = it.get();
-                assert(mesh != nullptr);
-
-                mesh->DrawAlpha(commandList, std::forward<TForwardArgs>(args)...);
-            }
-        }
-
-        template<typename... TForwardArgs> void Draw(_In_ ID3D12GraphicsCommandList* commandList, TForwardArgs&&... args) const
-        {
-            DrawOpaque(commandList, args...);
-            DrawAlpha(commandList, std::forward<TForwardArgs>(args)...);
-        }
-
-        // Draw mesh using skinning given bone transform array.
-        template<typename... TForwardArgs> void DrawSkinnedOpaque(_In_ ID3D12GraphicsCommandList* commandList, TForwardArgs&&... args) const
-        {
-            // Draw opaque parts
-            for (const auto& it : meshes)
-            {
-                auto mesh = it.get();
-                assert(mesh != nullptr);
-
-                mesh->DrawSkinnedOpaque(commandList, std::forward<TForwardArgs>(args)...);
-            }
-        }
-
-        template<typename... TForwardArgs> void DrawSkinnedAlpha(_In_ ID3D12GraphicsCommandList* commandList, TForwardArgs&&... args) const
-        {
-            // Draw alpha parts
-            for (const auto& it : meshes)
-            {
-                auto mesh = it.get();
-                assert(mesh != nullptr);
-
-                mesh->DrawSkinnedAlpha(commandList, std::forward<TForwardArgs>(args)...);
-            }
-        }
-
-        template<typename... TForwardArgs> void DrawSkinned(_In_ ID3D12GraphicsCommandList* commandList, TForwardArgs&&... args) const
-        {
-            DrawSkinnedOpaque(commandList, args...);
-            DrawSkinnedAlpha(commandList, std::forward<TForwardArgs>(args)...);
-        }
-
-        // Load texture resources into an existing Effect Texture Factory
-        int __cdecl LoadTextures(IEffectTextureFactory& texFactory, int destinationDescriptorOffset = 0) const;
-
-        // Load texture resources into a new Effect Texture Factory
-        std::unique_ptr<EffectTextureFactory> __cdecl LoadTextures(
-            _In_ ID3D12Device* device,
-            ResourceUploadBatch& resourceUploadBatch,
-            _In_opt_z_ const wchar_t* texturesPath = nullptr,
-            D3D12_DESCRIPTOR_HEAP_FLAGS flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE) const;
-
-        // Load VB/IB resources for static geometry
-        void __cdecl LoadStaticBuffers(
-            _In_ ID3D12Device* device,
-            ResourceUploadBatch& resourceUploadBatch,
-            bool keepMemory = false);
-
-        // Create effects using the default effect factory
-        EffectCollection __cdecl CreateEffects(
-            const EffectPipelineStateDescription& opaquePipelineState,
-            const EffectPipelineStateDescription& alphaPipelineState,
-            _In_ ID3D12DescriptorHeap* textureDescriptorHeap,
-            _In_ ID3D12DescriptorHeap* samplerDescriptorHeap,
-            int textureDescriptorOffset = 0,
-            int samplerDescriptorOffset = 0) const;
-
-        // Create effects using a custom effect factory
-        EffectCollection __cdecl CreateEffects(
-            IEffectFactory& fxFactory,
-            const EffectPipelineStateDescription& opaquePipelineState,
-            const EffectPipelineStateDescription& alphaPipelineState,
-            int textureDescriptorOffset = 0,
-            int samplerDescriptorOffset = 0) const;
-
-        // Compute bone positions based on heirarchy and transform matrices
-        void __cdecl CopyAbsoluteBoneTransformsTo(
-            size_t nbones,
-            _Out_writes_(nbones) XMMATRIX* boneTransforms) const;
-
-        void __cdecl CopyAbsoluteBoneTransforms(
-            size_t nbones,
-            _In_reads_(nbones) const XMMATRIX* inBoneTransforms,
-            _Out_writes_(nbones) XMMATRIX* outBoneTransforms) const;
-
-        // Set bone matrices to a set of relative tansforms
-        void __cdecl CopyBoneTransformsFrom(
-            size_t nbones,
-            _In_reads_(nbones) const XMMATRIX* boneTransforms);
-
-        // Copies the relative bone matrices to a transform array
-        void __cdecl CopyBoneTransformsTo(
-            size_t nbones,
-            _Out_writes_(nbones) XMMATRIX* boneTransforms) const;
-
-        // Loads a model from a Visual Studio Starter Kit .CMO file
-        static std::unique_ptr<Model> __cdecl CreateFromCMO(
-            _In_opt_ ID3D12Device* device,
-            _In_reads_bytes_(dataSize) const uint8_t* meshData, _In_ size_t dataSize,
-            ModelLoaderFlags flags = ModelLoader_Default,
-            _Out_opt_ size_t* animsOffset = nullptr);
-        static std::unique_ptr<Model> __cdecl CreateFromCMO(
-            _In_opt_ ID3D12Device* device,
-            _In_z_ const wchar_t* szFileName,
-            ModelLoaderFlags flags = ModelLoader_Default,
-            _Out_opt_ size_t* animsOffset = nullptr);
-
-        // Loads a model from a DirectX SDK .SDKMESH file
-        static std::unique_ptr<Model> __cdecl CreateFromSDKMESH(
-            _In_opt_ ID3D12Device* device,
-            _In_reads_bytes_(dataSize) const uint8_t* meshData, _In_ size_t dataSize,
-            ModelLoaderFlags flags = ModelLoader_Default);
-        static std::unique_ptr<Model> __cdecl CreateFromSDKMESH(
-            _In_opt_ ID3D12Device* device,
-            _In_z_ const wchar_t* szFileName,
-            ModelLoaderFlags flags = ModelLoader_Default);
-
-        // Loads a model from a .VBO file
-        static std::unique_ptr<Model> __cdecl CreateFromVBO(
-            _In_opt_ ID3D12Device* device,
-            _In_reads_bytes_(dataSize) const uint8_t* meshData, _In_ size_t dataSize,
-            ModelLoaderFlags flags = ModelLoader_Default);
-        static std::unique_ptr<Model> __cdecl CreateFromVBO(
-            _In_opt_ ID3D12Device* device,
-            _In_z_ const wchar_t* szFileName,
-            ModelLoaderFlags flags = ModelLoader_Default);
-
-        // Utility function for getting a GPU descriptor for a mesh part/material index. If there is no texture the
-        // descriptor will be zero.
-        D3D12_GPU_DESCRIPTOR_HANDLE __cdecl GetGpuTextureHandleForMaterialIndex(uint32_t materialIndex, _In_ ID3D12DescriptorHeap* heap, _In_ size_t descriptorSize, _In_ size_t descriptorOffset) const
-        {
-            D3D12_GPU_DESCRIPTOR_HANDLE handle = {};
-
-            if (materialIndex >= materials.size())
-                return handle;
-
-            const int textureIndex = materials[materialIndex].diffuseTextureIndex;
-            if (textureIndex == -1)
-                return handle;
-
-        #if defined(_MSC_VER) || !defined(_WIN32)
-            handle = heap->GetGPUDescriptorHandleForHeapStart();
-        #else
-            std::ignore = heap->GetGPUDescriptorHandleForHeapStart(&handle);
-        #endif
-            handle.ptr += static_cast<UINT64>(descriptorSize * (UINT64(textureIndex) + UINT64(descriptorOffset)));
-
-            return handle;
-        }
-
-        // Utility function for updating the matrices in a list of effects. This will SetWorld, SetView and SetProjection
-        // on any effect in the list that derives from IEffectMatrices.
-        static void XM_CALLCONV UpdateEffectMatrices(
-            EffectCollection& effects,
-            FXMMATRIX world,
-            CXMMATRIX view,
-            CXMMATRIX proj);
-
-        // Utility function to transition VB/IB resources for static geometry.
-        void __cdecl Transition(
-            _In_ ID3D12GraphicsCommandList* commandList,
-            D3D12_RESOURCE_STATES stateBeforeVB,
-            D3D12_RESOURCE_STATES stateAfterVB,
-            D3D12_RESOURCE_STATES stateBeforeIB,
-            D3D12_RESOURCE_STATES stateAfterIB);
-
-        ModelMesh::Collection           meshes;
-        ModelMaterialInfoCollection     materials;
-        TextureCollection               textureNames;
-        ModelBone::Collection           bones;
-        ModelBone::TransformArray       boneMatrices;
-        ModelBone::TransformArray       invBindPoseMatrices;
-        std::wstring                    name;
-
-    private:
-        std::shared_ptr<IEffect> __cdecl CreateEffectForMeshPart(
-            IEffectFactory& fxFactory,
-            const EffectPipelineStateDescription& opaquePipelineState,
-            const EffectPipelineStateDescription& alphaPipelineState,
-            int textureDescriptorOffset,
-            int samplerDescriptorOffset,
-            _In_ const ModelMeshPart* part) const;
-
-        void __cdecl ComputeAbsolute(uint32_t index,
-            CXMMATRIX local, size_t nbones,
-            _In_reads_(nbones) const XMMATRIX* inBoneTransforms,
-            _Inout_updates_(nbones) XMMATRIX* outBoneTransforms,
-            size_t& visited) const;
-    };
-
-
-    template<typename TEffectIterator, typename TEffectIteratorCategory>
-    void XM_CALLCONV ModelMeshPart::DrawSkinnedMeshParts(
-        _In_ ID3D12GraphicsCommandList* commandList,
-        const ModelMesh& mesh,
-        const ModelMeshPart::Collection& meshParts,
-        size_t nbones,
-        _In_reads_(nbones) const XMMATRIX* boneTransforms,
-        FXMMATRIX world,
-        TEffectIterator partEffects)
-    {
-        // This assert is here to prevent accidental use of containers that would cause undesirable performance penalties.
-        static_assert(
-            std::is_base_of<std::random_access_iterator_tag, TEffectIteratorCategory>::value,
-            "Providing an iterator without random access capabilities -- such as from std::list -- is not supported.");
-
-        assert(nbones > 0 && boneTransforms != nullptr);
-
-        ModelBone::TransformArray temp;
-
-        for (const auto& mit : meshParts)
-        {
-            auto part = mit.get();
-            assert(part != nullptr);
-
-            // Get the effect at the location specified by the part's material
-            TEffectIterator effect_iterator = partEffects;
-            std::advance(effect_iterator, part->partIndex);
-
-            auto imatrices = dynamic_cast<IEffectMatrices*>((*effect_iterator).get());
-            if (imatrices)
-            {
-                imatrices->SetWorld(world);
-            }
-
-            auto iskinning = dynamic_cast<IEffectSkinning*>((*effect_iterator).get());
-            if (iskinning)
-            {
-                if (mesh.boneInfluences.empty())
-                {
-                    // Direct-mapping of vertex bone indices to our master bone array
-                    iskinning->SetBoneTransforms(boneTransforms, nbones);
-                }
-                else
-                {
-                    if (!temp)
-                    {
-                        // Create the influence mapped bones on-demand.
-                        temp = ModelBone::MakeArray(IEffectSkinning::MaxBones);
-
-                        size_t count = 0;
-                        for (auto it : mesh.boneInfluences)
-                        {
-                            ++count;
-                            if (count > IEffectSkinning::MaxBones)
-                            {
-                                throw std::runtime_error("Too many bones for skinning");
-                            }
-
-                            if (it >= nbones)
-                            {
-                                throw std::runtime_error("Invalid bone influence index");
-                            }
-
-                            temp[count - 1] = boneTransforms[it];
-                        }
-
-                        assert(count == mesh.boneInfluences.size());
-                    }
-
-                    iskinning->SetBoneTransforms(temp.get(), mesh.boneInfluences.size());
-                }
-            }
-            else if (imatrices)
-            {
-                // Fallback for if we encounter a non-skinning effect in the model
-                XMMATRIX bm = (mesh.boneIndex != ModelBone::c_Invalid && mesh.boneIndex < nbones)
-                    ? boneTransforms[mesh.boneIndex] : XMMatrixIdentity();
-
-                imatrices->SetWorld(XMMatrixMultiply(bm, world));
-            }
-
-            // Apply the effect and draw
-            (*effect_iterator)->Apply(commandList);
-            part->Draw(commandList);
-        }
+    #ifdef __clang__
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-dynamic-exception-spec"
+    #endif
+
+        DEFINE_ENUM_FLAG_OPERATORS(ModelLoaderFlags);
+
+    #ifdef __clang__
+    #pragma clang diagnostic pop
+    #endif
     }
-
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-dynamic-exception-spec"
-#endif
-
-    DEFINE_ENUM_FLAG_OPERATORS(ModelLoaderFlags);
-
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
 }

--- a/Inc/PostProcess.h
+++ b/Inc/PostProcess.h
@@ -29,186 +29,189 @@
 
 namespace DirectX
 {
-    //----------------------------------------------------------------------------------
-    // Abstract interface representing a post-process pass
-    class IPostProcess
+    inline namespace DX12
     {
-    public:
-        virtual ~IPostProcess() = default;
-
-        IPostProcess(const IPostProcess&) = delete;
-        IPostProcess& operator=(const IPostProcess&) = delete;
-
-        virtual void __cdecl Process(_In_ ID3D12GraphicsCommandList* commandList) = 0;
-
-    protected:
-        IPostProcess() = default;
-        IPostProcess(IPostProcess&&) = default;
-        IPostProcess& operator=(IPostProcess&&) = default;
-    };
-
-
-    //----------------------------------------------------------------------------------
-    // Basic post-process
-    class BasicPostProcess : public IPostProcess
-    {
-    public:
-        enum Effect : unsigned int
+        //------------------------------------------------------------------------------
+        // Abstract interface representing a post-process pass
+        class IPostProcess
         {
-            Copy,
-            Monochrome,
-            Sepia,
-            DownScale_2x2,
-            DownScale_4x4,
-            GaussianBlur_5x5,
-            BloomExtract,
-            BloomBlur,
-            Effect_Max
+        public:
+            virtual ~IPostProcess() = default;
+
+            IPostProcess(const IPostProcess&) = delete;
+            IPostProcess& operator=(const IPostProcess&) = delete;
+
+            virtual void __cdecl Process(_In_ ID3D12GraphicsCommandList* commandList) = 0;
+
+        protected:
+            IPostProcess() = default;
+            IPostProcess(IPostProcess&&) = default;
+            IPostProcess& operator=(IPostProcess&&) = default;
         };
 
-        BasicPostProcess(_In_ ID3D12Device* device, const RenderTargetState& rtState, Effect fx);
 
-        BasicPostProcess(BasicPostProcess&&) noexcept;
-        BasicPostProcess& operator= (BasicPostProcess&&) noexcept;
-
-        BasicPostProcess(BasicPostProcess const&) = delete;
-        BasicPostProcess& operator= (BasicPostProcess const&) = delete;
-
-        ~BasicPostProcess() override;
-
-        // IPostProcess methods.
-        void __cdecl Process(_In_ ID3D12GraphicsCommandList* commandList) override;
-
-        // Properties
-        void __cdecl SetSourceTexture(D3D12_GPU_DESCRIPTOR_HANDLE srvDescriptor, _In_opt_ ID3D12Resource* resource);
-
-        // Sets multiplier for GaussianBlur_5x5
-        void __cdecl SetGaussianParameter(float multiplier);
-
-        // Sets parameters for BloomExtract
-        void __cdecl SetBloomExtractParameter(float threshold);
-
-        // Sets parameters for BloomBlur
-        void __cdecl SetBloomBlurParameters(bool horizontal, float size, float brightness);
-
-    private:
-        // Private implementation.
-        class Impl;
-
-        std::unique_ptr<Impl> pImpl;
-    };
-
-
-    //----------------------------------------------------------------------------------
-    // Dual-texure post-process
-    class DualPostProcess : public IPostProcess
-    {
-    public:
-        enum Effect : unsigned int
+        //------------------------------------------------------------------------------
+        // Basic post-process
+        class BasicPostProcess : public IPostProcess
         {
-            Merge,
-            BloomCombine,
-            Effect_Max
+        public:
+            enum Effect : unsigned int
+            {
+                Copy,
+                Monochrome,
+                Sepia,
+                DownScale_2x2,
+                DownScale_4x4,
+                GaussianBlur_5x5,
+                BloomExtract,
+                BloomBlur,
+                Effect_Max
+            };
+
+            BasicPostProcess(_In_ ID3D12Device* device, const RenderTargetState& rtState, Effect fx);
+
+            BasicPostProcess(BasicPostProcess&&) noexcept;
+            BasicPostProcess& operator= (BasicPostProcess&&) noexcept;
+
+            BasicPostProcess(BasicPostProcess const&) = delete;
+            BasicPostProcess& operator= (BasicPostProcess const&) = delete;
+
+            ~BasicPostProcess() override;
+
+            // IPostProcess methods.
+            void __cdecl Process(_In_ ID3D12GraphicsCommandList* commandList) override;
+
+            // Properties
+            void __cdecl SetSourceTexture(D3D12_GPU_DESCRIPTOR_HANDLE srvDescriptor, _In_opt_ ID3D12Resource* resource);
+
+            // Sets multiplier for GaussianBlur_5x5
+            void __cdecl SetGaussianParameter(float multiplier);
+
+            // Sets parameters for BloomExtract
+            void __cdecl SetBloomExtractParameter(float threshold);
+
+            // Sets parameters for BloomBlur
+            void __cdecl SetBloomBlurParameters(bool horizontal, float size, float brightness);
+
+        private:
+            // Private implementation.
+            class Impl;
+
+            std::unique_ptr<Impl> pImpl;
         };
 
-        DualPostProcess(_In_ ID3D12Device* device, const RenderTargetState& rtState, Effect fx);
 
-        DualPostProcess(DualPostProcess&&) noexcept;
-        DualPostProcess& operator= (DualPostProcess&&) noexcept;
-
-        DualPostProcess(DualPostProcess const&) = delete;
-        DualPostProcess& operator= (DualPostProcess const&) = delete;
-
-        ~DualPostProcess() override;
-
-        // IPostProcess methods.
-        void __cdecl Process(_In_ ID3D12GraphicsCommandList* commandList) override;
-
-        // Properties
-        void __cdecl SetSourceTexture(D3D12_GPU_DESCRIPTOR_HANDLE srvDescriptor);
-        void __cdecl SetSourceTexture2(D3D12_GPU_DESCRIPTOR_HANDLE srvDescriptor);
-
-        // Sets parameters for Merge
-        void __cdecl SetMergeParameters(float weight1, float weight2);
-
-        // Sets parameters for BloomCombine
-        void __cdecl SetBloomCombineParameters(float bloom, float base, float bloomSaturation, float baseSaturation);
-
-    private:
-        // Private implementation.
-        class Impl;
-
-        std::unique_ptr<Impl> pImpl;
-    };
-
-
-    //----------------------------------------------------------------------------------
-    // Tone-map post-process
-    class ToneMapPostProcess : public IPostProcess
-    {
-    public:
-        // Tone-mapping operator
-        enum Operator : unsigned int
+        //------------------------------------------------------------------------------
+        // Dual-texure post-process
+        class DualPostProcess : public IPostProcess
         {
-            None,               // Pass-through
-            Saturate,           // Clamp [0,1]
-            Reinhard,           // x/(1+x)
-            ACESFilmic,
-            Operator_Max
+        public:
+            enum Effect : unsigned int
+            {
+                Merge,
+                BloomCombine,
+                Effect_Max
+            };
+
+            DualPostProcess(_In_ ID3D12Device* device, const RenderTargetState& rtState, Effect fx);
+
+            DualPostProcess(DualPostProcess&&) noexcept;
+            DualPostProcess& operator= (DualPostProcess&&) noexcept;
+
+            DualPostProcess(DualPostProcess const&) = delete;
+            DualPostProcess& operator= (DualPostProcess const&) = delete;
+
+            ~DualPostProcess() override;
+
+            // IPostProcess methods.
+            void __cdecl Process(_In_ ID3D12GraphicsCommandList* commandList) override;
+
+            // Properties
+            void __cdecl SetSourceTexture(D3D12_GPU_DESCRIPTOR_HANDLE srvDescriptor);
+            void __cdecl SetSourceTexture2(D3D12_GPU_DESCRIPTOR_HANDLE srvDescriptor);
+
+            // Sets parameters for Merge
+            void __cdecl SetMergeParameters(float weight1, float weight2);
+
+            // Sets parameters for BloomCombine
+            void __cdecl SetBloomCombineParameters(float bloom, float base, float bloomSaturation, float baseSaturation);
+
+        private:
+            // Private implementation.
+            class Impl;
+
+            std::unique_ptr<Impl> pImpl;
         };
 
-        // Electro-Optical Transfer Function (EOTF)
-        enum TransferFunction : unsigned int
+
+        //------------------------------------------------------------------------------
+        // Tone-map post-process
+        class ToneMapPostProcess : public IPostProcess
         {
-            Linear,             // Pass-through
-            SRGB,               // sRGB (Rec.709 and approximate sRGB display curve)
-            ST2084,             // HDR10 (Rec.2020 color primaries and ST.2084 display curve)
-            TransferFunction_Max
+        public:
+            // Tone-mapping operator
+            enum Operator : unsigned int
+            {
+                None,               // Pass-through
+                Saturate,           // Clamp [0,1]
+                Reinhard,           // x/(1+x)
+                ACESFilmic,
+                Operator_Max
+            };
+
+            // Electro-Optical Transfer Function (EOTF)
+            enum TransferFunction : unsigned int
+            {
+                Linear,             // Pass-through
+                SRGB,               // sRGB (Rec.709 and approximate sRGB display curve)
+                ST2084,             // HDR10 (Rec.2020 color primaries and ST.2084 display curve)
+                TransferFunction_Max
+            };
+
+            // Color Rotation Transform for HDR10
+            enum ColorPrimaryRotation : unsigned int
+            {
+                HDTV_to_UHDTV,       // Rec.709 to Rec.2020
+                DCI_P3_D65_to_UHDTV, // DCI-P3-D65 (a.k.a Display P3 or P3D65) to Rec.2020
+                HDTV_to_DCI_P3_D65,  // Rec.709 to DCI-P3-D65 (a.k.a Display P3 or P3D65)
+            };
+
+            ToneMapPostProcess(_In_ ID3D12Device* device, const RenderTargetState& rtState,
+                Operator op, TransferFunction func
+            #if (defined(_XBOX_ONE) && defined(_TITLE)) || defined(_GAMING_XBOX)
+                , bool mrt = false
+            #endif
+            );
+
+            ToneMapPostProcess(ToneMapPostProcess&&) noexcept;
+            ToneMapPostProcess& operator= (ToneMapPostProcess&&) noexcept;
+
+            ToneMapPostProcess(ToneMapPostProcess const&) = delete;
+            ToneMapPostProcess& operator= (ToneMapPostProcess const&) = delete;
+
+            ~ToneMapPostProcess() override;
+
+            // IPostProcess methods.
+            void __cdecl Process(_In_ ID3D12GraphicsCommandList* commandList) override;
+
+            // Properties
+            void __cdecl SetHDRSourceTexture(D3D12_GPU_DESCRIPTOR_HANDLE srvDescriptor);
+
+            // Sets the Color Rotation Transform for HDR10 signal output
+            void __cdecl SetColorRotation(ColorPrimaryRotation value);
+            void __cdecl SetColorRotation(CXMMATRIX value);
+
+            // Sets exposure value for LDR tonemap operators
+            void __cdecl SetExposure(float exposureValue);
+
+            // Sets ST.2084 parameter for how bright white should be in nits
+            void __cdecl SetST2084Parameter(float paperWhiteNits);
+
+        private:
+            // Private implementation.
+            class Impl;
+
+            std::unique_ptr<Impl> pImpl;
         };
-
-        // Color Rotation Transform for HDR10
-        enum ColorPrimaryRotation : unsigned int
-        {
-            HDTV_to_UHDTV,       // Rec.709 to Rec.2020
-            DCI_P3_D65_to_UHDTV, // DCI-P3-D65 (a.k.a Display P3 or P3D65) to Rec.2020
-            HDTV_to_DCI_P3_D65,  // Rec.709 to DCI-P3-D65 (a.k.a Display P3 or P3D65)
-        };
-
-        ToneMapPostProcess(_In_ ID3D12Device* device, const RenderTargetState& rtState,
-            Operator op, TransferFunction func
-        #if (defined(_XBOX_ONE) && defined(_TITLE)) || defined(_GAMING_XBOX)
-            , bool mrt = false
-        #endif
-        );
-
-        ToneMapPostProcess(ToneMapPostProcess&&) noexcept;
-        ToneMapPostProcess& operator= (ToneMapPostProcess&&) noexcept;
-
-        ToneMapPostProcess(ToneMapPostProcess const&) = delete;
-        ToneMapPostProcess& operator= (ToneMapPostProcess const&) = delete;
-
-        ~ToneMapPostProcess() override;
-
-        // IPostProcess methods.
-        void __cdecl Process(_In_ ID3D12GraphicsCommandList* commandList) override;
-
-        // Properties
-        void __cdecl SetHDRSourceTexture(D3D12_GPU_DESCRIPTOR_HANDLE srvDescriptor);
-
-        // Sets the Color Rotation Transform for HDR10 signal output
-        void __cdecl SetColorRotation(ColorPrimaryRotation value);
-        void __cdecl SetColorRotation(CXMMATRIX value);
-
-        // Sets exposure value for LDR tonemap operators
-        void __cdecl SetExposure(float exposureValue);
-
-        // Sets ST.2084 parameter for how bright white should be in nits
-        void __cdecl SetST2084Parameter(float paperWhiteNits);
-
-    private:
-        // Private implementation.
-        class Impl;
-
-        std::unique_ptr<Impl> pImpl;
-    };
+    }
 }

--- a/Inc/PrimitiveBatch.h
+++ b/Inc/PrimitiveBatch.h
@@ -29,117 +29,119 @@
 
 namespace DirectX
 {
-    namespace Internal
+    inline namespace DX12
     {
-        // Base class, not to be used directly: clients should access this via the derived PrimitiveBatch<T>.
-        class PrimitiveBatchBase
+        namespace Private
         {
-        protected:
-            PrimitiveBatchBase(_In_ ID3D12Device* device, size_t maxIndices, size_t maxVertices, size_t vertexSize);
+            // Base class, not to be used directly: clients should access this via the derived PrimitiveBatch<T>.
+            class PrimitiveBatchBase
+            {
+            protected:
+                PrimitiveBatchBase(_In_ ID3D12Device* device, size_t maxIndices, size_t maxVertices, size_t vertexSize);
 
-            PrimitiveBatchBase(PrimitiveBatchBase&&) noexcept;
-            PrimitiveBatchBase& operator= (PrimitiveBatchBase&&) noexcept;
+                PrimitiveBatchBase(PrimitiveBatchBase&&) noexcept;
+                PrimitiveBatchBase& operator= (PrimitiveBatchBase&&) noexcept;
 
-            PrimitiveBatchBase(PrimitiveBatchBase const&) = delete;
-            PrimitiveBatchBase& operator= (PrimitiveBatchBase const&) = delete;
+                PrimitiveBatchBase(PrimitiveBatchBase const&) = delete;
+                PrimitiveBatchBase& operator= (PrimitiveBatchBase const&) = delete;
 
-            virtual ~PrimitiveBatchBase();
+                virtual ~PrimitiveBatchBase();
+
+            public:
+                // Begin/End a batch of primitive drawing operations.
+                void __cdecl Begin(_In_ ID3D12GraphicsCommandList* cmdList);
+                void __cdecl End();
+
+            protected:
+                // Internal, untyped drawing method.
+                void __cdecl Draw(D3D_PRIMITIVE_TOPOLOGY topology, bool isIndexed, _In_opt_count_(indexCount) uint16_t const* indices, size_t indexCount, size_t vertexCount, _Outptr_ void** pMappedVertices);
+
+            private:
+                // Private implementation.
+                class Impl;
+
+                std::unique_ptr<Impl> pImpl;
+            };
+        }
+
+        // Template makes the API typesafe, eg. PrimitiveBatch<VertexPositionColor>.
+        template<typename TVertex>
+        class PrimitiveBatch : public Private::PrimitiveBatchBase
+        {
+            static constexpr size_t DefaultBatchSize = 4096;
 
         public:
-            // Begin/End a batch of primitive drawing operations.
-            void __cdecl Begin(_In_ ID3D12GraphicsCommandList* cmdList);
-            void __cdecl End();
+            explicit PrimitiveBatch(_In_ ID3D12Device* device,
+                size_t maxIndices = DefaultBatchSize * 3,
+                size_t maxVertices = DefaultBatchSize)
+                : PrimitiveBatchBase(device, maxIndices, maxVertices, sizeof(TVertex))
+            {
+            }
 
-        protected:
-            // Internal, untyped drawing method.
-            void __cdecl Draw(D3D_PRIMITIVE_TOPOLOGY topology, bool isIndexed, _In_opt_count_(indexCount) uint16_t const* indices, size_t indexCount, size_t vertexCount, _Outptr_ void** pMappedVertices);
+            PrimitiveBatch(PrimitiveBatch&&) = default;
+            PrimitiveBatch& operator= (PrimitiveBatch&&) = default;
 
-        private:
-            // Private implementation.
-            class Impl;
+            PrimitiveBatch(PrimitiveBatch const&) = delete;
+            PrimitiveBatch& operator= (PrimitiveBatch const&) = delete;
 
-            std::unique_ptr<Impl> pImpl;
+            // Similar to the D3D9 API DrawPrimitiveUP.
+            void Draw(D3D_PRIMITIVE_TOPOLOGY topology, _In_reads_(vertexCount) TVertex const* vertices, size_t vertexCount)
+            {
+                void* mappedVertices;
+
+                PrimitiveBatchBase::Draw(topology, false, nullptr, 0, vertexCount, &mappedVertices);
+
+                memcpy(mappedVertices, vertices, vertexCount * sizeof(TVertex));
+            }
+
+
+            // Similar to the D3D9 API DrawIndexedPrimitiveUP.
+            void DrawIndexed(D3D_PRIMITIVE_TOPOLOGY topology, _In_reads_(indexCount) uint16_t const* indices, size_t indexCount, _In_reads_(vertexCount) TVertex const* vertices, size_t vertexCount)
+            {
+                void* mappedVertices;
+
+                PrimitiveBatchBase::Draw(topology, true, indices, indexCount, vertexCount, &mappedVertices);
+
+                memcpy(mappedVertices, vertices, vertexCount * sizeof(TVertex));
+            }
+
+
+            void DrawLine(TVertex const& v1, TVertex const& v2)
+            {
+                TVertex* mappedVertices;
+
+                PrimitiveBatchBase::Draw(D3D_PRIMITIVE_TOPOLOGY_LINELIST, false, nullptr, 0, 2, reinterpret_cast<void**>(&mappedVertices));
+
+                mappedVertices[0] = v1;
+                mappedVertices[1] = v2;
+            }
+
+
+            void DrawTriangle(TVertex const& v1, TVertex const& v2, TVertex const& v3)
+            {
+                TVertex* mappedVertices;
+
+                PrimitiveBatchBase::Draw(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST, false, nullptr, 0, 3, reinterpret_cast<void**>(&mappedVertices));
+
+                mappedVertices[0] = v1;
+                mappedVertices[1] = v2;
+                mappedVertices[2] = v3;
+            }
+
+
+            void DrawQuad(TVertex const& v1, TVertex const& v2, TVertex const& v3, TVertex const& v4)
+            {
+                static const uint16_t quadIndices[] = { 0, 1, 2, 0, 2, 3 };
+
+                TVertex* mappedVertices;
+
+                PrimitiveBatchBase::Draw(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST, true, quadIndices, 6, 4, reinterpret_cast<void**>(&mappedVertices));
+
+                mappedVertices[0] = v1;
+                mappedVertices[1] = v2;
+                mappedVertices[2] = v3;
+                mappedVertices[3] = v4;
+            }
         };
     }
-
-
-    // Template makes the API typesafe, eg. PrimitiveBatch<VertexPositionColor>.
-    template<typename TVertex>
-    class PrimitiveBatch : public Internal::PrimitiveBatchBase
-    {
-        static constexpr size_t DefaultBatchSize = 4096;
-
-    public:
-        explicit PrimitiveBatch(_In_ ID3D12Device* device,
-            size_t maxIndices = DefaultBatchSize * 3,
-            size_t maxVertices = DefaultBatchSize)
-            : PrimitiveBatchBase(device, maxIndices, maxVertices, sizeof(TVertex))
-        {
-        }
-
-        PrimitiveBatch(PrimitiveBatch&&) = default;
-        PrimitiveBatch& operator= (PrimitiveBatch&&) = default;
-
-        PrimitiveBatch(PrimitiveBatch const&) = delete;
-        PrimitiveBatch& operator= (PrimitiveBatch const&) = delete;
-
-        // Similar to the D3D9 API DrawPrimitiveUP.
-        void Draw(D3D_PRIMITIVE_TOPOLOGY topology, _In_reads_(vertexCount) TVertex const* vertices, size_t vertexCount)
-        {
-            void* mappedVertices;
-
-            PrimitiveBatchBase::Draw(topology, false, nullptr, 0, vertexCount, &mappedVertices);
-
-            memcpy(mappedVertices, vertices, vertexCount * sizeof(TVertex));
-        }
-
-
-        // Similar to the D3D9 API DrawIndexedPrimitiveUP.
-        void DrawIndexed(D3D_PRIMITIVE_TOPOLOGY topology, _In_reads_(indexCount) uint16_t const* indices, size_t indexCount, _In_reads_(vertexCount) TVertex const* vertices, size_t vertexCount)
-        {
-            void* mappedVertices;
-
-            PrimitiveBatchBase::Draw(topology, true, indices, indexCount, vertexCount, &mappedVertices);
-
-            memcpy(mappedVertices, vertices, vertexCount * sizeof(TVertex));
-        }
-
-
-        void DrawLine(TVertex const& v1, TVertex const& v2)
-        {
-            TVertex* mappedVertices;
-
-            PrimitiveBatchBase::Draw(D3D_PRIMITIVE_TOPOLOGY_LINELIST, false, nullptr, 0, 2, reinterpret_cast<void**>(&mappedVertices));
-
-            mappedVertices[0] = v1;
-            mappedVertices[1] = v2;
-        }
-
-
-        void DrawTriangle(TVertex const& v1, TVertex const& v2, TVertex const& v3)
-        {
-            TVertex* mappedVertices;
-
-            PrimitiveBatchBase::Draw(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST, false, nullptr, 0, 3, reinterpret_cast<void**>(&mappedVertices));
-
-            mappedVertices[0] = v1;
-            mappedVertices[1] = v2;
-            mappedVertices[2] = v3;
-        }
-
-
-        void DrawQuad(TVertex const& v1, TVertex const& v2, TVertex const& v3, TVertex const& v4)
-        {
-            static const uint16_t quadIndices[] = { 0, 1, 2, 0, 2, 3 };
-
-            TVertex* mappedVertices;
-
-            PrimitiveBatchBase::Draw(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST, true, quadIndices, 6, 4, reinterpret_cast<void**>(&mappedVertices));
-
-            mappedVertices[0] = v1;
-            mappedVertices[1] = v2;
-            mappedVertices[2] = v3;
-            mappedVertices[3] = v4;
-        }
-    };
 }

--- a/Inc/SpriteBatch.h
+++ b/Inc/SpriteBatch.h
@@ -37,118 +37,121 @@ namespace DirectX
 {
     class ResourceUploadBatch;
 
-    enum SpriteSortMode
+    inline namespace DX12
     {
-        SpriteSortMode_Deferred,
-        SpriteSortMode_Immediate,
-        SpriteSortMode_Texture,
-        SpriteSortMode_BackToFront,
-        SpriteSortMode_FrontToBack,
-    };
-
-    enum SpriteEffects : uint32_t
-    {
-        SpriteEffects_None = 0,
-        SpriteEffects_FlipHorizontally = 1,
-        SpriteEffects_FlipVertically = 2,
-        SpriteEffects_FlipBoth = SpriteEffects_FlipHorizontally | SpriteEffects_FlipVertically,
-    };
-
-    class SpriteBatchPipelineStateDescription
-    {
-    public:
-        explicit SpriteBatchPipelineStateDescription(
-            const RenderTargetState& renderTarget,
-            _In_opt_ const D3D12_BLEND_DESC* blend = nullptr,
-            _In_opt_ const D3D12_DEPTH_STENCIL_DESC* depthStencil = nullptr,
-            _In_opt_ const D3D12_RASTERIZER_DESC* rasterizer = nullptr,
-            _In_opt_ const D3D12_GPU_DESCRIPTOR_HANDLE* isamplerDescriptor = nullptr) noexcept
-            :
-            blendDesc(blend ? *blend : s_DefaultBlendDesc),
-            depthStencilDesc(depthStencil ? *depthStencil : s_DefaultDepthStencilDesc),
-            rasterizerDesc(rasterizer ? *rasterizer : s_DefaultRasterizerDesc),
-            renderTargetState(renderTarget),
-            samplerDescriptor{},
-            customRootSignature(nullptr),
-            customVertexShader{},
-            customPixelShader{}
+        enum SpriteSortMode
         {
-            if (isamplerDescriptor)
-                this->samplerDescriptor = *isamplerDescriptor;
-        }
+            SpriteSortMode_Deferred,
+            SpriteSortMode_Immediate,
+            SpriteSortMode_Texture,
+            SpriteSortMode_BackToFront,
+            SpriteSortMode_FrontToBack,
+        };
 
-        D3D12_BLEND_DESC            blendDesc;
-        D3D12_DEPTH_STENCIL_DESC    depthStencilDesc;
-        D3D12_RASTERIZER_DESC       rasterizerDesc;
-        RenderTargetState           renderTargetState;
-        D3D12_GPU_DESCRIPTOR_HANDLE samplerDescriptor;
-        ID3D12RootSignature*        customRootSignature;
-        D3D12_SHADER_BYTECODE       customVertexShader;
-        D3D12_SHADER_BYTECODE       customPixelShader;
+        enum SpriteEffects : uint32_t
+        {
+            SpriteEffects_None = 0,
+            SpriteEffects_FlipHorizontally = 1,
+            SpriteEffects_FlipVertically = 2,
+            SpriteEffects_FlipBoth = SpriteEffects_FlipHorizontally | SpriteEffects_FlipVertically,
+        };
 
-    private:
-        static const D3D12_BLEND_DESC           s_DefaultBlendDesc;
-        static const D3D12_RASTERIZER_DESC      s_DefaultRasterizerDesc;
-        static const D3D12_DEPTH_STENCIL_DESC   s_DefaultDepthStencilDesc;
-    };
+        class SpriteBatchPipelineStateDescription
+        {
+        public:
+            explicit SpriteBatchPipelineStateDescription(
+                const RenderTargetState& renderTarget,
+                _In_opt_ const D3D12_BLEND_DESC* blend = nullptr,
+                _In_opt_ const D3D12_DEPTH_STENCIL_DESC* depthStencil = nullptr,
+                _In_opt_ const D3D12_RASTERIZER_DESC* rasterizer = nullptr,
+                _In_opt_ const D3D12_GPU_DESCRIPTOR_HANDLE* isamplerDescriptor = nullptr) noexcept
+                :
+                blendDesc(blend ? *blend : s_DefaultBlendDesc),
+                depthStencilDesc(depthStencil ? *depthStencil : s_DefaultDepthStencilDesc),
+                rasterizerDesc(rasterizer ? *rasterizer : s_DefaultRasterizerDesc),
+                renderTargetState(renderTarget),
+                samplerDescriptor{},
+                customRootSignature(nullptr),
+                customVertexShader{},
+                customPixelShader{}
+            {
+                if (isamplerDescriptor)
+                    this->samplerDescriptor = *isamplerDescriptor;
+            }
 
-    class SpriteBatch
-    {
-    public:
-        SpriteBatch(_In_ ID3D12Device* device, ResourceUploadBatch& upload,
-            const SpriteBatchPipelineStateDescription& psoDesc,
-            _In_opt_ const D3D12_VIEWPORT* viewport = nullptr);
+            D3D12_BLEND_DESC            blendDesc;
+            D3D12_DEPTH_STENCIL_DESC    depthStencilDesc;
+            D3D12_RASTERIZER_DESC       rasterizerDesc;
+            RenderTargetState           renderTargetState;
+            D3D12_GPU_DESCRIPTOR_HANDLE samplerDescriptor;
+            ID3D12RootSignature*        customRootSignature;
+            D3D12_SHADER_BYTECODE       customVertexShader;
+            D3D12_SHADER_BYTECODE       customPixelShader;
 
-        SpriteBatch(SpriteBatch&&) noexcept;
-        SpriteBatch& operator= (SpriteBatch&&) noexcept;
+        private:
+            static const D3D12_BLEND_DESC           s_DefaultBlendDesc;
+            static const D3D12_RASTERIZER_DESC      s_DefaultRasterizerDesc;
+            static const D3D12_DEPTH_STENCIL_DESC   s_DefaultDepthStencilDesc;
+        };
 
-        SpriteBatch(SpriteBatch const&) = delete;
-        SpriteBatch& operator= (SpriteBatch const&) = delete;
+        class SpriteBatch
+        {
+        public:
+            SpriteBatch(_In_ ID3D12Device* device, ResourceUploadBatch& upload,
+                const SpriteBatchPipelineStateDescription& psoDesc,
+                _In_opt_ const D3D12_VIEWPORT* viewport = nullptr);
 
-        virtual ~SpriteBatch();
+            SpriteBatch(SpriteBatch&&) noexcept;
+            SpriteBatch& operator= (SpriteBatch&&) noexcept;
 
-        // Begin/End a batch of sprite drawing operations.
-        void XM_CALLCONV Begin(
-            _In_ ID3D12GraphicsCommandList* commandList,
-            SpriteSortMode sortMode = SpriteSortMode_Deferred,
-            FXMMATRIX transformMatrix = MatrixIdentity);
-        void XM_CALLCONV Begin(
-            _In_ ID3D12GraphicsCommandList* commandList,
-            D3D12_GPU_DESCRIPTOR_HANDLE sampler,
-            SpriteSortMode sortMode = SpriteSortMode_Deferred,
-            FXMMATRIX transformMatrix = MatrixIdentity);
-        void __cdecl End();
+            SpriteBatch(SpriteBatch const&) = delete;
+            SpriteBatch& operator= (SpriteBatch const&) = delete;
 
-        // Draw overloads specifying position, origin and scale as XMFLOAT2.
-        void XM_CALLCONV Draw(D3D12_GPU_DESCRIPTOR_HANDLE textureSRV, XMUINT2 const& textureSize, XMFLOAT2 const& position, FXMVECTOR color = Colors::White);
-        void XM_CALLCONV Draw(D3D12_GPU_DESCRIPTOR_HANDLE textureSRV, XMUINT2 const& textureSize, XMFLOAT2 const& position, _In_opt_ RECT const* sourceRectangle, FXMVECTOR color = Colors::White, float rotation = 0, XMFLOAT2 const& origin = Float2Zero, float scale = 1, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0);
-        void XM_CALLCONV Draw(D3D12_GPU_DESCRIPTOR_HANDLE textureSRV, XMUINT2 const& textureSize, XMFLOAT2 const& position, _In_opt_ RECT const* sourceRectangle, FXMVECTOR color, float rotation, XMFLOAT2 const& origin, XMFLOAT2 const& scale, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0);
+            virtual ~SpriteBatch();
 
-        // Draw overloads specifying position, origin and scale via the first two components of an XMVECTOR.
-        void XM_CALLCONV Draw(D3D12_GPU_DESCRIPTOR_HANDLE textureSRV, XMUINT2 const& textureSize, FXMVECTOR position, FXMVECTOR color = Colors::White);
-        void XM_CALLCONV Draw(D3D12_GPU_DESCRIPTOR_HANDLE textureSRV, XMUINT2 const& textureSize, FXMVECTOR position, _In_opt_ RECT const* sourceRectangle, FXMVECTOR color = Colors::White, float rotation = 0, FXMVECTOR origin = g_XMZero, float scale = 1, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0);
-        void XM_CALLCONV Draw(D3D12_GPU_DESCRIPTOR_HANDLE textureSRV, XMUINT2 const& textureSize, FXMVECTOR position, _In_opt_ RECT const* sourceRectangle, FXMVECTOR color, float rotation, FXMVECTOR origin, GXMVECTOR scale, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0);
+            // Begin/End a batch of sprite drawing operations.
+            void XM_CALLCONV Begin(
+                _In_ ID3D12GraphicsCommandList* commandList,
+                SpriteSortMode sortMode = SpriteSortMode_Deferred,
+                FXMMATRIX transformMatrix = MatrixIdentity);
+            void XM_CALLCONV Begin(
+                _In_ ID3D12GraphicsCommandList* commandList,
+                D3D12_GPU_DESCRIPTOR_HANDLE sampler,
+                SpriteSortMode sortMode = SpriteSortMode_Deferred,
+                FXMMATRIX transformMatrix = MatrixIdentity);
+            void __cdecl End();
 
-        // Draw overloads specifying position as a RECT.
-        void XM_CALLCONV Draw(D3D12_GPU_DESCRIPTOR_HANDLE textureSRV, XMUINT2 const& textureSize, RECT const& destinationRectangle, FXMVECTOR color = Colors::White);
-        void XM_CALLCONV Draw(D3D12_GPU_DESCRIPTOR_HANDLE textureSRV, XMUINT2 const& textureSize, RECT const& destinationRectangle, _In_opt_ RECT const* sourceRectangle, FXMVECTOR color = Colors::White, float rotation = 0, XMFLOAT2 const& origin = Float2Zero, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0);
+            // Draw overloads specifying position, origin and scale as XMFLOAT2.
+            void XM_CALLCONV Draw(D3D12_GPU_DESCRIPTOR_HANDLE textureSRV, XMUINT2 const& textureSize, XMFLOAT2 const& position, FXMVECTOR color = Colors::White);
+            void XM_CALLCONV Draw(D3D12_GPU_DESCRIPTOR_HANDLE textureSRV, XMUINT2 const& textureSize, XMFLOAT2 const& position, _In_opt_ RECT const* sourceRectangle, FXMVECTOR color = Colors::White, float rotation = 0, XMFLOAT2 const& origin = Float2Zero, float scale = 1, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0);
+            void XM_CALLCONV Draw(D3D12_GPU_DESCRIPTOR_HANDLE textureSRV, XMUINT2 const& textureSize, XMFLOAT2 const& position, _In_opt_ RECT const* sourceRectangle, FXMVECTOR color, float rotation, XMFLOAT2 const& origin, XMFLOAT2 const& scale, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0);
 
-        // Rotation mode to be applied to the sprite transformation
-    #if defined(__dxgi1_2_h__) || defined(__d3d11_x_h__) || defined(__d3d12_x_h__) || defined(__XBOX_D3D12_X__)
-        void __cdecl SetRotation(DXGI_MODE_ROTATION mode);
-        DXGI_MODE_ROTATION __cdecl GetRotation() const noexcept;
-    #endif
+            // Draw overloads specifying position, origin and scale via the first two components of an XMVECTOR.
+            void XM_CALLCONV Draw(D3D12_GPU_DESCRIPTOR_HANDLE textureSRV, XMUINT2 const& textureSize, FXMVECTOR position, FXMVECTOR color = Colors::White);
+            void XM_CALLCONV Draw(D3D12_GPU_DESCRIPTOR_HANDLE textureSRV, XMUINT2 const& textureSize, FXMVECTOR position, _In_opt_ RECT const* sourceRectangle, FXMVECTOR color = Colors::White, float rotation = 0, FXMVECTOR origin = g_XMZero, float scale = 1, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0);
+            void XM_CALLCONV Draw(D3D12_GPU_DESCRIPTOR_HANDLE textureSRV, XMUINT2 const& textureSize, FXMVECTOR position, _In_opt_ RECT const* sourceRectangle, FXMVECTOR color, float rotation, FXMVECTOR origin, GXMVECTOR scale, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0);
 
-        // Set viewport for sprite transformation
-        void __cdecl SetViewport(const D3D12_VIEWPORT& viewPort);
+            // Draw overloads specifying position as a RECT.
+            void XM_CALLCONV Draw(D3D12_GPU_DESCRIPTOR_HANDLE textureSRV, XMUINT2 const& textureSize, RECT const& destinationRectangle, FXMVECTOR color = Colors::White);
+            void XM_CALLCONV Draw(D3D12_GPU_DESCRIPTOR_HANDLE textureSRV, XMUINT2 const& textureSize, RECT const& destinationRectangle, _In_opt_ RECT const* sourceRectangle, FXMVECTOR color = Colors::White, float rotation = 0, XMFLOAT2 const& origin = Float2Zero, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0);
 
-    private:
-        // Private implementation.
-        struct Impl;
+            // Rotation mode to be applied to the sprite transformation
+        #if defined(__dxgi1_2_h__) || defined(__d3d11_x_h__) || defined(__d3d12_x_h__) || defined(__XBOX_D3D12_X__)
+            void __cdecl SetRotation(DXGI_MODE_ROTATION mode);
+            DXGI_MODE_ROTATION __cdecl GetRotation() const noexcept;
+        #endif
 
-        std::unique_ptr<Impl> pImpl;
+            // Set viewport for sprite transformation
+            void __cdecl SetViewport(const D3D12_VIEWPORT& viewPort);
 
-        static const XMMATRIX MatrixIdentity;
-        static const XMFLOAT2 Float2Zero;
-    };
+        private:
+            // Private implementation.
+            struct Impl;
+
+            std::unique_ptr<Impl> pImpl;
+
+            static const XMMATRIX MatrixIdentity;
+            static const XMFLOAT2 Float2Zero;
+        };
+    }
 }

--- a/Inc/SpriteFont.h
+++ b/Inc/SpriteFont.h
@@ -18,84 +18,87 @@
 
 namespace DirectX
 {
-    class SpriteFont
+    inline namespace DX12
     {
-    public:
-        struct Glyph;
-
-        SpriteFont(ID3D12Device* device, ResourceUploadBatch& upload,
-            _In_z_ wchar_t const* fileName,
-            D3D12_CPU_DESCRIPTOR_HANDLE cpuDescriptorDest, D3D12_GPU_DESCRIPTOR_HANDLE gpuDescriptor,
-            bool forceSRGB = false);
-        SpriteFont(ID3D12Device* device, ResourceUploadBatch& upload,
-            _In_reads_bytes_(dataSize) uint8_t const* dataBlob, size_t dataSize,
-            D3D12_CPU_DESCRIPTOR_HANDLE cpuDescriptorDest, D3D12_GPU_DESCRIPTOR_HANDLE gpuDescriptor,
-            bool forceSRGB = false);
-        SpriteFont(D3D12_GPU_DESCRIPTOR_HANDLE texture, XMUINT2 textureSize,
-            _In_reads_(glyphCount) Glyph const* glyphs, size_t glyphCount, float lineSpacing);
-
-        SpriteFont(SpriteFont&&) noexcept;
-        SpriteFont& operator= (SpriteFont&&) noexcept;
-
-        SpriteFont(SpriteFont const&) = delete;
-        SpriteFont& operator= (SpriteFont const&) = delete;
-
-        virtual ~SpriteFont();
-
-        // Wide-character / UTF-16LE
-        void XM_CALLCONV DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ wchar_t const* text, XMFLOAT2 const& position, FXMVECTOR color = Colors::White, float rotation = 0, XMFLOAT2 const& origin = Float2Zero, float scale = 1, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0) const;
-        void XM_CALLCONV DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ wchar_t const* text, XMFLOAT2 const& position, FXMVECTOR color, float rotation, XMFLOAT2 const& origin, XMFLOAT2 const& scale, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0) const;
-        void XM_CALLCONV DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ wchar_t const* text, FXMVECTOR position, FXMVECTOR color = Colors::White, float rotation = 0, FXMVECTOR origin = g_XMZero, float scale = 1, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0) const;
-        void XM_CALLCONV DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ wchar_t const* text, FXMVECTOR position, FXMVECTOR color, float rotation, FXMVECTOR origin, GXMVECTOR scale, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0) const;
-
-        XMVECTOR XM_CALLCONV MeasureString(_In_z_ wchar_t const* text, bool ignoreWhitespace = true) const;
-
-        RECT __cdecl MeasureDrawBounds(_In_z_ wchar_t const* text, XMFLOAT2 const& position, bool ignoreWhitespace = true) const;
-        RECT XM_CALLCONV MeasureDrawBounds(_In_z_ wchar_t const* text, FXMVECTOR position, bool ignoreWhitespace = true) const;
-
-        // UTF-8
-        void XM_CALLCONV DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ char const* text, XMFLOAT2 const& position, FXMVECTOR color = Colors::White, float rotation = 0, XMFLOAT2 const& origin = Float2Zero, float scale = 1, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0) const;
-        void XM_CALLCONV DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ char const* text, XMFLOAT2 const& position, FXMVECTOR color, float rotation, XMFLOAT2 const& origin, XMFLOAT2 const& scale, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0) const;
-        void XM_CALLCONV DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ char const* text, FXMVECTOR position, FXMVECTOR color = Colors::White, float rotation = 0, FXMVECTOR origin = g_XMZero, float scale = 1, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0) const;
-        void XM_CALLCONV DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ char const* text, FXMVECTOR position, FXMVECTOR color, float rotation, FXMVECTOR origin, GXMVECTOR scale, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0) const;
-
-        XMVECTOR XM_CALLCONV MeasureString(_In_z_ char const* text, bool ignoreWhitespace = true) const;
-
-        RECT __cdecl MeasureDrawBounds(_In_z_ char const* text, XMFLOAT2 const& position, bool ignoreWhitespace = true) const;
-        RECT XM_CALLCONV MeasureDrawBounds(_In_z_ char const* text, FXMVECTOR position, bool ignoreWhitespace = true) const;
-
-        // Spacing properties
-        float __cdecl GetLineSpacing() const noexcept;
-        void __cdecl SetLineSpacing(float spacing);
-
-        // Font properties
-        wchar_t __cdecl GetDefaultCharacter() const noexcept;
-        void __cdecl SetDefaultCharacter(wchar_t character);
-
-        bool __cdecl ContainsCharacter(wchar_t character) const;
-
-        // Custom layout/rendering
-        Glyph const* __cdecl FindGlyph(wchar_t character) const;
-        D3D12_GPU_DESCRIPTOR_HANDLE __cdecl GetSpriteSheet() const noexcept;
-        XMUINT2 __cdecl GetSpriteSheetSize() const noexcept;
-
-        // Describes a single character glyph.
-        struct Glyph
+        class SpriteFont
         {
-            uint32_t Character;
-            RECT Subrect;
-            float XOffset;
-            float YOffset;
-            float XAdvance;
+        public:
+            struct Glyph;
+
+            SpriteFont(ID3D12Device* device, ResourceUploadBatch& upload,
+                _In_z_ wchar_t const* fileName,
+                D3D12_CPU_DESCRIPTOR_HANDLE cpuDescriptorDest, D3D12_GPU_DESCRIPTOR_HANDLE gpuDescriptor,
+                bool forceSRGB = false);
+            SpriteFont(ID3D12Device* device, ResourceUploadBatch& upload,
+                _In_reads_bytes_(dataSize) uint8_t const* dataBlob, size_t dataSize,
+                D3D12_CPU_DESCRIPTOR_HANDLE cpuDescriptorDest, D3D12_GPU_DESCRIPTOR_HANDLE gpuDescriptor,
+                bool forceSRGB = false);
+            SpriteFont(D3D12_GPU_DESCRIPTOR_HANDLE texture, XMUINT2 textureSize,
+                _In_reads_(glyphCount) Glyph const* glyphs, size_t glyphCount, float lineSpacing);
+
+            SpriteFont(SpriteFont&&) noexcept;
+            SpriteFont& operator= (SpriteFont&&) noexcept;
+
+            SpriteFont(SpriteFont const&) = delete;
+            SpriteFont& operator= (SpriteFont const&) = delete;
+
+            virtual ~SpriteFont();
+
+            // Wide-character / UTF-16LE
+            void XM_CALLCONV DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ wchar_t const* text, XMFLOAT2 const& position, FXMVECTOR color = Colors::White, float rotation = 0, XMFLOAT2 const& origin = Float2Zero, float scale = 1, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0) const;
+            void XM_CALLCONV DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ wchar_t const* text, XMFLOAT2 const& position, FXMVECTOR color, float rotation, XMFLOAT2 const& origin, XMFLOAT2 const& scale, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0) const;
+            void XM_CALLCONV DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ wchar_t const* text, FXMVECTOR position, FXMVECTOR color = Colors::White, float rotation = 0, FXMVECTOR origin = g_XMZero, float scale = 1, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0) const;
+            void XM_CALLCONV DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ wchar_t const* text, FXMVECTOR position, FXMVECTOR color, float rotation, FXMVECTOR origin, GXMVECTOR scale, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0) const;
+
+            XMVECTOR XM_CALLCONV MeasureString(_In_z_ wchar_t const* text, bool ignoreWhitespace = true) const;
+
+            RECT __cdecl MeasureDrawBounds(_In_z_ wchar_t const* text, XMFLOAT2 const& position, bool ignoreWhitespace = true) const;
+            RECT XM_CALLCONV MeasureDrawBounds(_In_z_ wchar_t const* text, FXMVECTOR position, bool ignoreWhitespace = true) const;
+
+            // UTF-8
+            void XM_CALLCONV DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ char const* text, XMFLOAT2 const& position, FXMVECTOR color = Colors::White, float rotation = 0, XMFLOAT2 const& origin = Float2Zero, float scale = 1, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0) const;
+            void XM_CALLCONV DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ char const* text, XMFLOAT2 const& position, FXMVECTOR color, float rotation, XMFLOAT2 const& origin, XMFLOAT2 const& scale, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0) const;
+            void XM_CALLCONV DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ char const* text, FXMVECTOR position, FXMVECTOR color = Colors::White, float rotation = 0, FXMVECTOR origin = g_XMZero, float scale = 1, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0) const;
+            void XM_CALLCONV DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ char const* text, FXMVECTOR position, FXMVECTOR color, float rotation, FXMVECTOR origin, GXMVECTOR scale, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0) const;
+
+            XMVECTOR XM_CALLCONV MeasureString(_In_z_ char const* text, bool ignoreWhitespace = true) const;
+
+            RECT __cdecl MeasureDrawBounds(_In_z_ char const* text, XMFLOAT2 const& position, bool ignoreWhitespace = true) const;
+            RECT XM_CALLCONV MeasureDrawBounds(_In_z_ char const* text, FXMVECTOR position, bool ignoreWhitespace = true) const;
+
+            // Spacing properties
+            float __cdecl GetLineSpacing() const noexcept;
+            void __cdecl SetLineSpacing(float spacing);
+
+            // Font properties
+            wchar_t __cdecl GetDefaultCharacter() const noexcept;
+            void __cdecl SetDefaultCharacter(wchar_t character);
+
+            bool __cdecl ContainsCharacter(wchar_t character) const;
+
+            // Custom layout/rendering
+            Glyph const* __cdecl FindGlyph(wchar_t character) const;
+            D3D12_GPU_DESCRIPTOR_HANDLE __cdecl GetSpriteSheet() const noexcept;
+            XMUINT2 __cdecl GetSpriteSheetSize() const noexcept;
+
+            // Describes a single character glyph.
+            struct Glyph
+            {
+                uint32_t Character;
+                RECT Subrect;
+                float XOffset;
+                float YOffset;
+                float XAdvance;
+            };
+
+
+        private:
+            // Private implementation.
+            class Impl;
+
+            std::unique_ptr<Impl> pImpl;
+
+            static const XMFLOAT2 Float2Zero;
         };
-
-
-    private:
-        // Private implementation.
-        class Impl;
-
-        std::unique_ptr<Impl> pImpl;
-
-        static const XMFLOAT2 Float2Zero;
-    };
+    }
 }

--- a/Inc/VertexTypes.h
+++ b/Inc/VertexTypes.h
@@ -25,333 +25,336 @@
 
 namespace DirectX
 {
+    inline namespace DX12
+    {
     // Vertex struct holding position information.
-    struct VertexPosition
-    {
-        VertexPosition() = default;
-
-        VertexPosition(const VertexPosition&) = default;
-        VertexPosition& operator=(const VertexPosition&) = default;
-
-        VertexPosition(VertexPosition&&) = default;
-        VertexPosition& operator=(VertexPosition&&) = default;
-
-        VertexPosition(XMFLOAT3 const& iposition) noexcept
-            : position(iposition)
+        struct VertexPosition
         {
-        }
+            VertexPosition() = default;
 
-        VertexPosition(FXMVECTOR iposition) noexcept
+            VertexPosition(const VertexPosition&) = default;
+            VertexPosition& operator=(const VertexPosition&) = default;
+
+            VertexPosition(VertexPosition&&) = default;
+            VertexPosition& operator=(VertexPosition&&) = default;
+
+            VertexPosition(XMFLOAT3 const& iposition) noexcept
+                : position(iposition)
+            {
+            }
+
+            VertexPosition(FXMVECTOR iposition) noexcept
+            {
+                XMStoreFloat3(&this->position, iposition);
+            }
+
+            XMFLOAT3 position;
+
+            static const D3D12_INPUT_LAYOUT_DESC InputLayout;
+
+        private:
+            static constexpr unsigned int InputElementCount = 1;
+            static const D3D12_INPUT_ELEMENT_DESC InputElements[InputElementCount];
+        };
+
+
+        // Vertex struct holding position and color information.
+        struct VertexPositionColor
         {
-            XMStoreFloat3(&this->position, iposition);
-        }
+            VertexPositionColor() = default;
 
-        XMFLOAT3 position;
+            VertexPositionColor(const VertexPositionColor&) = default;
+            VertexPositionColor& operator=(const VertexPositionColor&) = default;
 
-        static const D3D12_INPUT_LAYOUT_DESC InputLayout;
+            VertexPositionColor(VertexPositionColor&&) = default;
+            VertexPositionColor& operator=(VertexPositionColor&&) = default;
 
-    private:
-        static constexpr unsigned int InputElementCount = 1;
-        static const D3D12_INPUT_ELEMENT_DESC InputElements[InputElementCount];
-    };
+            VertexPositionColor(XMFLOAT3 const& iposition, XMFLOAT4 const& icolor) noexcept
+                : position(iposition),
+                color(icolor)
+            {
+            }
+
+            VertexPositionColor(FXMVECTOR iposition, FXMVECTOR icolor) noexcept
+            {
+                XMStoreFloat3(&this->position, iposition);
+                XMStoreFloat4(&this->color, icolor);
+            }
+
+            XMFLOAT3 position;
+            XMFLOAT4 color;
+
+            static const D3D12_INPUT_LAYOUT_DESC InputLayout;
+
+        private:
+            static constexpr unsigned int InputElementCount = 2;
+            static const D3D12_INPUT_ELEMENT_DESC InputElements[InputElementCount];
+        };
 
 
-    // Vertex struct holding position and color information.
-    struct VertexPositionColor
-    {
-        VertexPositionColor() = default;
-
-        VertexPositionColor(const VertexPositionColor&) = default;
-        VertexPositionColor& operator=(const VertexPositionColor&) = default;
-
-        VertexPositionColor(VertexPositionColor&&) = default;
-        VertexPositionColor& operator=(VertexPositionColor&&) = default;
-
-        VertexPositionColor(XMFLOAT3 const& iposition, XMFLOAT4 const& icolor) noexcept
-            : position(iposition),
-            color(icolor)
+        // Vertex struct holding position and texture mapping information.
+        struct VertexPositionTexture
         {
-        }
+            VertexPositionTexture() = default;
 
-        VertexPositionColor(FXMVECTOR iposition, FXMVECTOR icolor) noexcept
+            VertexPositionTexture(const VertexPositionTexture&) = default;
+            VertexPositionTexture& operator=(const VertexPositionTexture&) = default;
+
+            VertexPositionTexture(VertexPositionTexture&&) = default;
+            VertexPositionTexture& operator=(VertexPositionTexture&&) = default;
+
+            VertexPositionTexture(XMFLOAT3 const& iposition, XMFLOAT2 const& itextureCoordinate) noexcept
+                : position(iposition),
+                textureCoordinate(itextureCoordinate)
+            {
+            }
+
+            VertexPositionTexture(FXMVECTOR iposition, FXMVECTOR itextureCoordinate) noexcept
+            {
+                XMStoreFloat3(&this->position, iposition);
+                XMStoreFloat2(&this->textureCoordinate, itextureCoordinate);
+            }
+
+            XMFLOAT3 position;
+            XMFLOAT2 textureCoordinate;
+
+            static const D3D12_INPUT_LAYOUT_DESC InputLayout;
+
+        private:
+            static constexpr unsigned int InputElementCount = 2;
+            static const D3D12_INPUT_ELEMENT_DESC InputElements[InputElementCount];
+        };
+
+
+        // Vertex struct holding position and dual texture mapping information.
+        struct VertexPositionDualTexture
         {
-            XMStoreFloat3(&this->position, iposition);
-            XMStoreFloat4(&this->color, icolor);
-        }
+            VertexPositionDualTexture() = default;
 
-        XMFLOAT3 position;
-        XMFLOAT4 color;
+            VertexPositionDualTexture(const VertexPositionDualTexture&) = default;
+            VertexPositionDualTexture& operator=(const VertexPositionDualTexture&) = default;
 
-        static const D3D12_INPUT_LAYOUT_DESC InputLayout;
+            VertexPositionDualTexture(VertexPositionDualTexture&&) = default;
+            VertexPositionDualTexture& operator=(VertexPositionDualTexture&&) = default;
 
-    private:
-        static constexpr unsigned int InputElementCount = 2;
-        static const D3D12_INPUT_ELEMENT_DESC InputElements[InputElementCount];
-    };
+            VertexPositionDualTexture(
+                XMFLOAT3 const& iposition,
+                XMFLOAT2 const& itextureCoordinate0,
+                XMFLOAT2 const& itextureCoordinate1) noexcept
+                : position(iposition),
+                textureCoordinate0(itextureCoordinate0),
+                textureCoordinate1(itextureCoordinate1)
+            {
+            }
+
+            VertexPositionDualTexture(
+                FXMVECTOR iposition,
+                FXMVECTOR itextureCoordinate0,
+                FXMVECTOR itextureCoordinate1) noexcept
+            {
+                XMStoreFloat3(&this->position, iposition);
+                XMStoreFloat2(&this->textureCoordinate0, itextureCoordinate0);
+                XMStoreFloat2(&this->textureCoordinate1, itextureCoordinate1);
+            }
+
+            XMFLOAT3 position;
+            XMFLOAT2 textureCoordinate0;
+            XMFLOAT2 textureCoordinate1;
+
+            static const D3D12_INPUT_LAYOUT_DESC InputLayout;
+
+        private:
+            static constexpr unsigned int InputElementCount = 3;
+            static const D3D12_INPUT_ELEMENT_DESC InputElements[InputElementCount];
+        };
 
 
-    // Vertex struct holding position and texture mapping information.
-    struct VertexPositionTexture
-    {
-        VertexPositionTexture() = default;
-
-        VertexPositionTexture(const VertexPositionTexture&) = default;
-        VertexPositionTexture& operator=(const VertexPositionTexture&) = default;
-
-        VertexPositionTexture(VertexPositionTexture&&) = default;
-        VertexPositionTexture& operator=(VertexPositionTexture&&) = default;
-
-        VertexPositionTexture(XMFLOAT3 const& iposition, XMFLOAT2 const& itextureCoordinate) noexcept
-            : position(iposition),
-            textureCoordinate(itextureCoordinate)
+        // Vertex struct holding position and normal vector.
+        struct VertexPositionNormal
         {
-        }
+            VertexPositionNormal() = default;
 
-        VertexPositionTexture(FXMVECTOR iposition, FXMVECTOR itextureCoordinate) noexcept
+            VertexPositionNormal(const VertexPositionNormal&) = default;
+            VertexPositionNormal& operator=(const VertexPositionNormal&) = default;
+
+            VertexPositionNormal(VertexPositionNormal&&) = default;
+            VertexPositionNormal& operator=(VertexPositionNormal&&) = default;
+
+            VertexPositionNormal(XMFLOAT3 const& iposition, XMFLOAT3 const& inormal) noexcept
+                : position(iposition),
+                normal(inormal)
+            {
+            }
+
+            VertexPositionNormal(FXMVECTOR iposition, FXMVECTOR inormal) noexcept
+            {
+                XMStoreFloat3(&this->position, iposition);
+                XMStoreFloat3(&this->normal, inormal);
+            }
+
+            XMFLOAT3 position;
+            XMFLOAT3 normal;
+
+            static const D3D12_INPUT_LAYOUT_DESC InputLayout;
+
+        private:
+            static constexpr unsigned int InputElementCount = 2;
+            static const D3D12_INPUT_ELEMENT_DESC InputElements[InputElementCount];
+        };
+
+
+        // Vertex struct holding position, color, and texture mapping information.
+        struct VertexPositionColorTexture
         {
-            XMStoreFloat3(&this->position, iposition);
-            XMStoreFloat2(&this->textureCoordinate, itextureCoordinate);
-        }
+            VertexPositionColorTexture() = default;
 
-        XMFLOAT3 position;
-        XMFLOAT2 textureCoordinate;
+            VertexPositionColorTexture(const VertexPositionColorTexture&) = default;
+            VertexPositionColorTexture& operator=(const VertexPositionColorTexture&) = default;
 
-        static const D3D12_INPUT_LAYOUT_DESC InputLayout;
+            VertexPositionColorTexture(VertexPositionColorTexture&&) = default;
+            VertexPositionColorTexture& operator=(VertexPositionColorTexture&&) = default;
 
-    private:
-        static constexpr unsigned int InputElementCount = 2;
-        static const D3D12_INPUT_ELEMENT_DESC InputElements[InputElementCount];
-    };
+            VertexPositionColorTexture(XMFLOAT3 const& iposition, XMFLOAT4 const& icolor, XMFLOAT2 const& itextureCoordinate) noexcept
+                : position(iposition),
+                color(icolor),
+                textureCoordinate(itextureCoordinate)
+            {
+            }
+
+            VertexPositionColorTexture(FXMVECTOR iposition, FXMVECTOR icolor, FXMVECTOR itextureCoordinate) noexcept
+            {
+                XMStoreFloat3(&this->position, iposition);
+                XMStoreFloat4(&this->color, icolor);
+                XMStoreFloat2(&this->textureCoordinate, itextureCoordinate);
+            }
+
+            XMFLOAT3 position;
+            XMFLOAT4 color;
+            XMFLOAT2 textureCoordinate;
+
+            static const D3D12_INPUT_LAYOUT_DESC InputLayout;
+
+        private:
+            static constexpr unsigned int InputElementCount = 3;
+            static const D3D12_INPUT_ELEMENT_DESC InputElements[InputElementCount];
+        };
 
 
-    // Vertex struct holding position and dual texture mapping information.
-    struct VertexPositionDualTexture
-    {
-        VertexPositionDualTexture() = default;
-
-        VertexPositionDualTexture(const VertexPositionDualTexture&) = default;
-        VertexPositionDualTexture& operator=(const VertexPositionDualTexture&) = default;
-
-        VertexPositionDualTexture(VertexPositionDualTexture&&) = default;
-        VertexPositionDualTexture& operator=(VertexPositionDualTexture&&) = default;
-
-        VertexPositionDualTexture(
-            XMFLOAT3 const& iposition,
-            XMFLOAT2 const& itextureCoordinate0,
-            XMFLOAT2 const& itextureCoordinate1) noexcept
-            : position(iposition),
-            textureCoordinate0(itextureCoordinate0),
-            textureCoordinate1(itextureCoordinate1)
+        // Vertex struct holding position, normal vector, and color information.
+        struct VertexPositionNormalColor
         {
-        }
+            VertexPositionNormalColor() = default;
 
-        VertexPositionDualTexture(
-            FXMVECTOR iposition,
-            FXMVECTOR itextureCoordinate0,
-            FXMVECTOR itextureCoordinate1) noexcept
+            VertexPositionNormalColor(const VertexPositionNormalColor&) = default;
+            VertexPositionNormalColor& operator=(const VertexPositionNormalColor&) = default;
+
+            VertexPositionNormalColor(VertexPositionNormalColor&&) = default;
+            VertexPositionNormalColor& operator=(VertexPositionNormalColor&&) = default;
+
+            VertexPositionNormalColor(XMFLOAT3 const& iposition, XMFLOAT3 const& inormal, XMFLOAT4 const& icolor) noexcept
+                : position(iposition),
+                normal(inormal),
+                color(icolor)
+            {
+            }
+
+            VertexPositionNormalColor(FXMVECTOR iposition, FXMVECTOR inormal, FXMVECTOR icolor) noexcept
+            {
+                XMStoreFloat3(&this->position, iposition);
+                XMStoreFloat3(&this->normal, inormal);
+                XMStoreFloat4(&this->color, icolor);
+            }
+
+            XMFLOAT3 position;
+            XMFLOAT3 normal;
+            XMFLOAT4 color;
+
+            static const D3D12_INPUT_LAYOUT_DESC InputLayout;
+
+        private:
+            static constexpr unsigned int InputElementCount = 3;
+            static const D3D12_INPUT_ELEMENT_DESC InputElements[InputElementCount];
+        };
+
+
+        // Vertex struct holding position, normal vector, and texture mapping information.
+        struct VertexPositionNormalTexture
         {
-            XMStoreFloat3(&this->position, iposition);
-            XMStoreFloat2(&this->textureCoordinate0, itextureCoordinate0);
-            XMStoreFloat2(&this->textureCoordinate1, itextureCoordinate1);
-        }
+            VertexPositionNormalTexture() = default;
 
-        XMFLOAT3 position;
-        XMFLOAT2 textureCoordinate0;
-        XMFLOAT2 textureCoordinate1;
+            VertexPositionNormalTexture(const VertexPositionNormalTexture&) = default;
+            VertexPositionNormalTexture& operator=(const VertexPositionNormalTexture&) = default;
 
-        static const D3D12_INPUT_LAYOUT_DESC InputLayout;
+            VertexPositionNormalTexture(VertexPositionNormalTexture&&) = default;
+            VertexPositionNormalTexture& operator=(VertexPositionNormalTexture&&) = default;
 
-    private:
-        static constexpr unsigned int InputElementCount = 3;
-        static const D3D12_INPUT_ELEMENT_DESC InputElements[InputElementCount];
-    };
+            VertexPositionNormalTexture(XMFLOAT3 const& iposition, XMFLOAT3 const& inormal, XMFLOAT2 const& itextureCoordinate) noexcept
+                : position(iposition),
+                normal(inormal),
+                textureCoordinate(itextureCoordinate)
+            {
+            }
+
+            VertexPositionNormalTexture(FXMVECTOR iposition, FXMVECTOR inormal, FXMVECTOR itextureCoordinate) noexcept
+            {
+                XMStoreFloat3(&this->position, iposition);
+                XMStoreFloat3(&this->normal, inormal);
+                XMStoreFloat2(&this->textureCoordinate, itextureCoordinate);
+            }
+
+            XMFLOAT3 position;
+            XMFLOAT3 normal;
+            XMFLOAT2 textureCoordinate;
+
+            static const D3D12_INPUT_LAYOUT_DESC InputLayout;
+
+        private:
+            static constexpr unsigned int InputElementCount = 3;
+            static const D3D12_INPUT_ELEMENT_DESC InputElements[InputElementCount];
+        };
 
 
-    // Vertex struct holding position and normal vector.
-    struct VertexPositionNormal
-    {
-        VertexPositionNormal() = default;
-
-        VertexPositionNormal(const VertexPositionNormal&) = default;
-        VertexPositionNormal& operator=(const VertexPositionNormal&) = default;
-
-        VertexPositionNormal(VertexPositionNormal&&) = default;
-        VertexPositionNormal& operator=(VertexPositionNormal&&) = default;
-
-        VertexPositionNormal(XMFLOAT3 const& iposition, XMFLOAT3 const& inormal) noexcept
-            : position(iposition),
-            normal(inormal)
+        // Vertex struct holding position, normal vector, color, and texture mapping information.
+        struct VertexPositionNormalColorTexture
         {
-        }
+            VertexPositionNormalColorTexture() = default;
 
-        VertexPositionNormal(FXMVECTOR iposition, FXMVECTOR inormal) noexcept
-        {
-            XMStoreFloat3(&this->position, iposition);
-            XMStoreFloat3(&this->normal, inormal);
-        }
+            VertexPositionNormalColorTexture(const VertexPositionNormalColorTexture&) = default;
+            VertexPositionNormalColorTexture& operator=(const VertexPositionNormalColorTexture&) = default;
 
-        XMFLOAT3 position;
-        XMFLOAT3 normal;
+            VertexPositionNormalColorTexture(VertexPositionNormalColorTexture&&) = default;
+            VertexPositionNormalColorTexture& operator=(VertexPositionNormalColorTexture&&) = default;
 
-        static const D3D12_INPUT_LAYOUT_DESC InputLayout;
+            VertexPositionNormalColorTexture(
+                XMFLOAT3 const& iposition,
+                XMFLOAT3 const& inormal,
+                XMFLOAT4 const& icolor,
+                XMFLOAT2 const& itextureCoordinate) noexcept
+                : position(iposition),
+                normal(inormal),
+                color(icolor),
+                textureCoordinate(itextureCoordinate)
+            {
+            }
 
-    private:
-        static constexpr unsigned int InputElementCount = 2;
-        static const D3D12_INPUT_ELEMENT_DESC InputElements[InputElementCount];
-    };
+            VertexPositionNormalColorTexture(FXMVECTOR iposition, FXMVECTOR inormal, FXMVECTOR icolor, CXMVECTOR itextureCoordinate) noexcept
+            {
+                XMStoreFloat3(&this->position, iposition);
+                XMStoreFloat3(&this->normal, inormal);
+                XMStoreFloat4(&this->color, icolor);
+                XMStoreFloat2(&this->textureCoordinate, itextureCoordinate);
+            }
 
+            XMFLOAT3 position;
+            XMFLOAT3 normal;
+            XMFLOAT4 color;
+            XMFLOAT2 textureCoordinate;
 
-    // Vertex struct holding position, color, and texture mapping information.
-    struct VertexPositionColorTexture
-    {
-        VertexPositionColorTexture() = default;
+            static const D3D12_INPUT_LAYOUT_DESC InputLayout;
 
-        VertexPositionColorTexture(const VertexPositionColorTexture&) = default;
-        VertexPositionColorTexture& operator=(const VertexPositionColorTexture&) = default;
-
-        VertexPositionColorTexture(VertexPositionColorTexture&&) = default;
-        VertexPositionColorTexture& operator=(VertexPositionColorTexture&&) = default;
-
-        VertexPositionColorTexture(XMFLOAT3 const& iposition, XMFLOAT4 const& icolor, XMFLOAT2 const& itextureCoordinate) noexcept
-            : position(iposition),
-            color(icolor),
-            textureCoordinate(itextureCoordinate)
-        {
-        }
-
-        VertexPositionColorTexture(FXMVECTOR iposition, FXMVECTOR icolor, FXMVECTOR itextureCoordinate) noexcept
-        {
-            XMStoreFloat3(&this->position, iposition);
-            XMStoreFloat4(&this->color, icolor);
-            XMStoreFloat2(&this->textureCoordinate, itextureCoordinate);
-        }
-
-        XMFLOAT3 position;
-        XMFLOAT4 color;
-        XMFLOAT2 textureCoordinate;
-
-        static const D3D12_INPUT_LAYOUT_DESC InputLayout;
-
-    private:
-        static constexpr unsigned int InputElementCount = 3;
-        static const D3D12_INPUT_ELEMENT_DESC InputElements[InputElementCount];
-    };
-
-
-    // Vertex struct holding position, normal vector, and color information.
-    struct VertexPositionNormalColor
-    {
-        VertexPositionNormalColor() = default;
-
-        VertexPositionNormalColor(const VertexPositionNormalColor&) = default;
-        VertexPositionNormalColor& operator=(const VertexPositionNormalColor&) = default;
-
-        VertexPositionNormalColor(VertexPositionNormalColor&&) = default;
-        VertexPositionNormalColor& operator=(VertexPositionNormalColor&&) = default;
-
-        VertexPositionNormalColor(XMFLOAT3 const& iposition, XMFLOAT3 const& inormal, XMFLOAT4 const& icolor) noexcept
-            : position(iposition),
-            normal(inormal),
-            color(icolor)
-        {
-        }
-
-        VertexPositionNormalColor(FXMVECTOR iposition, FXMVECTOR inormal, FXMVECTOR icolor) noexcept
-        {
-            XMStoreFloat3(&this->position, iposition);
-            XMStoreFloat3(&this->normal, inormal);
-            XMStoreFloat4(&this->color, icolor);
-        }
-
-        XMFLOAT3 position;
-        XMFLOAT3 normal;
-        XMFLOAT4 color;
-
-        static const D3D12_INPUT_LAYOUT_DESC InputLayout;
-
-    private:
-        static constexpr unsigned int InputElementCount = 3;
-        static const D3D12_INPUT_ELEMENT_DESC InputElements[InputElementCount];
-    };
-
-
-    // Vertex struct holding position, normal vector, and texture mapping information.
-    struct VertexPositionNormalTexture
-    {
-        VertexPositionNormalTexture() = default;
-
-        VertexPositionNormalTexture(const VertexPositionNormalTexture&) = default;
-        VertexPositionNormalTexture& operator=(const VertexPositionNormalTexture&) = default;
-
-        VertexPositionNormalTexture(VertexPositionNormalTexture&&) = default;
-        VertexPositionNormalTexture& operator=(VertexPositionNormalTexture&&) = default;
-
-        VertexPositionNormalTexture(XMFLOAT3 const& iposition, XMFLOAT3 const& inormal, XMFLOAT2 const& itextureCoordinate) noexcept
-            : position(iposition),
-            normal(inormal),
-            textureCoordinate(itextureCoordinate)
-        {
-        }
-
-        VertexPositionNormalTexture(FXMVECTOR iposition, FXMVECTOR inormal, FXMVECTOR itextureCoordinate) noexcept
-        {
-            XMStoreFloat3(&this->position, iposition);
-            XMStoreFloat3(&this->normal, inormal);
-            XMStoreFloat2(&this->textureCoordinate, itextureCoordinate);
-        }
-
-        XMFLOAT3 position;
-        XMFLOAT3 normal;
-        XMFLOAT2 textureCoordinate;
-
-        static const D3D12_INPUT_LAYOUT_DESC InputLayout;
-
-    private:
-        static constexpr unsigned int InputElementCount = 3;
-        static const D3D12_INPUT_ELEMENT_DESC InputElements[InputElementCount];
-    };
-
-
-    // Vertex struct holding position, normal vector, color, and texture mapping information.
-    struct VertexPositionNormalColorTexture
-    {
-        VertexPositionNormalColorTexture() = default;
-
-        VertexPositionNormalColorTexture(const VertexPositionNormalColorTexture&) = default;
-        VertexPositionNormalColorTexture& operator=(const VertexPositionNormalColorTexture&) = default;
-
-        VertexPositionNormalColorTexture(VertexPositionNormalColorTexture&&) = default;
-        VertexPositionNormalColorTexture& operator=(VertexPositionNormalColorTexture&&) = default;
-
-        VertexPositionNormalColorTexture(
-            XMFLOAT3 const& iposition,
-            XMFLOAT3 const& inormal,
-            XMFLOAT4 const& icolor,
-            XMFLOAT2 const& itextureCoordinate) noexcept
-            : position(iposition),
-            normal(inormal),
-            color(icolor),
-            textureCoordinate(itextureCoordinate)
-        {
-        }
-
-        VertexPositionNormalColorTexture(FXMVECTOR iposition, FXMVECTOR inormal, FXMVECTOR icolor, CXMVECTOR itextureCoordinate) noexcept
-        {
-            XMStoreFloat3(&this->position, iposition);
-            XMStoreFloat3(&this->normal, inormal);
-            XMStoreFloat4(&this->color, icolor);
-            XMStoreFloat2(&this->textureCoordinate, itextureCoordinate);
-        }
-
-        XMFLOAT3 position;
-        XMFLOAT3 normal;
-        XMFLOAT4 color;
-        XMFLOAT2 textureCoordinate;
-
-        static const D3D12_INPUT_LAYOUT_DESC InputLayout;
-
-    private:
-        static constexpr unsigned int InputElementCount = 4;
-        static const D3D12_INPUT_ELEMENT_DESC InputElements[InputElementCount];
-    };
+        private:
+            static constexpr unsigned int InputElementCount = 4;
+            static const D3D12_INPUT_ELEMENT_DESC InputElements[InputElementCount];
+        };
+    }
 }

--- a/Inc/WICTextureLoader.h
+++ b/Inc/WICTextureLoader.h
@@ -39,18 +39,21 @@
 
 namespace DirectX
 {
-    enum WIC_LOADER_FLAGS : uint32_t
+    inline namespace DX12
     {
-        WIC_LOADER_DEFAULT = 0,
-        WIC_LOADER_FORCE_SRGB = 0x1,
-        WIC_LOADER_IGNORE_SRGB = 0x2,
-        WIC_LOADER_SRGB_DEFAULT = 0x4,
-        WIC_LOADER_MIP_AUTOGEN = 0x8,
-        WIC_LOADER_MIP_RESERVE = 0x10,
-        WIC_LOADER_FIT_POW2 = 0x20,
-        WIC_LOADER_MAKE_SQUARE = 0x40,
-        WIC_LOADER_FORCE_RGBA32 = 0x80,
-    };
+        enum WIC_LOADER_FLAGS : uint32_t
+        {
+            WIC_LOADER_DEFAULT = 0,
+            WIC_LOADER_FORCE_SRGB = 0x1,
+            WIC_LOADER_IGNORE_SRGB = 0x2,
+            WIC_LOADER_SRGB_DEFAULT = 0x4,
+            WIC_LOADER_MIP_AUTOGEN = 0x8,
+            WIC_LOADER_MIP_RESERVE = 0x10,
+            WIC_LOADER_FIT_POW2 = 0x20,
+            WIC_LOADER_MAKE_SQUARE = 0x40,
+            WIC_LOADER_FORCE_RGBA32 = 0x80,
+        };
+    }
 
     class ResourceUploadBatch;
 
@@ -137,7 +140,10 @@ namespace DirectX
 #pragma clang diagnostic ignored "-Wdeprecated-dynamic-exception-spec"
 #endif
 
-    DEFINE_ENUM_FLAG_OPERATORS(WIC_LOADER_FLAGS);
+    inline namespace DX12
+    {
+        DEFINE_ENUM_FLAG_OPERATORS(WIC_LOADER_FLAGS);
+    }
 
 #ifdef __clang__
 #pragma clang diagnostic pop

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ For the latest version of DirectXTK12, bug reports, etc. please visit the projec
 
 ## Release Notes
 
+* As of the September 2022 release, the library makes use of C++11 inline namespaces for differing types that have the same names in the DirectX 11 and DirectX 12 version of the *DirectX Tool Kit*. This provides a link-unique name such as ``DirectX::DX12::SpriteBatch`` that will appear in linker output messages. In most use cases, however, there is no need to add explicit ``DX12`` namespace resolution in client code.
+
 * As of the March 2022 release, legacy Xbox One XDK support requires the XDK April 2018 release or later. Upgrading to the Microsoft GDKX is strongly recommended.
 
 * In the June 2021 release or later, the VS 2019 projects of this library build the HLSL shaders with Shader Model 6 via DXC. Since the NuGet still builds using VS 2017, the build-in shaders in that version are currently Shader Model 5.1. See [this wiki page](https://github.com/microsoft/DirectXTK12/wiki/Shader-Model-6) for more information. The Microsoft GDK projects always use Shader Model 6.

--- a/Src/EffectCommon.h
+++ b/Src/EffectCommon.h
@@ -28,13 +28,16 @@
 
 namespace DirectX
 {
-    // Internal effect flags
-    namespace EffectFlags
+    inline namespace DX12
     {
-        constexpr int PerPixelLightingBit = 0x04;
-    }
+        // Internal effect flags
+        namespace EffectFlags
+        {
+            constexpr int PerPixelLightingBit = 0x04;
+        }
 
-    static_assert(((EffectFlags::PerPixelLighting)& EffectFlags::PerPixelLightingBit) != 0, "PerPixelLighting enum flags mismatch");
+        static_assert(((EffectFlags::PerPixelLighting)& EffectFlags::PerPixelLightingBit) != 0, "PerPixelLighting enum flags mismatch");
+    }
 
     // Bitfield tracks which derived parameter values need to be recomputed.
     namespace EffectDirtyFlags

--- a/Src/PrimitiveBatch.cpp
+++ b/Src/PrimitiveBatch.cpp
@@ -14,7 +14,7 @@
 #include "GraphicsMemory.h"
 
 using namespace DirectX;
-using namespace DirectX::Internal;
+using namespace DirectX::DX12::Private;
 using Microsoft::WRL::ComPtr;
 
 

--- a/Src/ScreenGrab.cpp
+++ b/Src/ScreenGrab.cpp
@@ -435,7 +435,7 @@ HRESULT DirectX::SaveDDSTextureToFile(
 //--------------------------------------------------------------------------------------
 namespace DirectX
 {
-    namespace DX12
+    inline namespace DX12
     {
         namespace Internal
         {

--- a/Src/ScreenGrab.cpp
+++ b/Src/ScreenGrab.cpp
@@ -435,9 +435,12 @@ HRESULT DirectX::SaveDDSTextureToFile(
 //--------------------------------------------------------------------------------------
 namespace DirectX
 {
-    namespace Internal
+    namespace DX12
     {
-        extern IWICImagingFactory2* GetWIC() noexcept;
+        namespace Internal
+        {
+            extern IWICImagingFactory2* GetWIC() noexcept;
+        }
     }
 }
 
@@ -453,7 +456,7 @@ HRESULT DirectX::SaveWICTextureToFile(
     std::function<void(IPropertyBag2*)> setCustomProps,
     bool forceSRGB)
 {
-    using namespace DirectX::Internal;
+    using namespace DirectX::DX12::Internal;
 
     if (!fileName)
         return E_INVALIDARG;

--- a/Src/WICTextureLoader.cpp
+++ b/Src/WICTextureLoader.cpp
@@ -154,7 +154,7 @@ namespace
 //--------------------------------------------------------------------------------------
 namespace DirectX
 {
-    namespace DX12
+    inline namespace DX12
     {
         namespace Internal
         {

--- a/Src/WICTextureLoader.cpp
+++ b/Src/WICTextureLoader.cpp
@@ -154,14 +154,17 @@ namespace
 //--------------------------------------------------------------------------------------
 namespace DirectX
 {
-    namespace Internal
+    namespace DX12
     {
-        IWICImagingFactory2* GetWIC() noexcept;
-        // Also used by ScreenGrab
+        namespace Internal
+        {
+            IWICImagingFactory2* GetWIC() noexcept;
+            // Also used by ScreenGrab
+        }
     }
 }
 
-IWICImagingFactory2* DirectX::Internal::GetWIC() noexcept
+IWICImagingFactory2* DirectX::DX12::Internal::GetWIC() noexcept
 {
     static INIT_ONCE s_initOnce = INIT_ONCE_STATIC_INIT;
 
@@ -178,7 +181,7 @@ IWICImagingFactory2* DirectX::Internal::GetWIC() noexcept
     return factory;
 }
 
-using namespace Internal;
+using namespace DirectX::DX12::Internal;
 
 namespace
 {


### PR DESCRIPTION
This adds use of C++11 inline namespaces to wrap types that have *DirectX Tool Kit for DX11* equivalents with the same name. This would allow for 'mixed' use of the *DirectX Tool Kit for DX11* and *DirectX Tool Kit for DX12* in the same exe without link-time conflicts. This also requires making sure there is only one set of the 'shared' code modules like GamePad, etc. which is supported via a CMake build option `BUILD_MIXED_DX11=ON`

It has no client-code impacts, although all client code would need rebuilt to link against a static library build with these changes.