### PR TITLE
CMake update to use /ZH:SHA_256 for clang v16 or later

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -419,6 +419,11 @@ if(MSVC)
       target_compile_options(${PROJECT_NAME} PRIVATE "/Qspectre")
     endif()
 
+    if((MSVC_VERSION GREATER_EQUAL 1924)
+       AND ((NOT (CMAKE_CXX_COMPILER_ID MATCHES "Clang")) OR (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 16.0)))
+      target_compile_options(${PROJECT_NAME} PRIVATE /ZH:SHA_256)
+    endif()
+
     if((MSVC_VERSION GREATER_EQUAL 1928)
        AND (CMAKE_SIZEOF_VOID_P EQUAL 8)
        AND ((NOT (CMAKE_CXX_COMPILER_ID MATCHES "Clang")) OR (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13.0)))
@@ -460,10 +465,6 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
     if(CMAKE_INTERPROCEDURAL_OPTIMIZATION)
       message(STATUS "Building using Whole Program Optimization")
       target_compile_options(${PROJECT_NAME} PRIVATE /Gy /Gw)
-    endif()
-
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.24)
-        target_compile_options(${PROJECT_NAME} PRIVATE /ZH:SHA_256)
     endif()
 
     if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.26)

--- a/build/DirectXTK12-GitHub-GDK-Dev17.yml
+++ b/build/DirectXTK12-GitHub-GDK-Dev17.yml
@@ -44,7 +44,8 @@ jobs:
     fetchTags: false
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
-    versionSpec: '6.5.x'
+    inputs:
+      versionSpec: '6.5.x'
   - task: NuGetCommand@2
     # We have to use a nuget.config to provide the feed for the 'nuget install' option.
     displayName: 'NuGet set package source to ADO feed'

--- a/build/DirectXTK12-GitHub-GDK-Dev17.yml
+++ b/build/DirectXTK12-GitHub-GDK-Dev17.yml
@@ -44,12 +44,13 @@ jobs:
     fetchTags: false
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
+    versionSpec: '6.5.x'
   - task: NuGetCommand@2
     # We have to use a nuget.config to provide the feed for the 'nuget install' option.
     displayName: 'NuGet set package source to ADO feed'
     inputs:
       command: custom
-      arguments: sources add -Name xboxgdk -Source $(URL_FEED) -ConfigFile NuGet.config
+      arguments: sources add -Name xboxgdk -Source $(URL_FEED) -ConfigFile $(Build.SourcesDirectory)\NuGet.config
   - task: PowerShell@2
     displayName: 'Set nuget.config to single source'
     inputs:

--- a/build/DirectXTK12-GitHub-GDK.yml
+++ b/build/DirectXTK12-GitHub-GDK.yml
@@ -65,12 +65,13 @@ jobs:
     fetchTags: false
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
+    versionSpec: '6.5.x'
   - task: NuGetCommand@2
     # We have to use a nuget.config to provide the feed for the 'nuget install' option.
     displayName: 'NuGet set package source to ADO feed'
     inputs:
       command: custom
-      arguments: sources add -Name xboxgdk -Source $(URL_FEED) -ConfigFile NuGet.config
+      arguments: sources add -Name xboxgdk -Source $(URL_FEED) -ConfigFile $(Build.SourcesDirectory)\NuGet.config
   - task: PowerShell@2
     displayName: 'Set nuget.config to single source'
     inputs:
@@ -175,11 +176,12 @@ jobs:
       failOnStderr: true
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
+    versionSpec: '6.5.x'
   - task: NuGetCommand@2
     displayName: 'NuGet set package source to ADO feed'
     inputs:
       command: custom
-      arguments: sources add -Name xboxgdk -Source $(URL_FEED) -ConfigFile NuGet.config
+      arguments: sources add -Name xboxgdk -Source $(URL_FEED) -ConfigFile $(Build.SourcesDirectory)\NuGet.config
   - task: PowerShell@2
     displayName: 'Set nuget.config to single source'
     inputs:
