### PR TITLE
CMake target file fix

### DIFF
--- a/build/DirectXTK12-config.cmake.in
+++ b/build/DirectXTK12-config.cmake.in
@@ -3,7 +3,7 @@
 include(${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake)
 include(CMakeFindDependencyMacro)
 
-if(MINGW OR VCPKG_TOOLCHAIN)
+if(MINGW)
     find_dependency(directx-headers CONFIG)
     find_dependency(directxmath CONFIG)
 endif()


### PR DESCRIPTION
The CMakeLists.txt no longer mandates both **directxmath** and **directx-headers** packages be found unless building with MinGW. This fixes the behavior for CMake clients consuming this package from VCPKG.