### PR TITLE
Add NO_WCHAR_T build option to CMake

### DIFF
--- a/Audio/AudioEngine.cpp
+++ b/Audio/AudioEngine.cpp
@@ -1897,3 +1897,26 @@ std::vector<AudioEngine::RendererDetail> AudioEngine::GetRendererDetails()
 #else
 #error DirectX Tool Kit for Audio not supported on this platform
 #endif
+
+
+//--------------------------------------------------------------------------------------
+// Adapters for /Zc:wchar_t- clients
+#if defined(_MSC_VER) && !defined(_NATIVE_WCHAR_T_DEFINED)
+
+_Use_decl_annotations_
+AudioEngine::AudioEngine(
+    AUDIO_ENGINE_FLAGS flags,
+    const WAVEFORMATEX* wfx,
+    const __wchar_t* deviceId,
+    AUDIO_STREAM_CATEGORY category) noexcept(false) :
+        AudioEngine(flags, wfx, reinterpret_cast<const unsigned short*>(deviceId), category)
+{
+}
+
+_Use_decl_annotations_
+bool AudioEngine::Reset(const WAVEFORMATEX* wfx, const __wchar_t* deviceId)
+{
+    return Reset(wfx, reinterpret_cast<const unsigned short*>(deviceId));
+}
+
+#endif // !_NATIVE_WCHAR_T_DEFINED

--- a/Audio/SoundEffect.cpp
+++ b/Audio/SoundEffect.cpp
@@ -614,3 +614,16 @@ void SoundEffect::FillSubmitBuffer(_Out_ XAUDIO2_BUFFER& buffer) const
 }
 
 #endif
+
+
+//--------------------------------------------------------------------------------------
+// Adapters for /Zc:wchar_t- clients
+#if defined(_MSC_VER) && !defined(_NATIVE_WCHAR_T_DEFINED)
+
+_Use_decl_annotations_
+SoundEffect::SoundEffect(AudioEngine* engine, const __wchar_t* waveFileName) :
+    SoundEffect(engine, reinterpret_cast<const unsigned short*>(waveFileName))
+{
+}
+
+#endif // !_NATIVE_WCHAR_T_DEFINED

--- a/Audio/WaveBank.cpp
+++ b/Audio/WaveBank.cpp
@@ -603,3 +603,16 @@ bool WaveBank::GetPrivateData(unsigned int index, void* data, size_t datasize)
             return false;
     }
 }
+
+
+//--------------------------------------------------------------------------------------
+// Adapters for /Zc:wchar_t- clients
+#if defined(_MSC_VER) && !defined(_NATIVE_WCHAR_T_DEFINED)
+
+_Use_decl_annotations_
+WaveBank::WaveBank(AudioEngine* engine, const __wchar_t* wbFileName) :
+    WaveBank(engine, reinterpret_cast<const unsigned short*>(wbFileName))
+{
+}
+
+#endif // !_NATIVE_WCHAR_T_DEFINED

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,8 @@ option(USE_PREBUILT_SHADERS "Use externally built HLSL shaders" OFF)
 
 option(BUILD_DXIL_SHADERS "Use DXC Shader Model 6 for shaders" ON)
 
+option(NO_WCHAR_T "Use legacy wide-character as unsigned short" OFF)
+
 option(BUILD_MIXED_DX11 "Support linking with DX11 version of toolkit" OFF)
 
 set(CMAKE_CXX_STANDARD 17)
@@ -429,6 +431,11 @@ if(MSVC)
        AND ((NOT (CMAKE_CXX_COMPILER_ID MATCHES "Clang")) OR (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13.0)))
       target_compile_options(${PROJECT_NAME} PRIVATE "$<$<NOT:$<CONFIG:DEBUG>>:/guard:ehcont>")
       target_link_options(${PROJECT_NAME} PRIVATE "$<$<NOT:$<CONFIG:DEBUG>>:/guard:ehcont>")
+    endif()
+
+    if(NO_WCHAR_T)
+      message(STATUS "Using non-native wchar_t as unsigned short")
+      target_compile_options(${PROJECT_NAME} PRIVATE "/Zc:wchar_t-")
     endif()
 else()
     target_compile_definitions(${PROJECT_NAME} PRIVATE $<IF:$<CONFIG:DEBUG>,_DEBUG,NDEBUG>)

