### PR TITLE
Additional checks for video formats for DDSTextureLoader

### DIFF
--- a/Src/DDSTextureLoader.cpp
+++ b/Src/DDSTextureLoader.cpp
@@ -317,12 +317,52 @@ namespace
 
             switch (d3d10ext->dxgiFormat)
             {
+            case DXGI_FORMAT_NV12:
+            case DXGI_FORMAT_P010:
+            case DXGI_FORMAT_P016:
+            case DXGI_FORMAT_420_OPAQUE:
+                if ((d3d10ext->resourceDimension != D3D12_RESOURCE_DIMENSION_TEXTURE2D)
+                    || (width % 2) != 0 || (height % 2) != 0)
+                {
+                    DebugTrace("ERROR: Video texture does not meet width/height requirements.\n");
+                    return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
+                }
+                break;
+
+            case DXGI_FORMAT_YUY2:
+            case DXGI_FORMAT_Y210:
+            case DXGI_FORMAT_Y216:
+            case DXGI_FORMAT_P208:
+                if ((width % 2) != 0)
+                {
+                    DebugTrace("ERROR: Video texture does not meet width requirements.\n");
+                    return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
+                }
+                break;
+
+            case DXGI_FORMAT_NV11:
+                if ((width % 4) != 0)
+                {
+                    DebugTrace("ERROR: Video texture does not meet width requirements.\n");
+                    return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
+                }
+                break;
+
             case DXGI_FORMAT_AI44:
             case DXGI_FORMAT_IA44:
             case DXGI_FORMAT_P8:
             case DXGI_FORMAT_A8P8:
-                DebugTrace("ERROR: DDSTextureLoader does not support video textures. Consider using DirectXTex instead.\n");
+                DebugTrace("ERROR: Legacy stream video texture formats are not supported by Direct3D.\n");
                 return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
+
+            case DXGI_FORMAT_V208:
+                if ((d3d10ext->resourceDimension != D3D12_RESOURCE_DIMENSION_TEXTURE2D)
+                    || (height % 2) != 0)
+                {
+                    DebugTrace("ERROR: Video texture does not meet height requirements.\n");
+                    return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
+                }
+                break;
 
             default:
                 if (BitsPerPixel(d3d10ext->dxgiFormat) == 0)

--- a/Src/LoaderHelpers.h
+++ b/Src/LoaderHelpers.h
@@ -568,15 +568,31 @@ namespace DirectX
 
             case DXGI_FORMAT_NV12:
             case DXGI_FORMAT_420_OPAQUE:
-            #if (_WIN32_WINNT >= _WIN32_WINNT_WIN10)
-            case DXGI_FORMAT_P208:
-            #endif
+                if ((height % 2) != 0)
+                {
+                    // Requires a height alignment of 2.
+                    return E_INVALIDARG;
+                }
                 planar = true;
                 bpe = 2;
                 break;
 
+            #if (_WIN32_WINNT >= _WIN32_WINNT_WIN10)
+
+            case DXGI_FORMAT_P208:
+                planar = true;
+                bpe = 2;
+                break;
+
+            #endif
+
             case DXGI_FORMAT_P010:
             case DXGI_FORMAT_P016:
+                if ((height % 2) != 0)
+                {
+                    // Requires a height alignment of 2.
+                    return E_INVALIDARG;
+                }
                 planar = true;
                 bpe = 4;
                 break;


### PR DESCRIPTION
Added height alignment validation for planar video formats. This reports these issues earlier as NOT_SUPPORTED instead of the E_INVALIDARG error that is eventually returned from the Direct3D API.