### PR TITLE
Rework audio device enumeration for XAudio2.9

### DIFF
--- a/Audio/AudioEngine.cpp
+++ b/Audio/AudioEngine.cpp
@@ -1743,6 +1743,7 @@ namespace
 {
     void GetDeviceOutputFormat(const wchar_t*, WAVEFORMATEX& wfx)
     {
+        wfx.nSamplesPerSec = 48000;
         wfx.wBitsPerSample = 24;
     }
 }

--- a/Audio/AudioEngine.cpp
+++ b/Audio/AudioEngine.cpp
@@ -1342,6 +1342,7 @@ WAVEFORMATEXTENSIBLE AudioEngine::GetOutputFormat() const noexcept
 
     wfx.Format = pImpl->mOutputFormat;
     wfx.Format.cbSize = sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX);
+    wfx.Format.wFormatTag = WAVE_FORMAT_EXTENSIBLE;
 
     wfx.Samples.wValidBitsPerSample = wfx.Format.wBitsPerSample;
     wfx.dwChannelMask = pImpl->masterChannelMask;

--- a/Audio/AudioEngine.cpp
+++ b/Audio/AudioEngine.cpp
@@ -1488,6 +1488,10 @@ X3DAUDIO_HANDLE& AudioEngine::Get3DHandle() const noexcept
 
 #include <wrl.h>
 
+#ifdef __clang__
+#pragma clang diagnostic ignored "-Wdeprecated-dynamic-exception-spec"
+#endif
+
 namespace
 {
     const wchar_t* c_PKEY_AudioEngine_DeviceFormat = L"{f19f064d-082c-4e27-bc73-6882a1bb8e4c} 0";

--- a/Audio/AudioEngine.cpp
+++ b/Audio/AudioEngine.cpp
@@ -246,6 +246,8 @@ namespace
 
         return result.key;
     }
+
+    uint16_t GetDeviceBitDepth(const wchar_t*);
 }
 
 static_assert(static_cast<unsigned int>(std::size(gReverbPresets)) == Reverb_MAX, "AUDIO_ENGINE_REVERB enum mismatch");
@@ -270,6 +272,7 @@ public:
         mReverbVoice(nullptr),
         masterChannelMask(0),
         masterChannels(0),
+        masterBitDepth(0),
         masterRate(0),
         defaultRate(44100),
         maxVoiceOneshots(SIZE_MAX),
@@ -326,7 +329,8 @@ public:
     IXAudio2SubmixVoice*                mReverbVoice;
 
     uint32_t                            masterChannelMask;
-    uint32_t                            masterChannels;
+    uint16_t                            masterChannels;
+    uint16_t                            masterBitDepth;
     uint32_t                            masterRate;
 
     int                                 defaultRate;
