### PR TITLE
Add helper methods for SimpleMath, DirectXHelper, and WICTextureLoader

### DIFF
--- a/Inc/DirectXHelpers.h
+++ b/Inc/DirectXHelpers.h
@@ -118,6 +118,37 @@ namespace DirectX
         D3D12_CPU_DESCRIPTOR_HANDLE srvDescriptor,
         bool isCubeMap = false);
 
+    // Creates an unordered access view from an arbitrary resource
+    void __cdecl CreateUnorderedAccessView(
+        _In_ ID3D12Device* device,
+        _In_ ID3D12Resource* tex,
+        D3D12_CPU_DESCRIPTOR_HANDLE uavDescriptor,
+        UINT mipLevel = 0);
+
+    // Creates an render target view from an arbitrary resource
+    void __cdecl CreateRenderTargetView(
+        _In_ ID3D12Device* device,
+        _In_ ID3D12Resource* tex,
+        D3D12_CPU_DESCRIPTOR_HANDLE rtvDescriptor,
+        UINT mipLevel = 0);
+
+    // Creates a shader resource view from a buffer resource
+    void __cdecl CreateBufferShaderResourceView(
+        _In_ ID3D12Device* device,
+        _In_ ID3D12Resource* buffer,
+        D3D12_CPU_DESCRIPTOR_HANDLE srvDescriptor,
+        UINT stride = 0);
+
+    // Creates a unordered access view from a buffer resource
+    void __cdecl CreateBufferUnorderedAccessView(
+        _In_ ID3D12Device* device,
+        _In_ ID3D12Resource* buffer,
+        D3D12_CPU_DESCRIPTOR_HANDLE uavDescriptor,
+        UINT stride,
+        D3D12_BUFFER_UAV_FLAGS flag = D3D12_BUFFER_UAV_FLAG_NONE,
+        UINT counterOffset = 0,
+        _In_ _Maybenull_ ID3D12Resource* counterResource = nullptr);
+
     // Shorthand for creating a root signature
     inline HRESULT CreateRootSignature(
         _In_ ID3D12Device* device,

--- a/Inc/SimpleMath.h
+++ b/Inc/SimpleMath.h
@@ -583,12 +583,15 @@ namespace DirectX
             static Matrix CreateFromAxisAngle(const Vector3& axis, float angle) noexcept;
 
             static Matrix CreatePerspectiveFieldOfView(float fov, float aspectRatio, float nearPlane, float farPlane) noexcept;
+            static Matrix CreatePerspectiveFieldOfViewLH(float fov, float aspectRatio, float nearPlane, float farPlane) noexcept;
             static Matrix CreatePerspective(float width, float height, float nearPlane, float farPlane) noexcept;
+            static Matrix CreatePerspectiveLH(float width, float height, float nearPlane, float farPlane) noexcept;
             static Matrix CreatePerspectiveOffCenter(float left, float right, float bottom, float top, float nearPlane, float farPlane) noexcept;
             static Matrix CreateOrthographic(float width, float height, float zNearPlane, float zFarPlane) noexcept;
             static Matrix CreateOrthographicOffCenter(float left, float right, float bottom, float top, float zNearPlane, float zFarPlane) noexcept;
 
             static Matrix CreateLookAt(const Vector3& position, const Vector3& target, const Vector3& up) noexcept;
+            static Matrix CreateLookAtLH(const Vector3& position, const Vector3& target, const Vector3& up) noexcept;
             static Matrix CreateWorld(const Vector3& position, const Vector3& forward, const Vector3& up) noexcept;
 
             static Matrix CreateFromQuaternion(const Quaternion& quat) noexcept;

--- a/Inc/SimpleMath.inl
+++ b/Inc/SimpleMath.inl
@@ -1,3 +1,4 @@
+#include "SimpleMath.h"
 //-------------------------------------------------------------------------------------
 // SimpleMath.inl -- Simplified C++ Math wrapper for DirectXMath
 //
@@ -2584,11 +2585,27 @@ inline Matrix Matrix::CreatePerspectiveFieldOfView(float fov, float aspectRatio,
     return R;
 }
 
+inline Matrix Matrix::CreatePerspectiveFieldOfViewLH(float fov, float aspectRatio, float nearPlane, float farPlane) noexcept
+{
+    using namespace DirectX;
+    Matrix R;
+    XMStoreFloat4x4(&R, XMMatrixPerspectiveFovLH(fov, aspectRatio, nearPlane, farPlane));
+    return R;
+}
+
 inline Matrix Matrix::CreatePerspective(float width, float height, float nearPlane, float farPlane) noexcept
 {
     using namespace DirectX;
     Matrix R;
     XMStoreFloat4x4(&R, XMMatrixPerspectiveRH(width, height, nearPlane, farPlane));
+    return R;
+}
+
+inline Matrix DirectX::SimpleMath::Matrix::CreatePerspectiveLH(float width, float height, float nearPlane, float farPlane) noexcept
+{
+    using namespace DirectX;
+    Matrix R;
+    XMStoreFloat4x4(&R, XMMatrixPerspectiveLH(width, height, nearPlane, farPlane));
     return R;
 }
 
@@ -2624,6 +2641,17 @@ inline Matrix Matrix::CreateLookAt(const Vector3& eye, const Vector3& target, co
     const XMVECTOR targetv = XMLoadFloat3(&target);
     const XMVECTOR upv = XMLoadFloat3(&up);
     XMStoreFloat4x4(&R, XMMatrixLookAtRH(eyev, targetv, upv));
+    return R;
+}
+
+inline Matrix DirectX::SimpleMath::Matrix::CreateLookAtLH(const Vector3& position, const Vector3& target, const Vector3& up) noexcept
+{
+    using namespace DirectX;
+    Matrix R;
+    XMVECTOR eyev = XMLoadFloat3(&position);
+    XMVECTOR targetv = XMLoadFloat3(&target);
+    XMVECTOR upv = XMLoadFloat3(&up);
+    XMStoreFloat4x4(&R, XMMatrixLookAtLH(eyev, targetv, upv));
     return R;
 }
 

--- a/Inc/WICTextureLoader.h
+++ b/Inc/WICTextureLoader.h
@@ -135,6 +135,26 @@ namespace DirectX
         WIC_LOADER_FLAGS loadFlags,
         _Outptr_ ID3D12Resource** texture);
 
