### PR TITLE
Mouse needs to accumulate delta between calls to GetState

### DIFF
--- a/Inc/Mouse.h
+++ b/Inc/Mouse.h
@@ -113,6 +113,9 @@ namespace DirectX
         // Sets mouse mode (defaults to absolute)
         void __cdecl SetMode(Mode mode);
 
+        // Signals the end of frame (recommended, but optional)
+        void __cdecl EndOfInputFrame() noexcept;
+
         // Feature detection
         bool __cdecl IsConnected() const;
 

--- a/Src/Mouse.cpp
+++ b/Src/Mouse.cpp
@@ -726,7 +726,7 @@ public:
     }
 
     State           mState;
-    Mouse* mOwner;
+    Mouse*          mOwner;
     float           mDPI;
 
     static Mouse::Impl* s_mouse;
@@ -1057,6 +1057,8 @@ public:
             {
                 SetEvent(mRelativeRead.get());
             }
+
+            mState.x = mState.y = 0;
         }
     }
 
@@ -1141,7 +1143,7 @@ public:
         mWindow = window;
     }
 
-    State           mState;
+    mutable State   mState;
 
     Mouse*          mOwner;
 
@@ -1322,8 +1324,8 @@ void Mouse::ProcessMessage(UINT message, WPARAM wParam, LPARAM lParam)
             {
                 if (!(raw.data.mouse.usFlags & MOUSE_MOVE_ABSOLUTE))
                 {
-                    pImpl->mState.x = raw.data.mouse.lLastX;
-                    pImpl->mState.y = raw.data.mouse.lLastY;
+                    pImpl->mState.x += raw.data.mouse.lLastX;
+                    pImpl->mState.y += raw.data.mouse.lLastY;
 
                     ResetEvent(pImpl->mRelativeRead.get());
                 }

--- a/Src/Mouse.cpp
+++ b/Src/Mouse.cpp
@@ -218,7 +218,17 @@ public:
         else
         {
             ShowCursor(TRUE);
+
 #ifndef _GAMING_XBOX
+            POINT point;
+            point.x = mState.x;
+            point.y = mState.y;
+
+            if (MapWindowPoints(mWindow, nullptr, &point, 1))
+            {
+                SetCursorPos(point.x, point.y);
+            }
+
             ClipCursor(nullptr);
 #endif
         }

--- a/Src/Mouse.cpp
+++ b/Src/Mouse.cpp
@@ -228,8 +228,11 @@ public:
     {
         mAutoReset = false;
 
-        mRelativeX = mLastX;
-        mRelativeY = mLastY;
+        if (mMode == MODE_RELATIVE)
+        {
+            mRelativeX = mLastX;
+            mRelativeY = mLastY;
+        }
     }
 
     bool IsConnected() const noexcept
@@ -517,6 +520,8 @@ public:
         mDPI(96.f),
         mMode(MODE_ABSOLUTE),
         mAutoReset(true),
+        mLastX(0),
+        mLastY(0),
         mPointerPressedToken{},
         mPointerReleasedToken{},
         mPointerMovedToken{},
@@ -618,6 +623,11 @@ public:
 
             SetEvent(mRelativeRead.get());
 
+            mLastX = mState.x;
+            mLastY = mState.y;
+
+            mState.x = mState.y = 0;
+
             mMode = MODE_RELATIVE;
         }
         else
@@ -635,6 +645,9 @@ public:
             hr = window->put_PointerCursor(mCursor.Get());
             ThrowIfFailed(hr);
 
+            mState.x = mLastX;
+            mState.y = mLastY;
+
             mCursor.Reset();
 
             mMode = MODE_ABSOLUTE;
@@ -645,7 +658,10 @@ public:
     {
         mAutoReset = false;
 
-        mState.x = mState.y = 0;
+        if (mMode == MODE_RELATIVE)
+        {
+            mState.x = mState.y = 0;
+        }
     }
 
     bool IsConnected() const
@@ -773,6 +789,8 @@ public:
 private:
     Mode            mMode;
     bool            mAutoReset;
+    int             mLastX;
+    int             mLastY;
 
     ComPtr<ABI::Windows::UI::Core::ICoreWindow> mWindow;
     ComPtr<ABI::Windows::Devices::Input::IMouseDevice> mMouse;
@@ -971,7 +989,10 @@ private:
         if (!s_mouse)
             return S_OK;
 
-        s_mouse->mState.x = s_mouse->mState.y = 0;
+        if (s_mouse->mMode == MODE_RELATIVE)
+        {
+            s_mouse->mState.x = s_mouse->mState.y = 0;
+        }
 
         return S_OK;
     }
@@ -1149,7 +1170,10 @@ public:
     {
         mAutoReset = false;
 
-        mState.x = mState.y = 0;
+        if (mMode == MODE_RELATIVE)
+        {
+            mState.x = mState.y = 0;
+        }
     }
 
     bool IsConnected() const noexcept


### PR DESCRIPTION
For high-sensitivity mice, ``WM_INPUT`` is getting called multiple times per frame and the original implementation of RAW mouse for Win32 was only recording the most recent dx/dy. This change now accumulates delta from ``WM_INPUT`` in relative mode.

For this to work correctly, each time ``Mouse::GetState`` is called in relative movement mode, the accumulated delta is reset so the assumption is that this is called _once per frame_.

Since this does not cover all usage scenarios, there is new optional method for Mouse **EndOfInputFrame** that should be called once per render call. This turns off the 'auto-reset' behavior of **GetState** and instead clears it once per frame in this method instead.
