### PR TITLE
Fix WIC loader bug when using autogen+force-rgba32

### DIFF
--- a/Src/WICTextureLoader.cpp
+++ b/Src/WICTextureLoader.cpp
@@ -758,7 +758,7 @@ HRESULT DirectX::CreateWICTextureFromMemoryEx(
     if (FAILED(hr))
         return hr;
 
-    if (loadFlags & WIC_LOADER_MIP_AUTOGEN)
+    if ((loadFlags & (WIC_LOADER_MIP_AUTOGEN | WIC_LOADER_FORCE_RGBA32)) == WIC_LOADER_MIP_AUTOGEN)
     {
         const DXGI_FORMAT fmt = GetPixelFormat(frame.Get());
         if (!resourceUpload.IsSupportedForGenerateMips(fmt))
@@ -932,7 +932,7 @@ HRESULT DirectX::CreateWICTextureFromFileEx(
     if (FAILED(hr))
         return hr;
 
-    if (loadFlags & WIC_LOADER_MIP_AUTOGEN)
+    if ((loadFlags & (WIC_LOADER_MIP_AUTOGEN | WIC_LOADER_FORCE_RGBA32)) == WIC_LOADER_MIP_AUTOGEN)
     {
         const DXGI_FORMAT fmt = GetPixelFormat(frame.Get());
         if (!resourceUpload.IsSupportedForGenerateMips(fmt))


### PR DESCRIPTION
When using mipmap auto-generation with WIC source files that are BGRA format, the format will not be supported if the driver does not report support for both `D3D12_FEATURE_DATA_D3D12_OPTIONS.TypedUAVLoadAdditionalFormats` and `.StandardSwizzle64KBSupported`.

The "workaround" is to use the force RGBA32 which is always supported, but this combination of flags is not properly validated. This fixes that scenario.