### PR TITLE
Fix CMake problem with /Zc:templateScope on older Windows SDKs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -485,11 +485,7 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
 
     if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.35)
         if(NOT (DEFINED XBOX_CONSOLE_TARGET))
-            target_compile_options(${PROJECT_NAME} PRIVATE /Zc:templateScope)
-        endif()
-
-        if(CMAKE_INTERPROCEDURAL_OPTIMIZATION)
-            target_compile_options(${PROJECT_NAME} PRIVATE /Zc:checkGwOdr)
+          target_compile_options(${PROJECT_NAME} PRIVATE /Zc:checkGwOdr $<$<VERSION_GREATER_EQUAL:${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION},10.0.22000>:/Zc:templateScope>)
         endif()
     endif()
 endif()

--- a/Src/d3dx12.h
+++ b/Src/d3dx12.h
@@ -761,7 +761,7 @@ struct CD3DX12_HEAP_PROPERTIES : public D3D12_HEAP_PROPERTIES
     bool IsCPUAccessible() const noexcept
     {
         return Type == D3D12_HEAP_TYPE_UPLOAD || Type == D3D12_HEAP_TYPE_READBACK
-#if defined(D3D12_SDK_VERSION) && (D3D12_SDK_VERSION >= 609)
+#if 0
             || Type == D3D12_HEAP_TYPE_GPU_UPLOAD
 #endif
             || (Type == D3D12_HEAP_TYPE_CUSTOM &&


### PR DESCRIPTION
When building with CMake and VS 2022 Update 5 or later, I make use of ``/Zc:templateScope`` for conformance validation. This is, however, not compatible with the Windows SDK prior to the Windows SDK (22000) build.

> Also fixes a build break in the Windows SDK preview validation pipelines.