### PR TITLE
Fixed missing __cdecl on ReportCustomMemoryAlloc static method

### DIFF
--- a/Inc/GraphicsMemory.h
+++ b/Inc/GraphicsMemory.h
@@ -217,7 +217,7 @@ namespace DirectX
 
 #ifdef USING_PIX_CUSTOM_MEMORY_EVENTS
             // The declspec is required to ensure the proper information is captured in the PDB
-            __declspec(allocator) static void* ReportCustomMemoryAlloc(void* pMem, size_t size, UINT64 metadata);
+            __declspec(allocator) static void* __cdecl ReportCustomMemoryAlloc(void* pMem, size_t size, UINT64 metadata);
 #endif
 
             std::unique_ptr<Impl> pImpl;

--- a/Src/Model.cpp
+++ b/Src/Model.cpp
@@ -188,36 +188,36 @@ ModelMesh::~ModelMesh()
 }
 
 // Draw the mesh
-void __cdecl ModelMesh::DrawOpaque(_In_ ID3D12GraphicsCommandList* commandList) const
+void ModelMesh::DrawOpaque(_In_ ID3D12GraphicsCommandList* commandList) const
 {
     ModelMeshPart::DrawMeshParts(commandList, opaqueMeshParts);
 }
 
-void __cdecl ModelMesh::DrawAlpha(_In_ ID3D12GraphicsCommandList* commandList) const
+void ModelMesh::DrawAlpha(_In_ ID3D12GraphicsCommandList* commandList) const
 {
     ModelMeshPart::DrawMeshParts(commandList, alphaMeshParts);
 }
 
 
 // Draw the mesh with an effect
-void __cdecl ModelMesh::DrawOpaque(_In_ ID3D12GraphicsCommandList* commandList, _In_ IEffect* effect) const
+void ModelMesh::DrawOpaque(_In_ ID3D12GraphicsCommandList* commandList, _In_ IEffect* effect) const
 {
     ModelMeshPart::DrawMeshParts(commandList, opaqueMeshParts, effect);
 }
 
-void __cdecl ModelMesh::DrawAlpha(_In_ ID3D12GraphicsCommandList* commandList, _In_ IEffect* effect) const
+void ModelMesh::DrawAlpha(_In_ ID3D12GraphicsCommandList* commandList, _In_ IEffect* effect) const
 {
     ModelMeshPart::DrawMeshParts(commandList, alphaMeshParts, effect);
 }
 
 
 // Draw the mesh with a callback for each mesh part
-void __cdecl ModelMesh::DrawOpaque(_In_ ID3D12GraphicsCommandList* commandList, ModelMeshPart::DrawCallback callback) const
+void ModelMesh::DrawOpaque(_In_ ID3D12GraphicsCommandList* commandList, ModelMeshPart::DrawCallback callback) const
 {
     ModelMeshPart::DrawMeshParts(commandList, opaqueMeshParts, callback);
 }
 
-void __cdecl ModelMesh::DrawAlpha(_In_ ID3D12GraphicsCommandList* commandList, ModelMeshPart::DrawCallback callback) const
+void ModelMesh::DrawAlpha(_In_ ID3D12GraphicsCommandList* commandList, ModelMeshPart::DrawCallback callback) const
 {
     ModelMeshPart::DrawMeshParts(commandList, alphaMeshParts, callback);
 }

--- a/Src/ResourceUploadBatch.cpp
+++ b/Src/ResourceUploadBatch.cpp
@@ -1123,7 +1123,7 @@ std::future<void> ResourceUploadBatch::End(_In_ ID3D12CommandQueue* commandQueue
 }
 
 
-bool __cdecl ResourceUploadBatch::IsSupportedForGenerateMips(DXGI_FORMAT format) noexcept
+bool ResourceUploadBatch::IsSupportedForGenerateMips(DXGI_FORMAT format) noexcept
 {
     return pImpl->IsSupportedForGenerateMips(format);
 }


### PR DESCRIPTION
This fixes a missed header function in GraphicsMemory for Xbox which needed ``__cdecl`` (see #180)

The library uses explicit ``__cdecl`` decoration in the header to ensure that on x86/x64, the calling convention is consistent with how the library is built (i.e. it uses /Gd for x64/x86) no matter which default calling-convention the client code is using.

In most cases you only need to decorate the header declaration of a function, but you also need to decorate the definition in a few specific cases:

* Free functions (i.e. not class member methods)

* Virtual overrides