+    // Create a texture array from filenames with ResourceUploadBatch
+    HRESULT __cdecl CreateWICTextureArrayFromFiles(
+        _In_ ID3D12Device* d3dDevice,
+        ResourceUploadBatch& resourceUpload,
+        _In_reads_(fileNameCount) const wchar_t* fileNames[],
+        UINT fileNameCount,
+        _Outptr_ ID3D12Resource** texture,
+        bool generateMips = false,
+        size_t maxsize = 0);
+
+    HRESULT __cdecl CreateWICTextureArrayFromFilesEx(
+        _In_ ID3D12Device* d3dDevice,
+        ResourceUploadBatch& resourceUpload,
+        _In_reads_(fileNameCount) const wchar_t* fileNames[],
+        UINT fileNameCount,
+        size_t maxsize,
+        D3D12_RESOURCE_FLAGS resFlags,
+        WIC_LOADER_FLAGS loadFlags,
+        _Outptr_ ID3D12Resource** texture);
+
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-dynamic-exception-spec"

--- a/Src/DirectXHelpers.cpp
+++ b/Src/DirectXHelpers.cpp
@@ -93,3 +93,170 @@ void DirectX::CreateShaderResourceView(
 
     device->CreateShaderResourceView(tex, &srvDesc, srvDescriptor);
 }
