### PR TITLE
Fix warnings when using GPU-based validation on PC

### DIFF
--- a/Inc/DirectXHelpers.h
+++ b/Inc/DirectXHelpers.h
@@ -34,10 +34,6 @@
 #pragma comment(lib,"dxguid.lib")
 #endif
 
-#ifndef IID_GRAPHICS_PPV_ARGS
-#define IID_GRAPHICS_PPV_ARGS(x) IID_PPV_ARGS(x)
-#endif
-
 //
 // The d3dx12.h header includes the following helper C++ classes and functions
 //  CD3DX12_RECT
@@ -113,8 +109,18 @@
 //  CD3DX12FeatureSupport
 //
 
+#ifndef IID_GRAPHICS_PPV_ARGS
+#define IID_GRAPHICS_PPV_ARGS(x) IID_PPV_ARGS(x)
+#endif
+
 namespace DirectX
 {
+#if (defined(_XBOX_ONE) && defined(_TITLE)) || defined(_GAMING_XBOX)
+    constexpr D3D12_RESOURCE_STATES c_initialCopyTargetState = D3D12_RESOURCE_STATE_COPY_DEST;
+#else
+    constexpr D3D12_RESOURCE_STATES c_initialCopyTargetState = D3D12_RESOURCE_STATE_COMMON;
+#endif
+
     constexpr D3D12_CPU_DESCRIPTOR_HANDLE D3D12_CPU_DESCRIPTOR_HANDLE_ZERO = {};
 
     // Creates a shader resource view from an arbitrary resource

--- a/Src/BufferHelpers.cpp
+++ b/Src/BufferHelpers.cpp
@@ -57,7 +57,7 @@ HRESULT DirectX::CreateStaticBuffer(
         &heapProperties,
         D3D12_HEAP_FLAG_NONE,
         &desc,
-        D3D12_RESOURCE_STATE_COPY_DEST,
+        D3D12_RESOURCE_STATE_COMMON,
         nullptr,
         IID_GRAPHICS_PPV_ARGS(res.GetAddressOf()));
     if (FAILED(hr))
@@ -123,7 +123,7 @@ HRESULT DirectX::CreateTextureFromMemory(
         &heapProperties,
         D3D12_HEAP_FLAG_NONE,
         &desc,
-        D3D12_RESOURCE_STATE_COPY_DEST,
+        D3D12_RESOURCE_STATE_COMMON,
         nullptr,
         IID_GRAPHICS_PPV_ARGS(res.GetAddressOf()));
     if (FAILED(hr))
@@ -200,7 +200,7 @@ HRESULT DirectX::CreateTextureFromMemory(
         &heapProperties,
         D3D12_HEAP_FLAG_NONE,
         &desc,
-        D3D12_RESOURCE_STATE_COPY_DEST,
+        D3D12_RESOURCE_STATE_COMMON,
         nullptr,
         IID_GRAPHICS_PPV_ARGS(res.GetAddressOf()));
     if (FAILED(hr))
@@ -273,7 +273,7 @@ HRESULT DirectX::CreateTextureFromMemory(
         &heapProperties,
         D3D12_HEAP_FLAG_NONE,
         &desc,
-        D3D12_RESOURCE_STATE_COPY_DEST,
+        D3D12_RESOURCE_STATE_COMMON,
         nullptr,
         IID_GRAPHICS_PPV_ARGS(res.GetAddressOf()));
     if (FAILED(hr))

--- a/Src/BufferHelpers.cpp
+++ b/Src/BufferHelpers.cpp
@@ -57,7 +57,7 @@ HRESULT DirectX::CreateStaticBuffer(
         &heapProperties,
         D3D12_HEAP_FLAG_NONE,
         &desc,
-        D3D12_RESOURCE_STATE_COMMON,
+        c_initialCopyTargetState,
         nullptr,
         IID_GRAPHICS_PPV_ARGS(res.GetAddressOf()));
     if (FAILED(hr))
@@ -123,7 +123,7 @@ HRESULT DirectX::CreateTextureFromMemory(
         &heapProperties,
         D3D12_HEAP_FLAG_NONE,
         &desc,
-        D3D12_RESOURCE_STATE_COMMON,
+        c_initialCopyTargetState,
         nullptr,
         IID_GRAPHICS_PPV_ARGS(res.GetAddressOf()));
     if (FAILED(hr))
@@ -200,7 +200,7 @@ HRESULT DirectX::CreateTextureFromMemory(
         &heapProperties,
         D3D12_HEAP_FLAG_NONE,
         &desc,
-        D3D12_RESOURCE_STATE_COMMON,
+        c_initialCopyTargetState,
         nullptr,
         IID_GRAPHICS_PPV_ARGS(res.GetAddressOf()));
     if (FAILED(hr))
@@ -273,7 +273,7 @@ HRESULT DirectX::CreateTextureFromMemory(
         &heapProperties,
         D3D12_HEAP_FLAG_NONE,
         &desc,
-        D3D12_RESOURCE_STATE_COMMON,
+        c_initialCopyTargetState,
         nullptr,
         IID_GRAPHICS_PPV_ARGS(res.GetAddressOf()));
     if (FAILED(hr))

--- a/Src/DDSTextureLoader.cpp
+++ b/Src/DDSTextureLoader.cpp
@@ -261,7 +261,7 @@ namespace
             &defaultHeapProperties,
             D3D12_HEAP_FLAG_NONE,
             &desc,
-            D3D12_RESOURCE_STATE_COMMON,
+            c_initialCopyTargetState,
             nullptr,
             IID_GRAPHICS_PPV_ARGS(texture));
         if (SUCCEEDED(hr))