@@ -394,7 +398,8 @@ HRESULT AudioEngine::Impl::Reset(const WAVEFORMATEX* wfx, const wchar_t* deviceI
     assert(mMasterVoice == nullptr);
     assert(mReverbVoice == nullptr);
 
-    masterChannelMask = masterChannels = masterRate = 0;
+    masterChannelMask = masterRate = 0;
+    masterChannels = masterBitDepth = 0;
 
     memset(&mX3DAudio, 0, X3DAUDIO_HANDLE_BYTESIZE);
 
@@ -464,7 +469,7 @@ HRESULT AudioEngine::Impl::Reset(const WAVEFORMATEX* wfx, const wchar_t* deviceI
     mMasterVoice->GetVoiceDetails(&details);
 
     masterChannelMask = dwChannelMask;
-    masterChannels = details.InputChannels;
+    masterChannels = static_cast<uint16_t>(details.InputChannels);
     masterRate = details.InputSampleRate;
 
     DebugTrace("INFO: mastering voice has %u channels, %u sample rate, %08X channel mask\n",
@@ -480,6 +485,8 @@ HRESULT AudioEngine::Impl::Reset(const WAVEFORMATEX* wfx, const wchar_t* deviceI
             return hr;
         }
     }
+
+    masterBitDepth = GetDeviceBitDepth(deviceId);
 
     //
     // Setup mastering volume limiter (optional)
@@ -662,7 +669,8 @@ void AudioEngine::Impl::Shutdown() noexcept
         mVolumeLimiter.Reset();
         xaudio2.Reset();
 
-        masterChannelMask = masterChannels = masterRate = 0;
+        masterChannelMask = masterRate = 0;
+        masterChannels = masterBitDepth = 0;
 
         mCriticalError = false;
         mReverbEnabled = false;
@@ -1329,10 +1337,10 @@ WAVEFORMATEXTENSIBLE AudioEngine::GetOutputFormat() const noexcept
         return wfx;
 
     wfx.Format.wFormatTag = WAVE_FORMAT_EXTENSIBLE;
-    wfx.Format.wBitsPerSample = wfx.Samples.wValidBitsPerSample = 16; // This is a guess
+    wfx.Format.wBitsPerSample = wfx.Samples.wValidBitsPerSample = pImpl->masterBitDepth;
     wfx.Format.cbSize = sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX);
 
-    wfx.Format.nChannels = static_cast<WORD>(pImpl->masterChannels);
+    wfx.Format.nChannels = pImpl->masterChannels;
     wfx.Format.nSamplesPerSec = pImpl->masterRate;
     wfx.dwChannelMask = pImpl->masterChannelMask;
 
@@ -1450,15 +1458,15 @@ X3DAUDIO_HANDLE& AudioEngine::Get3DHandle() const noexcept
 
 
 // Static methods.
-#if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_GAMES)
-#include <mmdeviceapi.h>
-#elif defined(_XBOX_ONE)
-#include <Windows.Media.Devices.h>
-#include <wrl.h>
-#elif defined(USING_XAUDIO2_REDIST) || defined(_GAMING_DESKTOP)
-#include <mmdeviceapi.h>
-#include <functiondiscoverykeys_devpkey.h>
-#elif (_WIN32_WINNT >= _WIN32_WINNT_WIN8)
+#if (defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)) || defined(USING_XAUDIO2_8)
+//--- Use Windows Runtime device enumeration ---
+
+// Note that this form of enumeration would also be needed for XAudio2.9 prior to Windows 10 (18362).
+//
+// If you care about supporting Windows 10 (17763), Windows Server 2019, or earlier Windows 10 builds,
+// you will need to modify the library to use this codepath for Windows desktop
+// -or- use XAudio2Redist -or- use XAudio 2.8.
+
 #pragma comment(lib,"runtimeobject.lib")
 #pragma warning(push)
 #pragma warning(disable: 4471 5204 5256)
@@ -1467,140 +1475,20 @@ X3DAUDIO_HANDLE& AudioEngine::Get3DHandle() const noexcept
 #endif
 #include <Windows.Devices.Enumeration.h>
 #pragma warning(pop)
+
 #include <wrl.h>
-#endif
+
+namespace
+{
+    uint16_t GetDeviceBitDepth(const wchar_t*)
+    {
+        return 16; // This is a guess as there's no way to get this data via the Windows Runtime APIs
+    }
+}
 
 std::vector<AudioEngine::RendererDetail> AudioEngine::GetRendererDetails()
 {
     std::vector<RendererDetail> list;
-
-#if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_GAMES)
-
-    ComPtr<IMMDeviceEnumerator> devEnum;
-    HRESULT hr = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(devEnum.GetAddressOf()));
-    ThrowIfFailed(hr);
-
-    ComPtr<IMMDeviceCollection> devices;
-    hr = devEnum->EnumAudioEndpoints(eRender, DEVICE_STATE_ACTIVE, &devices);
-    ThrowIfFailed(hr);
-
-    ComPtr<IMMDevice> endpoint;
-    ThrowIfFailed(devices->Item(0, endpoint.GetAddressOf()));
-
-    LPWSTR id = nullptr;
-    ThrowIfFailed(endpoint->GetId(&id));
-
-    RendererDetail device;
-    device.deviceId = id;
-    device.description = L"Default";
-
-    CoTaskMemFree(id);
-
-    list.emplace_back(device);
-
-#elif defined(_XBOX_ONE)
-
-    using namespace Microsoft::WRL;
-    using namespace Microsoft::WRL::Wrappers;
-    using namespace ABI::Windows::Foundation;
-    using namespace ABI::Windows::Media::Devices;
-
-    ComPtr<IMediaDeviceStatics> mdStatics;
-    HRESULT hr = GetActivationFactory(HStringReference(RuntimeClass_Windows_Media_Devices_MediaDevice).Get(), &mdStatics);
-    ThrowIfFailed(hr);
-
-    HString id;
-    hr = mdStatics->GetDefaultAudioRenderId(AudioDeviceRole_Default, id.GetAddressOf());
-    ThrowIfFailed(hr);
-
-    RendererDetail device;
-    device.deviceId = id.GetRawBuffer(nullptr);
-    device.description = L"Default";
-    list.emplace_back(device);
-
-#elif defined(USING_XAUDIO2_REDIST) || defined(_GAMING_DESKTOP)
-
-#ifdef __MINGW32__
-    // Value matches Windows SDK header shared\devpkey.h
-    constexpr static PROPERTYKEY PKEY_Device_FriendlyName = { { 0xa45c254e, 0xdf1c, 0x4efd, { 0x80, 0x20, 0x67, 0xd1, 0x46, 0xa8, 0x50, 0xe0 } }, 14 };
-#endif
-
-    ComPtr<IMMDeviceEnumerator> devEnum;
-    HRESULT hr = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(devEnum.GetAddressOf()));
-    ThrowIfFailed(hr);
-
-    ComPtr<IMMDeviceCollection> devices;
-    hr = devEnum->EnumAudioEndpoints(eRender, DEVICE_STATE_ACTIVE, &devices);
-    ThrowIfFailed(hr);
-
-    UINT count = 0;
-    ThrowIfFailed(devices->GetCount(&count));
-
-    if (!count)
-        return list;
-
-    for (UINT j = 0; j < count; ++j)
-    {
-        ComPtr<IMMDevice> endpoint;
-        hr = devices->Item(j, endpoint.GetAddressOf());
-        ThrowIfFailed(hr);
-
-        LPWSTR id = nullptr;
-        ThrowIfFailed(endpoint->GetId(&id));
-
-        RendererDetail device;
-        device.deviceId = id;
-        CoTaskMemFree(id);
-
-        ComPtr<IPropertyStore> props;
-        if (SUCCEEDED(endpoint->OpenPropertyStore(STGM_READ, props.GetAddressOf())))
-        {
-            PROPVARIANT var;
-            PropVariantInit(&var);
-
-            if (SUCCEEDED(props->GetValue(PKEY_Device_FriendlyName, &var)))
-            {
-                if (var.vt == VT_LPWSTR)
-                {
-                    device.description = var.pwszVal;
-                }
-                PropVariantClear(&var);
-            }
-        }
-
-        list.emplace_back(device);
-    }
-
-#elif (_WIN32_WINNT >= _WIN32_WINNT_WIN8)
-
-#if defined(__cplusplus_winrt)
-
-    // Enumerating with WinRT using C++/CX (Windows Store apps)
-    using Windows::Devices::Enumeration::DeviceClass;
-    using Windows::Devices::Enumeration::DeviceInformation;
-    using Windows::Devices::Enumeration::DeviceInformationCollection;
-
-    auto operation = DeviceInformation::FindAllAsync(DeviceClass::AudioRender);
-    while (operation->Status == Windows::Foundation::AsyncStatus::Started) { Sleep(100); }
-    if (operation->Status != Windows::Foundation::AsyncStatus::Completed)
-    {
-        throw std::runtime_error("FindAllAsync");
-    }
-
-    DeviceInformationCollection^ devices = operation->GetResults();
-
-    for (unsigned i = 0; i < devices->Size; ++i)
-    {
-        using Windows::Devices::Enumeration::DeviceInformation;
-
-        DeviceInformation^ d = devices->GetAt(i);
-
-        RendererDetail device;
-        device.deviceId = d->Id->Data();
-        device.description = d->Name->Data();
-        list.emplace_back(device);
-    }
-#else
 
     // Enumerating with WinRT using WRL (Win32 desktop app for Windows 8.x)
     using namespace Microsoft::WRL;