@@ -255,11 +257,12 @@ jobs:
       failOnStderr: true
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
+    versionSpec: '6.5.x'
   - task: NuGetCommand@2
     displayName: 'NuGet set package source to ADO feed'
     inputs:
       command: custom
-      arguments: sources add -Name xboxgdk -Source $(URL_FEED) -ConfigFile NuGet.config
+      arguments: sources add -Name xboxgdk -Source $(URL_FEED) -ConfigFile $(Build.SourcesDirectory)\NuGet.config
   - task: PowerShell@2
     displayName: 'Set nuget.config to single source'
     inputs:

--- a/build/DirectXTK12-GitHub-GDK.yml
+++ b/build/DirectXTK12-GitHub-GDK.yml
@@ -65,7 +65,8 @@ jobs:
     fetchTags: false
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
-    versionSpec: '6.5.x'
+    inputs:
+      versionSpec: '6.5.x'
   - task: NuGetCommand@2
     # We have to use a nuget.config to provide the feed for the 'nuget install' option.
     displayName: 'NuGet set package source to ADO feed'
@@ -176,7 +177,8 @@ jobs:
       failOnStderr: true
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
-    versionSpec: '6.5.x'
+    inputs:
+      versionSpec: '6.5.x'
   - task: NuGetCommand@2
     displayName: 'NuGet set package source to ADO feed'
     inputs:
@@ -257,7 +259,8 @@ jobs:
       failOnStderr: true
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
-    versionSpec: '6.5.x'
+    inputs:
+      versionSpec: '6.5.x'
   - task: NuGetCommand@2
     displayName: 'NuGet set package source to ADO feed'
     inputs:

--- a/build/DirectXTK12-GitHub-SDK-prerelease.yml
+++ b/build/DirectXTK12-GitHub-SDK-prerelease.yml
@@ -44,12 +44,13 @@ jobs:
     fetchTags: false
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
+    versionSpec: '6.5.x'
   - task: NuGetCommand@2
     # We have to use a nuget.config to provide the feed for the 'nuget install' option.
     displayName: 'NuGet set package source to ADO feed'
     inputs:
       command: custom
-      arguments: sources add -Name xboxgdk -Source $(URL_FEED) -ConfigFile NuGet.config
+      arguments: sources add -Name xboxgdk -Source $(URL_FEED) -ConfigFile $(Build.SourcesDirectory)\NuGet.config
   - task: PowerShell@2
     displayName: 'Set nuget.config to single source'
     inputs:
@@ -135,11 +136,12 @@ jobs:
     fetchTags: false
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
+    versionSpec: '6.5.x'
   - task: NuGetCommand@2
     displayName: 'NuGet set package source to ADO feed'
     inputs:
       command: custom
-      arguments: sources add -Name xboxgdk -Source $(URL_FEED) -ConfigFile NuGet.config
+      arguments: sources add -Name xboxgdk -Source $(URL_FEED) -ConfigFile $(Build.SourcesDirectory)\NuGet.config
   - task: PowerShell@2
     displayName: 'Set nuget.config to single source'
     inputs:
@@ -204,11 +206,12 @@ jobs:
     fetchTags: false
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
+    versionSpec: '6.5.x'
   - task: NuGetCommand@2
     displayName: 'NuGet set package source to ADO feed'
     inputs:
       command: custom
-      arguments: sources add -Name xboxgdk -Source $(URL_FEED) -ConfigFile NuGet.config
+      arguments: sources add -Name xboxgdk -Source $(URL_FEED) -ConfigFile $(Build.SourcesDirectory)\NuGet.config
   - task: PowerShell@2
     displayName: 'Set nuget.config to single source'
     inputs:

--- a/build/DirectXTK12-GitHub-SDK-prerelease.yml
+++ b/build/DirectXTK12-GitHub-SDK-prerelease.yml
@@ -44,7 +44,8 @@ jobs:
     fetchTags: false
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
-    versionSpec: '6.5.x'
+    inputs:
+      versionSpec: '6.5.x'
   - task: NuGetCommand@2
     # We have to use a nuget.config to provide the feed for the 'nuget install' option.
     displayName: 'NuGet set package source to ADO feed'
