### PR TITLE
CMake updated to use /Zc:inline and /Zc:lambda

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -357,6 +357,10 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
         target_link_options(${PROJECT_NAME} PRIVATE /CETCOMPAT)
     endif()
 
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.28)
+        target_compile_options(${PROJECT_NAME} PRIVATE /Zc:lambda)
+    endif()
+
     if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.34)
         target_compile_options(${PROJECT_NAME} PRIVATE /wd5262)
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -339,7 +339,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 elseif(MINGW)
     target_compile_options(${PROJECT_NAME} PRIVATE -Wno-ignored-attributes)
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-    target_compile_options(${PROJECT_NAME} PRIVATE /sdl /permissive- /JMC- /Zc:__cplusplus)
+    target_compile_options(${PROJECT_NAME} PRIVATE /sdl /permissive- /JMC- /Zc:__cplusplus /Zc:inline)
 
     if(ENABLE_CODE_ANALYSIS)
         target_compile_options(${PROJECT_NAME} PRIVATE /analyze)


### PR DESCRIPTION
The ``/Zc:inline`` switch enforces C++11 rules on inline visibility which reduces redundant comdats in each OBJ file (i.e. all the DirectXMath inline functions you *didn't* call in that translation unit). This switch is on by default with MSBuild, but is *not* on by default for command-line builds. This update adds this switch to CMake builds as well.

This reduces the size of the Release obj/lib files in half.

There's also a ``/Zc:lambda`` conformance switch for VS 2019 16.8 or later which I'm enabling for coverage.