--- a/Inc/Audio.h
+++ b/Inc/Audio.h
@@ -296,6 +296,16 @@ namespace DirectX
         static std::vector<RendererDetail> __cdecl GetRendererDetails();
             // Returns a list of valid audio endpoint devices
 
+#if defined(_MSC_VER) && !defined(_NATIVE_WCHAR_T_DEFINED)
+        explicit AudioEngine(
+            AUDIO_ENGINE_FLAGS flags = AudioEngine_Default,
+            _In_opt_ const WAVEFORMATEX* wfx = nullptr,
+            _In_opt_z_ const __wchar_t* deviceId = nullptr,
+            AUDIO_STREAM_CATEGORY category = AudioCategory_GameEffects) noexcept(false);
+
+        bool __cdecl Reset(_In_opt_ const WAVEFORMATEX* wfx = nullptr, _In_opt_z_ const __wchar_t* deviceId = nullptr);
+#endif
+
     private:
         // Private implementation.
         class Impl;
@@ -363,6 +373,10 @@ namespace DirectX
 
         bool __cdecl GetPrivateData(unsigned int index, _Out_writes_bytes_(datasize) void* data, size_t datasize);
 
+#if defined(_MSC_VER) && !defined(_NATIVE_WCHAR_T_DEFINED)
+        WaveBank(_In_ AudioEngine* engine, _In_z_ const __wchar_t* wbFileName);
+#endif
+
     private:
         // Private implementation.
         class Impl;
@@ -425,6 +439,10 @@ namespace DirectX
     #endif
 
         void __cdecl UnregisterInstance(_In_ IVoiceNotify* instance);
+
+#if defined(_MSC_VER) && !defined(_NATIVE_WCHAR_T_DEFINED)
+        SoundEffect(_In_ AudioEngine* engine, _In_z_ const __wchar_t* waveFileName);
+#endif
 
     private:
         // Private implementation.
@@ -730,7 +748,7 @@ namespace DirectX
     {
     public:
         DynamicSoundEffectInstance(_In_ AudioEngine* engine,
-            _In_opt_ std::function<void __cdecl(DynamicSoundEffectInstance*)> bufferNeeded,
+            _In_ std::function<void __cdecl(DynamicSoundEffectInstance*)> bufferNeeded,
             int sampleRate, int channels, int sampleBits = 16,
             SOUND_EFFECT_INSTANCE_FLAGS flags = SoundEffectInstance_Default);
 

--- a/Inc/Effects.h
+++ b/Inc/Effects.h
@@ -9,6 +9,9 @@
 
 #pragma once
 
+#ifndef __DIRECTXTK_EFFECTS_H__
+#define __DIRECTXTK_EFFECTS_H__
+
 #ifdef _GAMING_XBOX_SCARLETT
 #include <d3d12_xs.h>
 #elif (defined(_XBOX_ONE) && defined(_TITLE)) || defined(_GAMING_XBOX)
@@ -930,3 +933,5 @@ namespace DirectX
         };
     }
 }
+
+#endif // __DIRECTXTK_EFFECTS_H__

--- a/Inc/Model.h
+++ b/Inc/Model.h
@@ -574,6 +574,32 @@ namespace DirectX
             ModelBone::TransformArray       invBindPoseMatrices;
             std::wstring                    name;
 
+#if defined(_MSC_VER) && !defined(_NATIVE_WCHAR_T_DEFINED)
+
+            std::unique_ptr<EffectTextureFactory> __cdecl LoadTextures(
+                _In_ ID3D12Device* device,
+                ResourceUploadBatch& resourceUploadBatch,
+                _In_opt_z_ const __wchar_t* texturesPath = nullptr,
+                D3D12_DESCRIPTOR_HEAP_FLAGS flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE) const;
+
+            static std::unique_ptr<Model> __cdecl CreateFromCMO(
+                _In_opt_ ID3D12Device* device,
+                _In_z_ const __wchar_t* szFileName,
+                ModelLoaderFlags flags = ModelLoader_Default,
+                _Out_opt_ size_t* animsOffset = nullptr);
+
+            static std::unique_ptr<Model> __cdecl CreateFromSDKMESH(
+                _In_opt_ ID3D12Device* device,
+                _In_z_ const __wchar_t* szFileName,
+                ModelLoaderFlags flags = ModelLoader_Default);
+
+            static std::unique_ptr<Model> __cdecl CreateFromVBO(
+                _In_opt_ ID3D12Device* device,
+                _In_z_ const __wchar_t* szFileName,
+                ModelLoaderFlags flags = ModelLoader_Default);
+
+#endif // !_NATIVE_WCHAR_T_DEFINED
+
         private:
             std::shared_ptr<IEffect> __cdecl CreateEffectForMeshPart(
                 IEffectFactory& fxFactory,

--- a/Inc/ScreenGrab.h
+++ b/Inc/ScreenGrab.h
@@ -55,6 +55,6 @@ namespace DirectX
         D3D12_RESOURCE_STATES beforeState = D3D12_RESOURCE_STATE_RENDER_TARGET,
         D3D12_RESOURCE_STATES afterState = D3D12_RESOURCE_STATE_RENDER_TARGET,
         _In_opt_ const GUID* targetFormat = nullptr,
-        _In_opt_ std::function<void __cdecl(IPropertyBag2*)> setCustomProps = nullptr,
+        _In_ std::function<void __cdecl(IPropertyBag2*)> setCustomProps = nullptr,
         bool forceSRGB = false);
 }