--- a/Src/DDSTextureLoader.cpp
+++ b/Src/DDSTextureLoader.cpp
@@ -261,7 +261,7 @@ namespace
             &defaultHeapProperties,
             D3D12_HEAP_FLAG_NONE,
             &desc,
-            D3D12_RESOURCE_STATE_COPY_DEST,
+            D3D12_RESOURCE_STATE_COMMON,
             nullptr,
             IID_GRAPHICS_PPV_ARGS(texture));
         if (SUCCEEDED(hr))

--- a/Src/GeometricPrimitive.cpp
+++ b/Src/GeometricPrimitive.cpp
@@ -121,7 +121,7 @@ void GeometricPrimitive::Impl::LoadStaticBuffers(
             &heapProperties,
             D3D12_HEAP_FLAG_NONE,
             &desc,
-            D3D12_RESOURCE_STATE_COPY_DEST,
+            D3D12_RESOURCE_STATE_COMMON,
             nullptr,
             IID_GRAPHICS_PPV_ARGS(mStaticVertexBuffer.GetAddressOf())
         ));
@@ -150,7 +150,7 @@ void GeometricPrimitive::Impl::LoadStaticBuffers(
             &heapProperties,
             D3D12_HEAP_FLAG_NONE,
             &desc,
-            D3D12_RESOURCE_STATE_COPY_DEST,
+            D3D12_RESOURCE_STATE_COMMON,
             nullptr,
             IID_GRAPHICS_PPV_ARGS(mStaticIndexBuffer.GetAddressOf())
         ));

--- a/Src/GeometricPrimitive.cpp
+++ b/Src/GeometricPrimitive.cpp
@@ -121,7 +121,7 @@ void GeometricPrimitive::Impl::LoadStaticBuffers(
             &heapProperties,
             D3D12_HEAP_FLAG_NONE,
             &desc,
-            D3D12_RESOURCE_STATE_COMMON,
+            c_initialCopyTargetState,
             nullptr,
             IID_GRAPHICS_PPV_ARGS(mStaticVertexBuffer.GetAddressOf())
         ));
