### PR TITLE
Add CreateUploadBuffer and CreateUAVBuffer helpers

### DIFF
--- a/Inc/BufferHelpers.h
+++ b/Inc/BufferHelpers.h
@@ -61,6 +61,36 @@ namespace DirectX
             afterState, pBuffer, resFlags);
     }
 
+    HRESULT __cdecl CreateUploadBuffer(_In_ ID3D12Device* device,
+        _In_reads_bytes_(count* stride) const void* ptr,
+        size_t count,
+        size_t stride,
+        _COM_Outptr_ ID3D12Resource** pBuffer,
+        D3D12_RESOURCE_STATES initialState = D3D12_RESOURCE_STATE_GENERIC_READ,
+        D3D12_RESOURCE_FLAGS resFlags = D3D12_RESOURCE_FLAG_NONE) noexcept;
+
+    template<typename T>
+    HRESULT CreateUploadBuffer(_In_ ID3D12Device* device,
+        _In_reads_(count) T const* data,
+        size_t count,
+        _COM_Outptr_ ID3D12Resource** pBuffer,
+        D3D12_RESOURCE_STATES initialState = D3D12_RESOURCE_STATE_GENERIC_READ,
+        D3D12_RESOURCE_FLAGS resFlags = D3D12_RESOURCE_FLAG_NONE) noexcept
+    {
+        return CreateUploadBuffer(device, data, count, sizeof(T), pBuffer, initialState, resFlags);
+    }
+
+    template<typename T>
+    HRESULT CreateUploadBuffer(_In_ ID3D12Device* device,
+        T const& data,
+        _COM_Outptr_ ID3D12Resource** pBuffer,
+        D3D12_RESOURCE_STATES initialState = D3D12_RESOURCE_STATE_GENERIC_READ,
+        D3D12_RESOURCE_FLAGS resFlags = D3D12_RESOURCE_FLAG_NONE) noexcept
+    {
+        return CreateUploadBuffer(device, data.data(), data.size(), sizeof(typename T::value_type),
+            pBuffer, initialState, resFlags);
+    }
+
     // Helpers for creating texture from memory arrays.
     HRESULT __cdecl CreateTextureFromMemory(_In_ ID3D12Device* device,
         ResourceUploadBatch& resourceUpload,

--- a/Inc/BufferHelpers.h
+++ b/Inc/BufferHelpers.h
@@ -61,8 +61,14 @@ namespace DirectX
             afterState, pBuffer, resFlags);
     }
 
+    HRESULT __cdecl CreateUAVBuffer(_In_ ID3D12Device* device,
+        uint64_t bufferSize,
+        _COM_Outptr_ ID3D12Resource** pBuffer,
+        D3D12_RESOURCE_STATES initialState = D3D12_RESOURCE_STATE_COMMON,
+        D3D12_RESOURCE_FLAGS additionalResFlags = D3D12_RESOURCE_FLAG_NONE) noexcept;
+
     HRESULT __cdecl CreateUploadBuffer(_In_ ID3D12Device* device,
-        _In_reads_bytes_(count* stride) const void* ptr,
+        _In_reads_bytes_opt_(count* stride) const void* ptr,
         size_t count,
         size_t stride,
         _COM_Outptr_ ID3D12Resource** pBuffer,

--- a/Inc/BufferHelpers.h
+++ b/Inc/BufferHelpers.h
@@ -21,6 +21,7 @@
 #endif
 
 #include <cstddef>
+#include <cstdint>
 
 
 namespace DirectX

--- a/Src/BufferHelpers.cpp
+++ b/Src/BufferHelpers.cpp
@@ -88,6 +88,64 @@ HRESULT DirectX::CreateStaticBuffer(
 
 //--------------------------------------------------------------------------------------
 _Use_decl_annotations_
+HRESULT DirectX::CreateUploadBuffer(
+    ID3D12Device* device,
+    const void* ptr,
+    size_t count,
+    size_t stride,
+    ID3D12Resource** pBuffer,
+    D3D12_RESOURCE_STATES initialState,
+    D3D12_RESOURCE_FLAGS resFlags) noexcept
+{
+    if (!pBuffer)
+        return E_INVALIDARG;
+
+    *pBuffer = nullptr;
+
+    if (!device || !ptr || !count || !stride)
+        return E_INVALIDARG;
+
+    const uint64_t sizeInbytes = uint64_t(count) * uint64_t(stride);
+
+    static constexpr uint64_t c_maxBytes = D3D12_REQ_RESOURCE_SIZE_IN_MEGABYTES_EXPRESSION_A_TERM * 1024u * 1024u;
+
+    if (sizeInbytes > c_maxBytes)
+    {
+        DebugTrace("ERROR: Resource size too large for DirectX 12 (size %llu)\n", sizeInbytes);
+        return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
+    }
+
+    auto const desc = CD3DX12_RESOURCE_DESC::Buffer(sizeInbytes, resFlags);
+
+    const CD3DX12_HEAP_PROPERTIES heapProperties(D3D12_HEAP_TYPE_UPLOAD);
+
+    ComPtr<ID3D12Resource> res;
+    HRESULT hr = device->CreateCommittedResource(
+        &heapProperties,
+        D3D12_HEAP_FLAG_NONE,
+        &desc,
+        initialState,
+        nullptr,
+        IID_GRAPHICS_PPV_ARGS(res.GetAddressOf()));
+    if (FAILED(hr))
+        return hr;
+
+    void* mappedPtr = nullptr;
+    hr = res->Map(0, nullptr, &mappedPtr);
+    if (FAILED(hr))
+        return hr;
+
+    memcpy(mappedPtr, ptr, sizeInbytes);
+    res->Unmap(0, nullptr);
+
+    *pBuffer = res.Detach();
+
+    return S_OK;
+}
+
+
+//--------------------------------------------------------------------------------------
+_Use_decl_annotations_
 HRESULT DirectX::CreateTextureFromMemory(
     ID3D12Device* device,
     ResourceUploadBatch& resourceUpload,

--- a/Src/BufferHelpers.cpp
+++ b/Src/BufferHelpers.cpp
@@ -183,7 +183,7 @@ HRESULT DirectX::CreateUploadBuffer(
         if (FAILED(hr))
             return hr;
 
-        memcpy(mappedPtr, ptr, sizeInbytes);
+        memcpy(mappedPtr, ptr, static_cast<const size_t>(sizeInbytes));
         res->Unmap(0, nullptr);
     }
 


### PR DESCRIPTION
The ``CreateStaticBuffer`` helper is designed to create a DEFAULT resource and initialize it with data uploaded via a ResourceUploadBatch.

This PR adds ``CreateUploadBuffer`` which creates an UPLOAD resource and initializes it via a direct Map/Unmap cycle since it's CPU accessible. If you pass a ``nullptr`` for the data, it just creates the UPLOAD resource.

This also adds ``CreateUAVBuffer`` which is just a simple way to create a UAV resource since that's common for DXR and DirectCompute scenarios.
