### PR TITLE
Update MinGW YAML for XAudio2Redist 1.2.11

### DIFF
--- a/build/DirectXTK12-GitHub-MinGW.yml
+++ b/build/DirectXTK12-GitHub-MinGW.yml
@@ -36,17 +36,20 @@ variables:
 
 jobs:
 - job: MINGW32_BUILD
-  displayName: 'Minimalist GNU for Windows (MinGW32)'
+  displayName: 'Minimalist GNU for Windows (MinGW32) BUILD_TESTING=ON'
   steps:
   - checkout: self
     clean: true
     fetchTags: false
   - task: CmdLine@2
-    # We can use the preinstalled vcpkg instead of the latest when MS Hosted updates their vcpkg to the newer DirectX-Headers
     displayName: Fetch VCPKG
     inputs:
       script: git clone --quiet https://%GITHUB_PAT%@github.com/microsoft/vcpkg.git
       workingDirectory: $(Build.SourcesDirectory)
+  - task: CmdLine@2
+    displayName: Fetch Tests
+    inputs:
+      script: git clone --quiet https://%GITHUB_PAT%@github.com/walbourn/directxtk12test.git Tests
   - task: CmdLine@2
     # Note we have to use x64-mingw-static for the host to use the directx-dxc port.
     displayName: VCPKG Bootstrap
@@ -93,18 +96,17 @@ jobs:
     inputs:
       script: g++ --version
   - task: CmdLine@2
-    # The error checks are commented out due to a bug with vcpkg not returning 0 on success.
     displayName: VCPKG install headers
     inputs:
       script: |
         call vcpkg install directxmath
-        REM @if ERRORLEVEL 1 goto error
+        @if ERRORLEVEL 1 goto error
         call vcpkg install directx-headers
-        REM @if ERRORLEVEL 1 goto error
+        @if ERRORLEVEL 1 goto error
         call vcpkg install xaudio2redist
-        REM @if ERRORLEVEL 1 goto error
+        @if ERRORLEVEL 1 goto error
         call vcpkg install directx-dxc:x64-mingw-static
-        REM @if ERRORLEVEL 1 goto error
+        @if ERRORLEVEL 1 goto error
         :finish
         @echo --- VCPKG COMPLETE ---
         exit /b 0
@@ -203,11 +205,10 @@ jobs:
 
       workingDirectory: $(Build.SourcesDirectory)\vcpkg
   - task: CMake@1
-    # We are building with audio off until the GUID+MinGW linker issues are fixed in the xaudio2redist port.
     displayName: CMake (MinGW-W64)
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out -DCMAKE_BUILD_TYPE="Debug" -DDIRECTX_ARCH=x64 -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DVCPKG_TARGET_TRIPLET=x64-mingw-static -DBUILD_XAUDIO_REDIST=OFF -DDIRECTX_DXC_PATH="$(DIRECTX_DXC_DIR)"
+      cmakeArgs: -B out -DCMAKE_BUILD_TYPE="Debug" -DDIRECTX_ARCH=x64 -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DVCPKG_TARGET_TRIPLET=x64-mingw-static -DBUILD_XAUDIO_REDIST=ON -DDIRECTX_DXC_PATH="$(DIRECTX_DXC_DIR)"
   - task: CMake@1
     displayName: CMake (MinGW-W64) Build
     inputs:


### PR DESCRIPTION
Update for latest XAudio2Redist NuGet release. 1.2.11 includes bug fixes to make the headers link correctly when using the MinGW toolset.