@@ -1676,10 +1564,158 @@ std::vector<AudioEngine::RendererDetail> AudioEngine::GetRendererDetails()
             list.emplace_back(device);
         }
     }
-#endif
-#else
-#error DirectX Tool Kit for Audio not supported on this platform
-#endif
 
     return list;
 }
+
+
+#elif defined(_XBOX_ONE)
+//--- Use legacy Xbox One XDK device enumeration ---
+
+#include <Windows.Media.Devices.h>
+#include <wrl.h>
+
+namespace
+{
+    uint16_t GetDeviceBitDepth(const wchar_t*)
+    {
+        return 24;
+    }
+}
+
+std::vector<AudioEngine::RendererDetail> AudioEngine::GetRendererDetails()
+{
+    std::vector<RendererDetail> list;
+
+    using namespace Microsoft::WRL;
+    using namespace Microsoft::WRL::Wrappers;
+    using namespace ABI::Windows::Foundation;
+    using namespace ABI::Windows::Media::Devices;
+
+    ComPtr<IMediaDeviceStatics> mdStatics;
+    HRESULT hr = GetActivationFactory(HStringReference(RuntimeClass_Windows_Media_Devices_MediaDevice).Get(), &mdStatics);
+    ThrowIfFailed(hr);
+
+    HString id;
+    hr = mdStatics->GetDefaultAudioRenderId(AudioDeviceRole_Default, id.GetAddressOf());
+    ThrowIfFailed(hr);
+
+    RendererDetail device;
+    device.deviceId = id.GetRawBuffer(nullptr);
+    device.description = L"Default";
+    list.emplace_back(device);
+
+    return list;
+}
+
+
+#elif defined(USING_XAUDIO2_9) || defined(USING_XAUDIO2_REDIST) || defined(_GAMING_DESKTOP)
+#include <mmdeviceapi.h>
+//--- Use WASAPI device enumeration ---
+
+namespace
+{
+    uint16_t GetDeviceBitDepth(const wchar_t* deviceId)
+    {
+        ComPtr<IMMDeviceEnumerator> devEnum;
+        if (FAILED(CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(devEnum.GetAddressOf()))))
+            return 0;
+
+        ComPtr<IMMDevice> endpoint;
+        if (!deviceId)
+        {
+            if (FAILED(devEnum->GetDefaultAudioEndpoint(eRender, eConsole, endpoint.GetAddressOf())))
+                return 0;
+        }
+        else
+        {
+            if (FAILED(devEnum->GetDevice(deviceId, endpoint.GetAddressOf())))
+                return 0;
+        }
+
+        uint16_t bitDepth = 16; // This is a guess.
+
+        // Value matches Windows SDK header um\mmdeviceapi.h
+        constexpr static PROPERTYKEY s_PKEY_AudioEngine_DeviceFormat = { { 0xf19f064d, 0x82c, 0x4e27, { 0xbc, 0x73, 0x68, 0x82, 0xa1, 0xbb, 0x8e, 0x4c } }, 0 };
+
+        ComPtr<IPropertyStore> props;
+        if (SUCCEEDED(endpoint->OpenPropertyStore(STGM_READ, props.GetAddressOf())))
+        {
+            PROPVARIANT var;
+            PropVariantInit(&var);
+
+            if (SUCCEEDED(props->GetValue(s_PKEY_AudioEngine_DeviceFormat, &var)))
+            {
+                if (var.vt == VT_BLOB && var.blob.cbSize >= sizeof(WAVEFORMATEX))
+                {
+                    auto wfx = reinterpret_cast<const WAVEFORMATEX*>(var.blob.pBlobData);
+                    bitDepth = wfx->wBitsPerSample;
+                }
+                PropVariantClear(&var);
+            }
+        }
+
+        return bitDepth;
+    }
+}
+
+std::vector<AudioEngine::RendererDetail> AudioEngine::GetRendererDetails()
+{
+    std::vector<RendererDetail> list;
+
+    // Value matches Windows SDK header shared\devpkey.h
+    constexpr static PROPERTYKEY s_PKEY_Device_FriendlyName = { { 0xa45c254e, 0xdf1c, 0x4efd, { 0x80, 0x20, 0x67, 0xd1, 0x46, 0xa8, 0x50, 0xe0 } }, 14 };
+
+    ComPtr<IMMDeviceEnumerator> devEnum;
+    HRESULT hr = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(devEnum.GetAddressOf()));
+    ThrowIfFailed(hr);
+
+    ComPtr<IMMDeviceCollection> devices;
+    hr = devEnum->EnumAudioEndpoints(eRender, DEVICE_STATE_ACTIVE, &devices);
+    ThrowIfFailed(hr);
+
+    UINT count = 0;
+    ThrowIfFailed(devices->GetCount(&count));
+
+    if (!count)
+        return list;
+
+    for (UINT j = 0; j < count; ++j)
+    {
+        ComPtr<IMMDevice> endpoint;
+        hr = devices->Item(j, endpoint.GetAddressOf());
+        ThrowIfFailed(hr);
+
+        LPWSTR id = nullptr;
+        ThrowIfFailed(endpoint->GetId(&id));
+
+        RendererDetail device;
+        device.deviceId = id;
+        CoTaskMemFree(id);
+
+        ComPtr<IPropertyStore> props;
+        if (SUCCEEDED(endpoint->OpenPropertyStore(STGM_READ, props.GetAddressOf())))
+        {
+            PROPVARIANT var;
+            PropVariantInit(&var);
+
+            if (SUCCEEDED(props->GetValue(s_PKEY_Device_FriendlyName, &var)))
+            {
+                if (var.vt == VT_LPWSTR)
+                {
+                    device.description = var.pwszVal;
+                }
+                PropVariantClear(&var);
+            }
+        }
+
+        list.emplace_back(device);
+    }
+
+    return list;
+}
+
+
+#else
+#error DirectX Tool Kit for Audio not supported on this platform
+#endif

