### PR TITLE
GraphicsMemory updated to support Xbox PIX memory tracking

### DIFF
--- a/Inc/GraphicsMemory.h
+++ b/Inc/GraphicsMemory.h
@@ -179,7 +179,8 @@ namespace DirectX
                 constexpr size_t alignedSize = (sizeof(T) + alignment - 1) & ~(alignment - 1);
                 auto alloc = AllocateImpl(alignedSize, alignment);
 #ifdef USING_PIX_CUSTOM_MEMORY_EVENTS
-                std::ignore = ReportCustomMemoryAlloc(alloc.Memory(), alloc.Size(), TAG_CONSTANT);
+                // This cast is needed to capture the type information in the PDB
+                std::ignore = reinterpret_cast<T*>(ReportCustomMemoryAlloc(alloc.Memory(), alloc.Size(), TAG_CONSTANT));
 #endif
                 return alloc;
             }
@@ -215,6 +216,7 @@ namespace DirectX
             GraphicsResource __cdecl AllocateImpl(size_t size, size_t alignment);
 
 #ifdef USING_PIX_CUSTOM_MEMORY_EVENTS
+            // The declspec is required to ensure the proper information is captured in the PDB
             __declspec(allocator) static void* ReportCustomMemoryAlloc(void* pMem, size_t size, UINT64 metadata);
 #endif
 

--- a/Inc/GraphicsMemory.h
+++ b/Inc/GraphicsMemory.h
@@ -24,6 +24,14 @@
 #include <cstring>
 #include <memory>
 