--- a/Inc/SpriteFont.h
+++ b/Inc/SpriteFont.h
@@ -91,6 +91,26 @@ namespace DirectX
                 float XAdvance;
             };
 
+#if defined(_MSC_VER) && !defined(_NATIVE_WCHAR_T_DEFINED)
+            SpriteFont(ID3D12Device* device, ResourceUploadBatch& upload, _In_z_ __wchar_t const* fileName, D3D12_CPU_DESCRIPTOR_HANDLE cpuDescriptorDest, D3D12_GPU_DESCRIPTOR_HANDLE gpuDescriptor, bool forceSRGB = false);
+
+            void XM_CALLCONV DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ __wchar_t const* text, XMFLOAT2 const& position, FXMVECTOR color = Colors::White, float rotation = 0, XMFLOAT2 const& origin = Float2Zero, float scale = 1, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0) const;
+
+            void XM_CALLCONV DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ __wchar_t const* text, XMFLOAT2 const& position, FXMVECTOR color, float rotation, XMFLOAT2 const& origin, XMFLOAT2 const& scale, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0) const;
+            void XM_CALLCONV DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ __wchar_t const* text, FXMVECTOR position, FXMVECTOR color = Colors::White, float rotation = 0, FXMVECTOR origin = g_XMZero, float scale = 1, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0) const;
+            void XM_CALLCONV DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ __wchar_t const* text, FXMVECTOR position, FXMVECTOR color, float rotation, FXMVECTOR origin, GXMVECTOR scale, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0) const;
+
+            XMVECTOR XM_CALLCONV MeasureString(_In_z_ __wchar_t const* text, bool ignoreWhitespace = true) const;
+
+            RECT __cdecl MeasureDrawBounds(_In_z_ __wchar_t const* text, XMFLOAT2 const& position, bool ignoreWhitespace = true) const;
+            RECT XM_CALLCONV MeasureDrawBounds(_In_z_ __wchar_t const* text, FXMVECTOR position, bool ignoreWhitespace = true) const;
+
+            void __cdecl SetDefaultCharacter(__wchar_t character);
+
+            bool __cdecl ContainsCharacter(__wchar_t character) const;
+
+            Glyph const* __cdecl FindGlyph(__wchar_t character) const;
+#endif // !_NATIVE_WCHAR_T_DEFINED
 
         private:
             // Private implementation.

--- a/Src/DDSTextureLoader.cpp
+++ b/Src/DDSTextureLoader.cpp
@@ -1052,3 +1052,77 @@ HRESULT DirectX::CreateDDSTextureFromFileEx(
 
     return hr;
 }