--- a/Audio/AudioEngine.cpp
+++ b/Audio/AudioEngine.cpp
@@ -1499,9 +1499,15 @@ namespace
 
     class PropertyIterator : public Microsoft::WRL::RuntimeClass<ABI::Windows::Foundation::Collections::IIterator<HSTRING>>
     {
+    #if !defined(WINAPI_FAMILY) || (WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP)
+        InspectableClass(L"AudioEngine.PropertyIterator", FullTrust)
+    #else
         InspectableClass(L"AudioEngine.PropertyIterator", BaseTrust)
+    #endif
 
     public:
+        PropertyIterator() : mFirst(true), mString(c_PKEY_AudioEngine_DeviceFormat) {}
+
         HRESULT STDMETHODCALLTYPE get_Current(HSTRING *current) override
         {
             if (!current)
@@ -1509,7 +1515,7 @@ namespace
 
             if (mFirst)
             {
-                *current = Microsoft::WRL::Wrappers::HStringReference(c_PKEY_AudioEngine_DeviceFormat).Get();
+                *current = mString.Get();
             }
 
             return S_OK;
@@ -1535,12 +1541,19 @@ namespace
         }
 
     private:
-        bool mFirst = true;
+        bool mFirst;
+        Microsoft::WRL::Wrappers::HStringReference mString;
+
+        ~PropertyIterator() = default;
     };
 
     class PropertyList : public Microsoft::WRL::RuntimeClass<ABI::Windows::Foundation::Collections::IIterable<HSTRING>>
     {
+    #if !defined(WINAPI_FAMILY) || (WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP)
+        InspectableClass(L"AudioEngine.PropertyList", FullTrust)
+    #else
         InspectableClass(L"AudioEngine.PropertyList", BaseTrust)
+    #endif
 
     public:
         HRESULT STDMETHODCALLTYPE First(ABI::Windows::Foundation::Collections::IIterator<HSTRING> **first) override
@@ -1552,6 +1565,9 @@ namespace
             *first = p.Detach();
             return S_OK;
         }