+#ifdef _GAMING_XBOX
+#include <gxdk.h>
+#endif
+
+#if defined(_GAMING_XBOX) && (defined(_DEBUG) || defined(PROFILE)) && (_GXDK_VER >= 0x585D073C) /* GDK Edition 221000 */
+#define USING_PIX_CUSTOM_MEMORY_EVENTS
+#include <tuple>
+#endif
 
 namespace DirectX
 {
@@ -129,6 +137,17 @@ namespace DirectX
         class GraphicsMemory
         {
         public:
+            enum Tag
+            {
+                TAG_GENERIC = 0,
+                TAG_CONSTANT,
+                TAG_VERTEX,
+                TAG_INDEX,
+                TAG_SPRITES,
+                TAG_TEXTURE,
+                TAG_COMPUTE,
+            };
+
             explicit GraphicsMemory(_In_ ID3D12Device* device);
 
             GraphicsMemory(GraphicsMemory&&) noexcept;
@@ -142,14 +161,27 @@ namespace DirectX
             // Make sure to keep the GraphicsResource handle alive as long as you need to access
             // the memory on the CPU. For example, do not simply cache GpuAddress() and discard
             // the GraphicsResource object, or your memory may be overwritten later.
-            GraphicsResource __cdecl Allocate(size_t size, size_t alignment = 16);
+            GraphicsResource __cdecl Allocate(size_t size, size_t alignment = 16, uint32_t tag = TAG_GENERIC)
+            {
+                auto alloc = AllocateImpl(size, alignment);
+#ifdef USING_PIX_CUSTOM_MEMORY_EVENTS
+                std::ignore = ReportCustomMemoryAlloc(alloc.Memory(), alloc.Size(), tag);
+#else
+                UNREFERENCED_PARAMETER(tag);
+#endif
+                return alloc;
+            }
 
-            // Special overload of Allocate that aligns to D3D12 constant buffer alignment requirements
+            // Version of Allocate that aligns to D3D12 constant buffer requirements
             template<typename T> GraphicsResource AllocateConstant()
             {
                 constexpr size_t alignment = D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT;
                 constexpr size_t alignedSize = (sizeof(T) + alignment - 1) & ~(alignment - 1);
-                return Allocate(alignedSize, alignment);
+                auto alloc = AllocateImpl(alignedSize, alignment);
+#ifdef USING_PIX_CUSTOM_MEMORY_EVENTS
+                std::ignore = ReportCustomMemoryAlloc(alloc.Memory(), alloc.Size(), TAG_CONSTANT);
+#endif
+                return alloc;
             }
             template<typename T> GraphicsResource AllocateConstant(const T& setData)
             {
@@ -179,6 +211,12 @@ namespace DirectX
         private:
             // Private implementation.
             class Impl;
+
+            GraphicsResource __cdecl AllocateImpl(size_t size, size_t alignment);
+
+#ifdef USING_PIX_CUSTOM_MEMORY_EVENTS
+            __declspec(allocator) static void* ReportCustomMemoryAlloc(void* pMem, size_t size, UINT64 metadata);
+#endif
 
             std::unique_ptr<Impl> pImpl;
         };

--- a/README.md
+++ b/README.md
@@ -140,4 +140,6 @@ Thanks for Travis Johnson for the mGPU support.
 
 Thanks to Roberto Sonnino for his help with the CMO format and the VS Starter Kit animation.
 
+Thanks to Richie Meyer for their contribution of Xbox PIX custom memory and type allocation tracking events support.
+
 Thanks to Andrew Farrier and Scott Matloff for their on-going help with code reviews.

--- a/Src/GeometricPrimitive.cpp
+++ b/Src/GeometricPrimitive.cpp
@@ -71,7 +71,7 @@ void GeometricPrimitive::Impl::Initialize(
 
     auto const vertSizeBytes = static_cast<size_t>(sizeInBytes);
 
-    mVertexBuffer = GraphicsMemory::Get(device).Allocate(vertSizeBytes);
+    mVertexBuffer = GraphicsMemory::Get(device).Allocate(vertSizeBytes, 16, GraphicsMemory::TAG_VERTEX);
 
     auto verts = reinterpret_cast<const uint8_t*>(vertices.data());
     memcpy(mVertexBuffer.Memory(), verts, vertSizeBytes);
@@ -83,7 +83,7 @@ void GeometricPrimitive::Impl::Initialize(
 
     auto const indSizeBytes = static_cast<size_t>(sizeInBytes);
 
-    mIndexBuffer = GraphicsMemory::Get(device).Allocate(indSizeBytes);
+    mIndexBuffer = GraphicsMemory::Get(device).Allocate(indSizeBytes, 16, GraphicsMemory::TAG_INDEX);
 
     auto ind = reinterpret_cast<const uint8_t*>(indices.data());
     memcpy(mIndexBuffer.Memory(), ind, indSizeBytes);

--- a/Src/GraphicsMemory.cpp
+++ b/Src/GraphicsMemory.cpp
@@ -12,6 +12,11 @@
 #include "PlatformHelpers.h"
 #include "LinearAllocator.h"
 
+#ifdef USING_PIX_CUSTOM_MEMORY_EVENTS
+#include <pix3.h>
+#include <pixmemory.h>
+#endif
+
 using namespace DirectX;
 using Microsoft::WRL::ComPtr;
 using ScopedLock = std::lock_guard<std::mutex>;
@@ -214,6 +219,10 @@ namespace
         std::array<std::unique_ptr<LinearAllocator>, AllocatorPoolCount> mPools;
         mutable std::mutex mMutex;
     };
+
+#ifdef USING_PIX_CUSTOM_MEMORY_EVENTS
+    constexpr uint16_t c_PIXAllocatorID = 1001;
+#endif
 } // anonymous namespace
 
 
@@ -372,7 +381,7 @@ GraphicsMemory& GraphicsMemory::operator= (GraphicsMemory&& moveFrom) noexcept
 GraphicsMemory::~GraphicsMemory() = default;
 
 
-GraphicsResource GraphicsMemory::Allocate(size_t size, size_t alignment)
+GraphicsResource GraphicsMemory::AllocateImpl(size_t size, size_t alignment)
 {
     assert(alignment >= 4); // Should use at least DWORD alignment
     return pImpl->Allocate(size, alignment);
@@ -436,6 +445,15 @@ GraphicsMemory& GraphicsMemory::Get(_In_opt_ ID3D12Device* device)
 }
 #endif
 
+#ifdef USING_PIX_CUSTOM_MEMORY_EVENTS
+__declspec(allocator)
+void* GraphicsMemory::ReportCustomMemoryAlloc(void* pMem, size_t size, UINT64 metadata)
+{
+    PIXRecordMemoryAllocationEvent(c_PIXAllocatorID, pMem, size, metadata);
+    return pMem;
+}
+#endif
+
 
 //--------------------------------------------------------------------------------------
 // GraphicsResource smart-pointer interface
@@ -484,6 +502,10 @@ GraphicsResource::~GraphicsResource()
 {
     if (mPage)
     {
+#ifdef USING_PIX_CUSTOM_MEMORY_EVENTS
+        PIXRecordMemoryFreeEvent(c_PIXAllocatorID, reinterpret_cast<void*>(mGpuAddress), mSize, 0);
+#endif
+
         mPage->Release();
         mPage = nullptr;
     }
@@ -499,6 +521,10 @@ void GraphicsResource::Reset() noexcept
 {
     if (mPage)
     {
+#ifdef USING_PIX_CUSTOM_MEMORY_EVENTS
+        PIXRecordMemoryFreeEvent(c_PIXAllocatorID, reinterpret_cast<void*>(mGpuAddress), mSize, 0);
+#endif
+
         mPage->Release();
         mPage = nullptr;
     }
@@ -514,6 +540,10 @@ void GraphicsResource::Reset(GraphicsResource&& alloc) noexcept
 {
     if (mPage)
     {
+#ifdef USING_PIX_CUSTOM_MEMORY_EVENTS
+        PIXRecordMemoryFreeEvent(c_PIXAllocatorID, reinterpret_cast<void*>(mGpuAddress), mSize, 0);
+#endif
+
         mPage->Release();
         mPage = nullptr;
     }

--- a/Src/GraphicsMemory.cpp
+++ b/Src/GraphicsMemory.cpp
@@ -246,6 +246,10 @@ public:
         }
 
         s_graphicsMemory = this;
+
+    #endif
+    #ifdef USING_PIX_CUSTOM_MEMORY_EVENTS
+        DebugTrace("INFO: GraphicsMemory PIX custom memory tracking events enabled (Allocator ID %u)\n", c_PIXAllocatorID);
     #endif
     }
 

--- a/Src/ModelLoadCMO.cpp
+++ b/Src/ModelLoadCMO.cpp
@@ -539,7 +539,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
             ib.ptr = indexes;
             ibData.emplace_back(ib);
 
-            ibs[j] = GraphicsMemory::Get(device).Allocate(ibBytes);
+            ibs[j] = GraphicsMemory::Get(device).Allocate(ibBytes, 16, GraphicsMemory::TAG_INDEX);
             memcpy(ibs[j].Memory(), indexes, ibBytes);
         }
 
@@ -890,7 +890,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
                     }
                 }
 