+
+
+//--------------------------------------------------------------------------------------
+// Adapters for /Zc:wchar_t- clients
+
+#if defined(_MSC_VER) && !defined(_NATIVE_WCHAR_T_DEFINED)
+
+namespace DirectX
+{
+    HRESULT __cdecl LoadDDSTextureFromFile(
+        _In_ ID3D12Device* d3dDevice,
+        _In_z_ const __wchar_t* szFileName,
+        _Outptr_ ID3D12Resource** texture,
+        std::unique_ptr<uint8_t[]>& ddsData,
+        std::vector<D3D12_SUBRESOURCE_DATA>& subresources,
+        size_t maxsize,
+        _Out_opt_ DDS_ALPHA_MODE* alphaMode,
+        _Out_opt_ bool* isCubeMap)
+    {
+        return LoadDDSTextureFromFile(d3dDevice,
+            reinterpret_cast<const unsigned short*>(szFileName),
+            texture, ddsData, subresources, maxsize, alphaMode, isCubeMap);
+    }
+
+    HRESULT __cdecl CreateDDSTextureFromFile(
+        _In_ ID3D12Device* device,
+        ResourceUploadBatch& resourceUpload,
+        _In_z_ const __wchar_t* szFileName,
+        _Outptr_ ID3D12Resource** texture,
+        bool generateMipsIfMissing,
+        size_t maxsize,
+        _Out_opt_ DDS_ALPHA_MODE* alphaMode,
+        _Out_opt_ bool* isCubeMap)
+    {
+        return CreateDDSTextureFromFile(device, resourceUpload,
+            reinterpret_cast<const unsigned short*>(szFileName),
+            texture, generateMipsIfMissing, maxsize, alphaMode, isCubeMap);
+    }
+
+    HRESULT __cdecl LoadDDSTextureFromFileEx(
+        _In_ ID3D12Device* d3dDevice,
+        _In_z_ const __wchar_t* szFileName,
+        size_t maxsize,
+        D3D12_RESOURCE_FLAGS resFlags,
+        DDS_LOADER_FLAGS loadFlags,
+        _Outptr_ ID3D12Resource** texture,
+        std::unique_ptr<uint8_t[]>& ddsData,
+        std::vector<D3D12_SUBRESOURCE_DATA>& subresources,
+        _Out_opt_ DDS_ALPHA_MODE* alphaMode,
+        _Out_opt_ bool* isCubeMap)
+    {
+        return LoadDDSTextureFromFileEx(d3dDevice,
+            reinterpret_cast<const unsigned short*>(szFileName),
+            maxsize, resFlags, loadFlags, texture, ddsData, subresources, alphaMode, isCubeMap);
+    }
+
+    HRESULT __cdecl CreateDDSTextureFromFileEx(
+        _In_ ID3D12Device* device,
+        ResourceUploadBatch& resourceUpload,
+        _In_z_ const __wchar_t* szFileName,
+        size_t maxsize,
+        D3D12_RESOURCE_FLAGS resFlags,
+        DDS_LOADER_FLAGS loadFlags,
+        _Outptr_ ID3D12Resource** texture,
+        _Out_opt_ DDS_ALPHA_MODE* alphaMode,
+        _Out_opt_ bool* isCubeMap)
+    {
+        return CreateDDSTextureFromFileEx(device, resourceUpload,
+            reinterpret_cast<const unsigned short*>(szFileName),
+            maxsize, resFlags, loadFlags, texture, alphaMode, isCubeMap);
+    }
+}
+
+#endif // !_NATIVE_WCHAR_T_DEFINED

--- a/Src/Model.cpp
+++ b/Src/Model.cpp
@@ -830,3 +830,21 @@ void Model::Transition(
         commandList->ResourceBarrier(count, barrier);
     }
 }
+
+
+//--------------------------------------------------------------------------------------
+// Adapters for /Zc:wchar_t- clients
+
+#if defined(_MSC_VER) && !defined(_NATIVE_WCHAR_T_DEFINED)
+
+_Use_decl_annotations_
+std::unique_ptr<EffectTextureFactory> Model::LoadTextures(
+    ID3D12Device* device,
+    ResourceUploadBatch& resourceUploadBatch,
+    const __wchar_t* texturesPath,
+    D3D12_DESCRIPTOR_HEAP_FLAGS flags) const
+{
+    return LoadTextures(device, resourceUploadBatch, reinterpret_cast<const unsigned short*>(texturesPath), flags);
+}
+
+#endif

--- a/Src/ModelLoadCMO.cpp
+++ b/Src/ModelLoadCMO.cpp
@@ -998,3 +998,21 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
 
     return model;
 }
+
+
+//--------------------------------------------------------------------------------------
+// Adapters for /Zc:wchar_t- clients
+
+#if defined(_MSC_VER) && !defined(_NATIVE_WCHAR_T_DEFINED)
+
+_Use_decl_annotations_
+std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
+    ID3D12Device* device,
+    const __wchar_t* szFileName,
+    ModelLoaderFlags flags,
+    size_t* animsOffset)
+{
+    return CreateFromCMO(device, reinterpret_cast<const unsigned short*>(szFileName), flags, animsOffset);
+}
+
+#endif