@@ -150,7 +150,7 @@ void GeometricPrimitive::Impl::LoadStaticBuffers(
             &heapProperties,
             D3D12_HEAP_FLAG_NONE,
             &desc,
-            D3D12_RESOURCE_STATE_COMMON,
+            c_initialCopyTargetState,
             nullptr,
             IID_GRAPHICS_PPV_ARGS(mStaticIndexBuffer.GetAddressOf())
         ));

--- a/Src/Model.cpp
+++ b/Src/Model.cpp
@@ -358,7 +358,7 @@ void Model::LoadStaticBuffers(
                 &heapProperties,
                 D3D12_HEAP_FLAG_NONE,
                 &desc,
-                D3D12_RESOURCE_STATE_COMMON,
+                c_initialCopyTargetState,
                 nullptr,
                 IID_GRAPHICS_PPV_ARGS(part->staticVertexBuffer.GetAddressOf())
             ));
@@ -414,7 +414,7 @@ void Model::LoadStaticBuffers(
                 &heapProperties,
                 D3D12_HEAP_FLAG_NONE,
                 &desc,
-                D3D12_RESOURCE_STATE_COMMON,
+                c_initialCopyTargetState,
                 nullptr,
                 IID_GRAPHICS_PPV_ARGS(part->staticIndexBuffer.GetAddressOf())
             ));

--- a/Src/Model.cpp
+++ b/Src/Model.cpp
@@ -358,7 +358,7 @@ void Model::LoadStaticBuffers(
                 &heapProperties,
                 D3D12_HEAP_FLAG_NONE,
                 &desc,
-                D3D12_RESOURCE_STATE_COPY_DEST,
+                D3D12_RESOURCE_STATE_COMMON,
                 nullptr,
                 IID_GRAPHICS_PPV_ARGS(part->staticVertexBuffer.GetAddressOf())
             ));
@@ -414,7 +414,7 @@ void Model::LoadStaticBuffers(
                 &heapProperties,
                 D3D12_HEAP_FLAG_NONE,
                 &desc,
-                D3D12_RESOURCE_STATE_COPY_DEST,
+                D3D12_RESOURCE_STATE_COMMON,
                 nullptr,
                 IID_GRAPHICS_PPV_ARGS(part->staticIndexBuffer.GetAddressOf())
             ));

--- a/Src/SpriteBatch.cpp
+++ b/Src/SpriteBatch.cpp
@@ -313,7 +313,7 @@ void SpriteBatch::Impl::DeviceResources::CreateIndexBuffer(_In_ ID3D12Device* de
         &heapProps,
         D3D12_HEAP_FLAG_NONE,
         &bufferDesc,
-        D3D12_RESOURCE_STATE_COMMON,
+        c_initialCopyTargetState,
         nullptr,
         IID_GRAPHICS_PPV_ARGS(indexBuffer.ReleaseAndGetAddressOf())));
 

--- a/Src/SpriteBatch.cpp
+++ b/Src/SpriteBatch.cpp
@@ -313,7 +313,7 @@ void SpriteBatch::Impl::DeviceResources::CreateIndexBuffer(_In_ ID3D12Device* de
         &heapProps,
         D3D12_HEAP_FLAG_NONE,
         &bufferDesc,
-        D3D12_RESOURCE_STATE_COPY_DEST,
+        D3D12_RESOURCE_STATE_COMMON,
         nullptr,
         IID_GRAPHICS_PPV_ARGS(indexBuffer.ReleaseAndGetAddressOf())));
 

--- a/Src/SpriteFont.cpp
+++ b/Src/SpriteFont.cpp
@@ -348,7 +348,7 @@ void SpriteFont::Impl::CreateTextureResource(
         &defaultHeapProperties,
         D3D12_HEAP_FLAG_NONE,
         &desc,
-        D3D12_RESOURCE_STATE_COMMON,
+        c_initialCopyTargetState,
         nullptr,
         IID_GRAPHICS_PPV_ARGS(textureResource.ReleaseAndGetAddressOf())));
 