-                vbs[j] = GraphicsMemory::Get(device).Allocate(bytes);
+                vbs[j] = GraphicsMemory::Get(device).Allocate(bytes, 16, GraphicsMemory::TAG_VERTEX);
                 memcpy(vbs[j].Memory(), temp.get(), bytes);
             }
         }

--- a/Src/ModelLoadSDKMESH.cpp
+++ b/Src/ModelLoadSDKMESH.cpp
@@ -681,14 +681,14 @@ std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(
             auto verts = bufferData + (vh.DataOffset - bufferDataOffset);
             auto const vbytes = static_cast<size_t>(vh.SizeBytes);
             part->vertexBufferSize = static_cast<uint32_t>(vh.SizeBytes);
-            part->vertexBuffer = GraphicsMemory::Get(device).Allocate(vbytes);
+            part->vertexBuffer = GraphicsMemory::Get(device).Allocate(vbytes, 16, GraphicsMemory::TAG_VERTEX);
             memcpy(part->vertexBuffer.Memory(), verts, vbytes);
 
             // Index data
             auto indices = bufferData + (ih.DataOffset - bufferDataOffset);
             auto const ibytes = static_cast<size_t>(ih.SizeBytes);
             part->indexBufferSize = static_cast<uint32_t>(ih.SizeBytes);
-            part->indexBuffer = GraphicsMemory::Get(device).Allocate(ibytes);
+            part->indexBuffer = GraphicsMemory::Get(device).Allocate(ibytes, 16, GraphicsMemory::TAG_INDEX);
             memcpy(part->indexBuffer.Memory(), indices, ibytes);
 
             part->materialIndex = subset.MaterialID;

--- a/Src/ModelLoadVBO.cpp
+++ b/Src/ModelLoadVBO.cpp
@@ -99,11 +99,11 @@ std::unique_ptr<Model> DirectX::Model::CreateFromVBO(
     auto indices = reinterpret_cast<const uint16_t*>(meshData + sizeof(VBO::header_t) + vertSize);
 
     // Create vertex buffer
-    auto vb = GraphicsMemory::Get(device).Allocate(vertSize);
+    auto vb = GraphicsMemory::Get(device).Allocate(vertSize, 16, GraphicsMemory::TAG_VERTEX);
     memcpy(vb.Memory(), verts, vertSize);
 
     // Create index buffer
-    auto ib = GraphicsMemory::Get(device).Allocate(indexSize);
+    auto ib = GraphicsMemory::Get(device).Allocate(indexSize, 16, GraphicsMemory::TAG_INDEX);
     memcpy(ib.Memory(), indices, indexSize);
 
     auto part = new ModelMeshPart(0);

--- a/Src/PrimitiveBatch.cpp
+++ b/Src/PrimitiveBatch.cpp
@@ -178,9 +178,11 @@ void PrimitiveBatchBase::Impl::Draw(D3D_PRIMITIVE_TOPOLOGY topology, bool isInde
 
         // Allocate a page for the primitive data
         if (isIndexed)
-            mIndexSegment = GraphicsMemory::Get(mDevice.Get()).Allocate(mIndexPageSize);
+        {
+            mIndexSegment = GraphicsMemory::Get(mDevice.Get()).Allocate(mIndexPageSize, 16, GraphicsMemory::TAG_INDEX);
+        }
 
-        mVertexSegment = GraphicsMemory::Get(mDevice.Get()).Allocate(mVertexPageSize);
+        mVertexSegment = GraphicsMemory::Get(mDevice.Get()).Allocate(mVertexPageSize, 16, GraphicsMemory::TAG_VERTEX);
     }
 
     // Copy over the index data.

--- a/Src/ScreenGrab.cpp
+++ b/Src/ScreenGrab.cpp
@@ -493,7 +493,7 @@ HRESULT DirectX::SaveWICTextureToFile(
     // Round up the srcPitch to multiples of 1024
     UINT64 dstRowPitch = (fpRowPitch + static_cast<uint64_t>(D3D12XBOX_TEXTURE_DATA_PITCH_ALIGNMENT) - 1u) & ~(static_cast<uint64_t>(D3D12XBOX_TEXTURE_DATA_PITCH_ALIGNMENT) - 1u);
 #else
-    // Round up the srcPitch to multiples of 256
+    // Round up the srcPitch to multiples of 256 (D3D12_TEXTURE_DATA_PITCH_ALIGNMENT)
     const UINT64 dstRowPitch = (fpRowPitch + 255) & ~0xFFu;
 #endif
 

--- a/Src/SpriteBatch.cpp
+++ b/Src/SpriteBatch.cpp
@@ -830,7 +830,7 @@ void SpriteBatch::Impl::RenderBatch(D3D12_GPU_DESCRIPTOR_HANDLE texture, XMVECTO
         // Allocate a new page of vertex memory if we're starting the batch
         if (mSpriteCount == 0)
         {
-            mVertexSegment = GraphicsMemory::Get(mDeviceResources->mDevice).Allocate(mVertexPageSize);
+            mVertexSegment = GraphicsMemory::Get(mDeviceResources->mDevice).Allocate(mVertexPageSize, 16, GraphicsMemory::TAG_SPRITES);
         }
 
         auto vertices = static_cast<VertexPositionColorTexture*>(mVertexSegment.Memory()) + mSpriteCount * VerticesPerSprite;


### PR DESCRIPTION
Adds ``enum GraphicsMemory::Tag`` and a defaulted parameter for ``GraphicsMemory::Allocate`` to take a tag.

> These tags are currently unused on all other platforms.