--- a/Src/ModelLoadSDKMESH.cpp
+++ b/Src/ModelLoadSDKMESH.cpp
@@ -793,3 +793,20 @@ std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(
 
     return model;
 }
+
+
+//--------------------------------------------------------------------------------------
+// Adapters for /Zc:wchar_t- clients
+
+#if defined(_MSC_VER) && !defined(_NATIVE_WCHAR_T_DEFINED)
+
+_Use_decl_annotations_
+std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(
+    ID3D12Device* device,
+    const __wchar_t* szFileName,
+    ModelLoaderFlags flags)
+{
+    return CreateFromSDKMESH(device, reinterpret_cast<const unsigned short*>(szFileName), flags);
+}
+
+#endif

--- a/Src/ModelLoadVBO.cpp
+++ b/Src/ModelLoadVBO.cpp
@@ -153,3 +153,20 @@ std::unique_ptr<Model> DirectX::Model::CreateFromVBO(
 
     return model;
 }
+
+
+//--------------------------------------------------------------------------------------
+// Adapters for /Zc:wchar_t- clients
+
+#if defined(_MSC_VER) && !defined(_NATIVE_WCHAR_T_DEFINED)
+
+_Use_decl_annotations_
+std::unique_ptr<Model> DirectX::Model::CreateFromVBO(
+    ID3D12Device* device,
+    const __wchar_t* szFileName,
+    ModelLoaderFlags flags)
+{
+    return CreateFromVBO(device, reinterpret_cast<const unsigned short*>(szFileName), flags);
+}
+
+#endif

--- a/Src/ScreenGrab.cpp
+++ b/Src/ScreenGrab.cpp
@@ -809,3 +809,42 @@ HRESULT DirectX::SaveWICTextureToFile(
 
     return S_OK;
 }
+
+
+//--------------------------------------------------------------------------------------
+// Adapters for /Zc:wchar_t- clients
+
+#if defined(_MSC_VER) && !defined(_NATIVE_WCHAR_T_DEFINED)
+
+namespace DirectX
+{
+    HRESULT __cdecl SaveDDSTextureToFile(
+        _In_ ID3D12CommandQueue* pCommandQueue,
+        _In_ ID3D12Resource* pSource,
+        _In_z_ const __wchar_t* fileName,
+        D3D12_RESOURCE_STATES beforeState,
+        D3D12_RESOURCE_STATES afterState) noexcept
+    {
+        return SaveDDSTextureToFile(pCommandQueue, pSource,
+            reinterpret_cast<const unsigned short*>(fileName),
+            beforeState, afterState);
+    }
+
+    HRESULT __cdecl SaveWICTextureToFile(
+        _In_ ID3D12CommandQueue* pCommandQ,
+        _In_ ID3D12Resource* pSource,
+        REFGUID guidContainerFormat,
+        _In_z_ const __wchar_t* fileName,
+        D3D12_RESOURCE_STATES beforeState,
+        D3D12_RESOURCE_STATES afterState,
+        _In_opt_ const GUID* targetFormat,
+        _In_ std::function<void __cdecl(IPropertyBag2*)> setCustomProps,
+        bool forceSRGB)
+    {
+        return SaveWICTextureToFile(pCommandQ, pSource, guidContainerFormat,
+            reinterpret_cast<const unsigned short*>(fileName),
+            beforeState, afterState, targetFormat, setCustomProps, forceSRGB);
+    }
+}
+
+#endif // !_NATIVE_WCHAR_T_DEFINED

--- a/Src/SpriteFont.cpp
+++ b/Src/SpriteFont.cpp
@@ -674,3 +674,80 @@ XMUINT2 SpriteFont::GetSpriteSheetSize() const noexcept
 {
     return pImpl->textureSize;
 }