+
+    private:
+        ~PropertyList() = default;
     };
 
     void GetDeviceOutputFormat(const wchar_t* deviceId, WAVEFORMATEX& wfx)

--- a/Inc/Audio.h
+++ b/Inc/Audio.h
@@ -242,13 +242,16 @@ namespace DirectX
             // Gathers audio engine statistics
 
         WAVEFORMATEXTENSIBLE __cdecl GetOutputFormat() const noexcept;
-            // Returns the format consumed by the mastering voice (which is the same as the device output if defaults are used)
+            // Returns the format of the audio output device associated with the mastering voice.
 
         uint32_t __cdecl GetChannelMask() const noexcept;
             // Returns the output channel mask
 
+        int __cdecl GetOutputSampleRate() const noexcept;
+            // Returns the sample rate going into the mastering voice
+
         unsigned int __cdecl GetOutputChannels() const noexcept;
-            // Returns the number of output channels
+            // Returns the number of channels going into the mastering voice
 
         bool __cdecl IsAudioDevicePresent() const noexcept;
             // Returns true if the audio graph is operating normally, false if in 'silent mode'


### PR DESCRIPTION
XAudio 2.8 on Windows 8 required the use of Windows Runtime APIs for device enumeration. XAudio2.9 on Windows 10 (18362)  or later and all versions of XAudio2Redist support both Windows Runtime device ids -and- standard WASAPI device ids.

This PR reworks the device enumeration to use WASAPI enumeration for most cases, and WinRT enumeration for the UWP platform and for XAudio 2.8 scenarios only.

In addition, this PR returns correct values for ``GetOutputFormat().Format.wBitsPerSample`` where possible. It previously always returned a value of 16.

> For Windows Server 2019 (17763) or other older Windows 10 scenarios, the recommendation is to use XAudio2Redist instead of the built-in XAudio 2.9.