### PR TITLE
GDKX not currently compatible with /Zc:templateScope

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -459,7 +459,13 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
     endif()
 
     if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.35)
-        target_compile_options(${PROJECT_NAME} PRIVATE /Zc:templateScope /Zc:checkGwOdr)
+        if(NOT (DEFINED XBOX_CONSOLE_TARGET))
+            target_compile_options(${PROJECT_NAME} PRIVATE /Zc:templateScope)
+        endif()
+
+        if(CMAKE_INTERPROCEDURAL_OPTIMIZATION)
+            target_compile_options(${PROJECT_NAME} PRIVATE /Zc:checkGwOdr)
+        endif()
     endif()
 endif()
 


### PR DESCRIPTION
With VS 2022 17.5 or later I use ``/Zc:templateScope`` for conformance, but this fails to build with current Microsoft GDK with Xbox release if you make use of **wrl.h** or **wrl/events.h**.

This updates the CMake to avoid using the conformance switch on Xbox targets.