+
+
+//--------------------------------------------------------------------------------------
+// Adapters for /Zc:wchar_t- clients
+
+#if defined(_MSC_VER) && !defined(_NATIVE_WCHAR_T_DEFINED)
+
+SpriteFont::SpriteFont(
+    ID3D12Device* device,
+    ResourceUploadBatch& upload,
+    _In_z_ __wchar_t const* fileName,
+    D3D12_CPU_DESCRIPTOR_HANDLE cpuDescriptorDest,
+    D3D12_GPU_DESCRIPTOR_HANDLE gpuDescriptor,
+    bool forceSRGB) :
+    SpriteFont(
+        device, upload,
+        reinterpret_cast<const unsigned short*>(fileName),
+        cpuDescriptorDest, gpuDescriptor, forceSRGB)
+{
+}
+
+void SpriteFont::DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ __wchar_t const* text, XMFLOAT2 const& position, FXMVECTOR color, float rotation, XMFLOAT2 const& origin, float scale, SpriteEffects effects, float layerDepth) const
+{
+    DrawString(spriteBatch, reinterpret_cast<const unsigned short*>(text), XMLoadFloat2(&position), color, rotation, XMLoadFloat2(&origin), XMVectorReplicate(scale), effects, layerDepth);
+}
+
+void SpriteFont::DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ __wchar_t const* text, XMFLOAT2 const& position, FXMVECTOR color, float rotation, XMFLOAT2 const& origin, XMFLOAT2 const& scale, SpriteEffects effects, float layerDepth) const
+{
+    DrawString(spriteBatch, reinterpret_cast<const unsigned short*>(text), XMLoadFloat2(&position), color, rotation, XMLoadFloat2(&origin), XMLoadFloat2(&scale), effects, layerDepth);
+}
+
+void SpriteFont::DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ __wchar_t const* text, FXMVECTOR position, FXMVECTOR color, float rotation, FXMVECTOR origin, float scale, SpriteEffects effects, float layerDepth) const
+{
+    DrawString(spriteBatch, reinterpret_cast<const unsigned short*>(text), position, color, rotation, origin, XMVectorReplicate(scale), effects, layerDepth);
+}
+
+void XM_CALLCONV SpriteFont::DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ __wchar_t const* text, FXMVECTOR position, FXMVECTOR color, float rotation, FXMVECTOR origin, GXMVECTOR scale, SpriteEffects effects, float layerDepth) const
+{
+    DrawString(spriteBatch, reinterpret_cast<const unsigned short*>(text), position, color, rotation, origin, scale, effects, layerDepth);
+}
+
+XMVECTOR SpriteFont::MeasureString(_In_z_ __wchar_t const* text, bool ignoreWhitespace) const
+{
+    return MeasureString(reinterpret_cast<const unsigned short*>(text), ignoreWhitespace);
+}
+
+RECT SpriteFont::MeasureDrawBounds(_In_z_ __wchar_t const* text, XMFLOAT2 const& position, bool ignoreWhitespace) const
+{
+    return MeasureDrawBounds(reinterpret_cast<const unsigned short*>(text), position, ignoreWhitespace);
+}
+
+RECT SpriteFont::MeasureDrawBounds(_In_z_ __wchar_t const* text, FXMVECTOR position, bool ignoreWhitespace) const
+{
+    XMFLOAT2 pos;
+    XMStoreFloat2(&pos, position);
+
+    return MeasureDrawBounds(reinterpret_cast<const unsigned short*>(text), pos, ignoreWhitespace);
+}
+
+// Can't do this for GetDefaultCharacter since it only differs by return type.
+
+void SpriteFont::SetDefaultCharacter(__wchar_t character)
+{
+    pImpl->SetDefaultCharacter(static_cast<unsigned short>(character));
+}
+
+bool SpriteFont::ContainsCharacter(__wchar_t character) const
+{
+    return ContainsCharacter(static_cast<unsigned short>(character));
+}
+
+SpriteFont::Glyph const* SpriteFont::FindGlyph(__wchar_t character) const
+{
+    return pImpl->FindGlyph(static_cast<unsigned short>(character));
+}
+
+#endif // !_NATIVE_WCHAR_T_DEFINED

--- a/Src/WICTextureLoader.cpp
+++ b/Src/WICTextureLoader.cpp
@@ -972,3 +972,69 @@ HRESULT DirectX::CreateWICTextureFromFileEx(
 
     return hr;
 }