+
+_Use_decl_annotations_
+void DirectX::CreateUnorderedAccessView(
+    ID3D12Device* device,
+    ID3D12Resource* tex,
+    D3D12_CPU_DESCRIPTOR_HANDLE uavDescriptor,
+    UINT mipLevel)
+{
+    const auto desc = tex->GetDesc();
+
+    D3D12_UNORDERED_ACCESS_VIEW_DESC uavDesc = {};
+    uavDesc.Format = desc.Format;
+
+    switch (desc.Dimension)
+    {
+    case D3D12_RESOURCE_DIMENSION_TEXTURE1D:
+        if (desc.DepthOrArraySize > 1)
+        {
+            uavDesc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE1DARRAY;
+            uavDesc.Texture1DArray.MipSlice = mipLevel;
+            uavDesc.Texture1DArray.FirstArraySlice = 0;
+            uavDesc.Texture1DArray.ArraySize = desc.DepthOrArraySize;
+        }
+        else
+        {
+            uavDesc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE1D;
+            uavDesc.Texture1D.MipSlice = mipLevel;
+        }
+        break;
+
+    case D3D12_RESOURCE_DIMENSION_TEXTURE2D:
+        if (desc.DepthOrArraySize > 1)
+        {
+            uavDesc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE2DARRAY;
+            uavDesc.Texture2DArray.MipSlice = mipLevel;
+            uavDesc.Texture2DArray.ArraySize = desc.DepthOrArraySize;
+        }
+        else
+        {
+            uavDesc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE2D;
+            uavDesc.Texture2D.MipSlice = mipLevel;
+        }
+        break;
+
+    case D3D12_RESOURCE_DIMENSION_TEXTURE3D:
+        uavDesc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE3D;
+        uavDesc.Texture3D.MipSlice = mipLevel;
+        uavDesc.Texture3D.WSize = desc.DepthOrArraySize;
+        break;
+
+    case D3D12_RESOURCE_DIMENSION_BUFFER:
+        DebugTrace("ERROR: CreateUnorderedResourceView cannot be used with DIMENSION_BUFFER.\n\tUse CreateBufferUnorderedAccessView.");
+        throw std::exception("buffer resources not supported");
+
+    case D3D12_RESOURCE_DIMENSION_UNKNOWN:
+    default:
+        DebugTrace("ERROR: CreateUnorderedResourceView cannot be used with DIMENSION_UNKNOWN (%d).\n", desc.Dimension);
+        throw std::exception("unknown resource dimension");
+
+    }
+    device->CreateUnorderedAccessView(tex, nullptr, &uavDesc, uavDescriptor);
+}
+
+_Use_decl_annotations_
+void DirectX::CreateRenderTargetView(
+    ID3D12Device* device,
+    ID3D12Resource* tex,
+    D3D12_CPU_DESCRIPTOR_HANDLE rtvDescriptor,
+    UINT mipLevel)
+{
+    const auto desc = tex->GetDesc();
+
+    D3D12_RENDER_TARGET_VIEW_DESC rtvDesc = {};
+    rtvDesc.Format = desc.Format;
+
+    switch (desc.Dimension)
+    {
+    case D3D12_RESOURCE_DIMENSION_TEXTURE1D:
+        if (desc.DepthOrArraySize > 1)
+        {
+            rtvDesc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE1DARRAY;
+            rtvDesc.Texture1DArray.MipSlice = mipLevel;
+            rtvDesc.Texture1DArray.FirstArraySlice = 0;
+            rtvDesc.Texture1DArray.ArraySize = desc.DepthOrArraySize;
+        }
+        else
+        {
+            rtvDesc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE1D;
+            rtvDesc.Texture1D.MipSlice = mipLevel;
+        }
+        break;
+
+    case D3D12_RESOURCE_DIMENSION_TEXTURE2D:
+        if (desc.DepthOrArraySize > 1)
+        {
+            rtvDesc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE2DARRAY;
+            rtvDesc.Texture2DArray.MipSlice = mipLevel;
+            rtvDesc.Texture2DArray.ArraySize = desc.DepthOrArraySize;
+        }
+        else
+        {
+            rtvDesc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE2D;
+            rtvDesc.Texture2D.MipSlice = mipLevel;
+        }
+        break;
+
+    case D3D12_RESOURCE_DIMENSION_TEXTURE3D:
+        rtvDesc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE3D;
+        rtvDesc.Texture3D.MipSlice = mipLevel;
+        rtvDesc.Texture3D.WSize = desc.DepthOrArraySize;
+        break;
+
+    case D3D12_RESOURCE_DIMENSION_BUFFER:
+        DebugTrace("ERROR: CreateRenderTargetView cannot be used with DIMENSION_BUFFER.\n");
+        throw std::exception("buffer resources not supported");
+
+    case D3D12_RESOURCE_DIMENSION_UNKNOWN:
+    default:
+        DebugTrace("ERROR: CreateRenderTargetView cannot be used with DIMENSION_UNKNOWN (%d).\n", desc.Dimension);
+        throw std::exception("unknown resource dimension");
+
+    }
+    device->CreateRenderTargetView(tex, &rtvDesc, rtvDescriptor);
+}
+
+_Use_decl_annotations_
+void DirectX::CreateBufferShaderResourceView(
+    ID3D12Device* device,
+    ID3D12Resource* buffer,
+    D3D12_CPU_DESCRIPTOR_HANDLE srvDescriptor,
+    UINT stride)
+{
+    const auto desc = buffer->GetDesc();
+    D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+    srvDesc.Format = desc.Format;
+    srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+    srvDesc.ViewDimension = D3D12_SRV_DIMENSION_BUFFER;
+    srvDesc.Buffer.FirstElement = 0;
+    srvDesc.Buffer.NumElements = static_cast<UINT>((stride > 0) ? (desc.Width / stride) : desc.Width);
+    srvDesc.Buffer.StructureByteStride = stride;
+
+    device->CreateShaderResourceView(buffer, &srvDesc, srvDescriptor);
+}
+
+_Use_decl_annotations_
+void DirectX::CreateBufferUnorderedAccessView(
+    ID3D12Device* device,
+    ID3D12Resource* buffer,
+    D3D12_CPU_DESCRIPTOR_HANDLE uavDescriptor,
+    UINT stride,
+    D3D12_BUFFER_UAV_FLAGS flag,
+    UINT counterOffset,
+    ID3D12Resource* counterResource)
+{
+    const auto desc = buffer->GetDesc();
+
+    D3D12_UNORDERED_ACCESS_VIEW_DESC uavDesc = {};
+    uavDesc.Format = desc.Format;
+    uavDesc.ViewDimension = D3D12_UAV_DIMENSION_BUFFER;
+    uavDesc.Buffer.FirstElement = 0;
+    uavDesc.Buffer.NumElements = static_cast<UINT>(stride > 0 ? desc.Width / stride : desc.Width);
+    uavDesc.Buffer.StructureByteStride = stride;
+    uavDesc.Buffer.CounterOffsetInBytes = counterOffset;
+    uavDesc.Buffer.Flags = flag;
+
+    device->CreateUnorderedAccessView(buffer, counterResource, &uavDesc, uavDescriptor);
+}


### PR DESCRIPTION
Thanks for all your hard work on this project!

I have added some left-hand matrix creation methods to the SimpleMath::Matrix class.

I also added UAV and RTV creation for textures, along with SRV and UAV creation for buffer resources.

Finally I added a couple methods to the WIC texture loading for creating a texture array from a list of file names.