### PR TITLE
Enable HLSL 2021 language model for DXC on Xbox

### DIFF
--- a/Src/Shaders/CompileShaders.cmd
+++ b/Src/Shaders/CompileShaders.cmd
@@ -306,14 +306,14 @@ echo %fxc%
 exit /b
 
 :CompileShaderdxil
-set dxc=%PCDXC% "%1.fx" %FXCOPTS% -HV 2021 /T%2_6_0 /E%3 "/Fh%CompileShadersOutput%\%1_%3.inc" "/Fd%CompileShadersOutput%\%1_%3.pdb" /Vn%1_%3
+set dxc=%PCDXC% "%1.fx" %FXCOPTS% /T%2_6_0 /E%3 "/Fh%CompileShadersOutput%\%1_%3.inc" "/Fd%CompileShadersOutput%\%1_%3.pdb" /Vn%1_%3
 echo.
 echo %dxc%
 %dxc% || set error=1
 exit /b
 
 :CompileComputeShaderdxil
-set dxc=%PCDXC% "%1.hlsl" %FXCOPTS% -HV 2021 /Tcs_6_0 /E%2 "/Fh%CompileShadersOutput%\%1_%2.inc" "/Fd%CompileShadersOutput%\%1_%2.pdb" /Vn%1_%2
+set dxc=%PCDXC% "%1.hlsl" %FXCOPTS% /Tcs_6_0 /E%2 "/Fh%CompileShadersOutput%\%1_%2.inc" "/Fd%CompileShadersOutput%\%1_%2.pdb" /Vn%1_%2
 echo.
 echo %dxc%
 %dxc% || set error=1

--- a/Src/Shaders/CompileShaders.cmd
+++ b/Src/Shaders/CompileShaders.cmd
@@ -306,14 +306,14 @@ echo %fxc%
 exit /b
 
 :CompileShaderdxil
-set dxc=%PCDXC% "%1.fx" %FXCOPTS% /T%2_6_0 /E%3 "/Fh%CompileShadersOutput%\%1_%3.inc" "/Fd%CompileShadersOutput%\%1_%3.pdb" /Vn%1_%3
+set dxc=%PCDXC% "%1.fx" %FXCOPTS% -HV 2021 /T%2_6_0 /E%3 "/Fh%CompileShadersOutput%\%1_%3.inc" "/Fd%CompileShadersOutput%\%1_%3.pdb" /Vn%1_%3
 echo.
 echo %dxc%
 %dxc% || set error=1
 exit /b
 
 :CompileComputeShaderdxil
-set dxc=%PCDXC% "%1.hlsl" %FXCOPTS% /Tcs_6_0 /E%2 "/Fh%CompileShadersOutput%\%1_%2.inc" "/Fd%CompileShadersOutput%\%1_%2.pdb" /Vn%1_%2
+set dxc=%PCDXC% "%1.hlsl" %FXCOPTS% -HV 2021 /Tcs_6_0 /E%2 "/Fh%CompileShadersOutput%\%1_%2.inc" "/Fd%CompileShadersOutput%\%1_%2.pdb" /Vn%1_%2
 echo.
 echo %dxc%
 %dxc% || set error=1
@@ -334,14 +334,14 @@ echo %fxc%
 exit /b
 
 :CompileShadergxdk
-set dxc=%XBOXDXC% "%1.fx" %FXCOPTS% /T%2_6_0 /E%3 "/Fh%CompileShadersOutput%\%XBOXPREFIX%%1_%3.inc" "/Fd%CompileShadersOutput%\%XBOXPREFIX%%1_%3.pdb" /Vn%1_%3
+set dxc=%XBOXDXC% "%1.fx" %FXCOPTS% -HV 2021 /T%2_6_0 /E%3 "/Fh%CompileShadersOutput%\%XBOXPREFIX%%1_%3.inc" "/Fd%CompileShadersOutput%\%XBOXPREFIX%%1_%3.pdb" /Vn%1_%3
 echo.
 echo %dxc%
 %dxc% || set error=1
 exit /b
 
 :CompileComputeShadergxdk
-set dxc=%XBOXDXC% "%1.hlsl" %FXCOPTS% /Tcs_6_0 /E%2 "/Fh%CompileShadersOutput%\%XBOXPREFIX%%1_%2.inc" "/Fd%CompileShadersOutput%\%XBOXPREFIX%%1_%2.pdb" /Vn%1_%2
+set dxc=%XBOXDXC% "%1.hlsl" %FXCOPTS% -HV 2021 /Tcs_6_0 /E%2 "/Fh%CompileShadersOutput%\%XBOXPREFIX%%1_%2.inc" "/Fd%CompileShadersOutput%\%XBOXPREFIX%%1_%2.pdb" /Vn%1_%2
 echo.
 echo %dxc%
 %dxc% || set error=1

--- a/Src/pch.h
+++ b/Src/pch.h
@@ -106,8 +106,8 @@
 #ifdef _GAMING_XBOX
 #include <gxdk.h>
 
-#if _GXDK_VER < 0x4A610D2B /* GXDK Edition 200600 */
-#error DirectX Tool Kit requires the June 2020 GDK or later
+#if _GXDK_VER < 0x55F00C58 /* GXDK Edition 220300 */
+#error DirectX Tool Kit requires the March 2022 GDK or later
 #endif
 
 #ifdef _GAMING_XBOX_SCARLETT
@@ -137,8 +137,8 @@
 #ifdef _GAMING_DESKTOP
 #include <grdk.h>
 
-#if _GRDK_VER < 0x47BB2070 /* GDK Edition 191102 */
-#error DirectX Tool Kit requires the November 2020 GDK QFE2 or later
+#if _GRDK_VER < 0x4A611B35 /* GDK Edition 210600 */
+#error DirectX Tool Kit requires June 2021 GDK or later
 #endif
 #endif
 


### PR DESCRIPTION
Per [this blog post](https://devblogs.microsoft.com/directx/announcing-hlsl-2021/) there is a new HLSL language syntax supported by DXC. This will eventually become the default, so we explicitly opt into it for the toolkit shaders for Xbox.

> For all Windows SDKs prior to 22621, the ``-HV 2021`` switch results in "unknown version". As such, we don't use it yet for PC.

Also updated minimum guards for GDK versions (June 2021 for GDK, March 2022 for GDXK)