+
+
+//--------------------------------------------------------------------------------------
+// Adapters for /Zc:wchar_t- clients
+
+#if defined(_MSC_VER) && !defined(_NATIVE_WCHAR_T_DEFINED)
+
+namespace DirectX
+{
+    HRESULT __cdecl LoadWICTextureFromFile(
+        _In_ ID3D12Device* d3dDevice,
+        _In_z_ const __wchar_t* szFileName,
+        _Outptr_ ID3D12Resource** texture,
+        std::unique_ptr<uint8_t[]>& decodedData,
+        D3D12_SUBRESOURCE_DATA& subresource,
+        size_t maxsize) noexcept
+    {
+        return LoadWICTextureFromFile(d3dDevice,
+            reinterpret_cast<const unsigned short*>(szFileName),
+            texture, decodedData, subresource, maxsize);
+    }
+
+    HRESULT __cdecl CreateWICTextureFromFile(
+        _In_ ID3D12Device* d3dDevice,
+        ResourceUploadBatch& resourceUpload,
+        _In_z_ const __wchar_t* szFileName,
+        _Outptr_ ID3D12Resource** texture,
+        bool generateMips,
+        size_t maxsize)
+    {
+        return CreateWICTextureFromFile(d3dDevice, resourceUpload,
+            reinterpret_cast<const unsigned short*>(szFileName),
+            texture, generateMips, maxsize);
+    }
+
+    HRESULT __cdecl LoadWICTextureFromFileEx(
+        _In_ ID3D12Device* d3dDevice,
+        _In_z_ const __wchar_t* szFileName,
+        size_t maxsize,
+        D3D12_RESOURCE_FLAGS resFlags,
+        WIC_LOADER_FLAGS loadFlags,
+        _Outptr_ ID3D12Resource** texture,
+        std::unique_ptr<uint8_t[]>& decodedData,
+        D3D12_SUBRESOURCE_DATA& subresource) noexcept
+    {
+        return LoadWICTextureFromFileEx(d3dDevice,
+            reinterpret_cast<const unsigned short*>(szFileName),
+            maxsize, resFlags, loadFlags, texture, decodedData, subresource);
+    }
+
+    HRESULT __cdecl CreateWICTextureFromFileEx(
+        _In_ ID3D12Device* d3dDevice,
+        ResourceUploadBatch& resourceUpload,
+        _In_z_ const __wchar_t* szFileName,
+        size_t maxsize,
+        D3D12_RESOURCE_FLAGS resFlags,
+        WIC_LOADER_FLAGS loadFlags,
+        _Outptr_ ID3D12Resource** texture)
+    {
+        return CreateWICTextureFromFileEx(d3dDevice, resourceUpload,
+            reinterpret_cast<const unsigned short*>(szFileName),
+            maxsize, resFlags, loadFlags, texture);
+    }
+}
+
+#endif // !_NATIVE_WCHAR_T_DEFINED

--- a/build/DirectXTK12-GitHub-CMake-Dev17.yml
+++ b/build/DirectXTK12-GitHub-CMake-Dev17.yml
@@ -165,3 +165,13 @@ jobs:
     inputs:
       cwd: '$(Build.SourcesDirectory)'
       cmakeArgs: --build out9 -v --config RelWithDebInfo
+  - task: CMake@1
+    displayName: 'CMake (NO_WCHAR_T): Config'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out10 -DNO_WCHAR_T=ON -DCMAKE_SYSTEM_VERSION=$(WIN11_SDK)'
+  - task: CMake@1
+    displayName: 'CMake (NO_WCHAR_T): Build'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out10 -v --config Debug

--- a/build/DirectXTK12-GitHub-CMake.yml
+++ b/build/DirectXTK12-GitHub-CMake.yml
@@ -170,3 +170,13 @@ jobs:
     inputs:
       cwd: '$(Build.SourcesDirectory)'
       cmakeArgs: --build out9 -v --config RelWithDebInfo
+  - task: CMake@1
+    displayName: 'CMake (NO_WCHAR_T): Config'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out10 -DNO_WCHAR_T=ON -DCMAKE_SYSTEM_VERSION=$(WIN11_SDK)'
+  - task: CMake@1
+    displayName: 'CMake (NO_WCHAR_T): Build'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out10 -v --config Debug


### PR DESCRIPTION
Some usage scenarios build the library with ``/Zc:wchar_t-`` but mix both ``unsigned short*`` and ``wchar_t*`` client usage. For this *opt-in* build scenario, the library will link with both the non-native and native ``wchar_t``.

Note this works for general use, but not necessarily all use cases. For example, all the effect and texture factory virtual methods are defined only using the type that matches the compiler setting for the library, as there's no easy way to provide an adapter for these. There are also some edge-cases like ``SpriteFont::GetDefaultCharacter`` that you can't use a link-time adapter because the overloading rules don't allow only differing by return type.

> Also fixes some Code Analysis warnings as you can't use ``_In_opt_`` with ``std::function<>``.