--- a/Src/SpriteFont.cpp
+++ b/Src/SpriteFont.cpp
@@ -348,7 +348,7 @@ void SpriteFont::Impl::CreateTextureResource(
         &defaultHeapProperties,
         D3D12_HEAP_FLAG_NONE,
         &desc,
-        D3D12_RESOURCE_STATE_COPY_DEST,
+        D3D12_RESOURCE_STATE_COMMON,
         nullptr,
         IID_GRAPHICS_PPV_ARGS(textureResource.ReleaseAndGetAddressOf())));
 

--- a/Src/WICTextureLoader.cpp
+++ b/Src/WICTextureLoader.cpp
@@ -533,7 +533,7 @@ namespace
             &defaultHeapProperties,
             D3D12_HEAP_FLAG_NONE,
             &desc,
-            D3D12_RESOURCE_STATE_COMMON,
+            c_initialCopyTargetState,
             nullptr,
             IID_GRAPHICS_PPV_ARGS(&tex));
 

--- a/Src/WICTextureLoader.cpp
+++ b/Src/WICTextureLoader.cpp
@@ -533,7 +533,7 @@ namespace
             &defaultHeapProperties,
             D3D12_HEAP_FLAG_NONE,
             &desc,
-            D3D12_RESOURCE_STATE_COPY_DEST,
+            D3D12_RESOURCE_STATE_COMMON,
             nullptr,
             IID_GRAPHICS_PPV_ARGS(&tex));
 

--- a/build/DirectXTK12-GitHub-MinGW.yml
+++ b/build/DirectXTK12-GitHub-MinGW.yml
@@ -93,18 +93,17 @@ jobs:
     inputs:
       script: g++ --version
   - task: CmdLine@2
-    # The error checks are commented out due to a bug with vcpkg not returning 0 on success.
     displayName: VCPKG install headers
     inputs:
       script: |
         call vcpkg install directxmath
-        REM @if ERRORLEVEL 1 goto error
+        @if ERRORLEVEL 1 goto error
         call vcpkg install directx-headers
-        REM @if ERRORLEVEL 1 goto error
+        @if ERRORLEVEL 1 goto error
         call vcpkg install xaudio2redist
-        REM @if ERRORLEVEL 1 goto error
+        @if ERRORLEVEL 1 goto error
         call vcpkg install directx-dxc:x64-mingw-static
-        REM @if ERRORLEVEL 1 goto error
+        @if ERRORLEVEL 1 goto error
         :finish
         @echo --- VCPKG COMPLETE ---
         exit /b 0
@@ -187,13 +186,13 @@ jobs:
     inputs:
       script: |
         call vcpkg install directxmath
-        REM @if ERRORLEVEL 1 goto error
+        @if ERRORLEVEL 1 goto error
         call vcpkg install directx-headers
-        REM @if ERRORLEVEL 1 goto error
+        @if ERRORLEVEL 1 goto error
         call vcpkg install xaudio2redist
-        REM @if ERRORLEVEL 1 goto error
+        @if ERRORLEVEL 1 goto error
         call vcpkg install directx-dxc
-        REM @if ERRORLEVEL 1 goto error
+        @if ERRORLEVEL 1 goto error
         :finish
         @echo --- VCPKG COMPLETE ---
         exit /b 0


### PR DESCRIPTION
When **SetEnableGPUBasedValidation** is enabled on Windows, the initial state for a resource will result in a harmless but noisy warning.

```
D3D12 WARNING: ID3D12Device::CreateCommittedResource: Ignoring InitialState D3D12_RESOURCE_STATE_COPY_DEST. Buffers are effectively created in state D3D12_RESOURCE_STATE_COMMON. [ STATE_CREATION WARNING #1328: CREATERESOURCE_STATE_IGNORED]
```

The fix is to use the ``COMMON`` state initially and allow it to promote automatically.

> Since common state promotion/decay is optional on Xbox, it must continue to use COPY_DEST as the initial state for this platform.
