### PR TITLE
CMake targets fixes for optional vs. required packages

### DIFF
--- a/build/DirectXTK12-config.cmake.in
+++ b/build/DirectXTK12-config.cmake.in
@@ -4,8 +4,11 @@ include(${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake)
 include(CMakeFindDependencyMacro)
 
 if(MINGW)
-    find_dependency(directx-headers CONFIG)
-    find_dependency(directxmath CONFIG)
+    find_dependency(directx-headers)
+    find_dependency(directxmath)
+else()
+    find_package(directx-headers CONFIG QUIET)
+    find_package(directxmath CONFIG QUIET)
 endif()
 
 check_required_components("@PROJECT_NAME@")


### PR DESCRIPTION
With the changes to make use of DirectXMath & DirectX-Headers 'optional' for VCPKG scenarios unless using MinGW, the generated targets file needed more robust handling of these targets.