@@ -136,7 +137,8 @@ jobs:
     fetchTags: false
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
-    versionSpec: '6.5.x'
+    inputs:
+      versionSpec: '6.5.x'
   - task: NuGetCommand@2
     displayName: 'NuGet set package source to ADO feed'
     inputs:
@@ -206,7 +208,8 @@ jobs:
     fetchTags: false
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
-    versionSpec: '6.5.x'
+    inputs:
+      versionSpec: '6.5.x'
   - task: NuGetCommand@2
     displayName: 'NuGet set package source to ADO feed'
     inputs:

--- a/build/DirectXTK12-GitHub-SDK-release.yml
+++ b/build/DirectXTK12-GitHub-SDK-release.yml
@@ -44,12 +44,13 @@ jobs:
     fetchTags: false
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
+    versionSpec: '6.5.x'
   - task: NuGetCommand@2
     # We have to use a nuget.config to provide the feed for the 'nuget install' option.
     displayName: 'NuGet set package source to ADO feed'
     inputs:
       command: custom
-      arguments: sources add -Name xboxgdk -Source $(URL_FEED) -ConfigFile NuGet.config
+      arguments: sources add -Name xboxgdk -Source $(URL_FEED) -ConfigFile $(Build.SourcesDirectory)\NuGet.config
   - task: PowerShell@2
     displayName: 'Set nuget.config to single source'
     inputs:
@@ -135,11 +136,12 @@ jobs:
     fetchTags: false
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
+    versionSpec: '6.5.x'
   - task: NuGetCommand@2
     displayName: 'NuGet set package source to ADO feed'
     inputs:
       command: custom
-      arguments: sources add -Name xboxgdk -Source $(URL_FEED) -ConfigFile NuGet.config
+      arguments: sources add -Name xboxgdk -Source $(URL_FEED) -ConfigFile $(Build.SourcesDirectory)\NuGet.config
   - task: PowerShell@2
     displayName: 'Set nuget.config to single source'
     inputs:
@@ -204,11 +206,12 @@ jobs:
     fetchTags: false
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
+    versionSpec: '6.5.x'
   - task: NuGetCommand@2
     displayName: 'NuGet set package source to ADO feed'
     inputs:
       command: custom
-      arguments: sources add -Name xboxgdk -Source $(URL_FEED) -ConfigFile NuGet.config
+      arguments: sources add -Name xboxgdk -Source $(URL_FEED) -ConfigFile $(Build.SourcesDirectory)\NuGet.config
   - task: PowerShell@2
     displayName: 'Set nuget.config to single source'
     inputs:

--- a/build/DirectXTK12-GitHub-SDK-release.yml
+++ b/build/DirectXTK12-GitHub-SDK-release.yml
@@ -44,7 +44,8 @@ jobs:
     fetchTags: false
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
-    versionSpec: '6.5.x'
+    inputs:
+      versionSpec: '6.5.x'
   - task: NuGetCommand@2
     # We have to use a nuget.config to provide the feed for the 'nuget install' option.
     displayName: 'NuGet set package source to ADO feed'
@@ -136,7 +137,8 @@ jobs:
     fetchTags: false
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
-    versionSpec: '6.5.x'
+    inputs:
+      versionSpec: '6.5.x'
   - task: NuGetCommand@2
     displayName: 'NuGet set package source to ADO feed'
     inputs:
@@ -206,7 +208,8 @@ jobs:
     fetchTags: false
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
-    versionSpec: '6.5.x'
+    inputs:
+      versionSpec: '6.5.x'
   - task: NuGetCommand@2
     displayName: 'NuGet set package source to ADO feed'
     inputs:


### PR DESCRIPTION
Support for "SHA256" hashing of PDBs is required for SDL compliance, and is supported by VS 2019 or later. Support for this switch was added to clang/LLVM for Windows v16 which is coming in VS 2022 17.6.

> Also need a workaround applied for a problem with NuGet 6.6 and NuGetCommand@2 using custom.