### PR TITLE
Add c_initialRead/UAVTargetState to help with PC vs. Xbox warnings

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -307,6 +307,9 @@
     { "name": "arm64-Debug"  , "configurePreset": "arm64-Debug" },
     { "name": "arm64-Release", "configurePreset": "arm64-Release" },
 
+    { "name": "x64-Debug-VCPKG"    , "configurePreset": "x64-Debug-VCPKG" },
+    { "name": "x64-Release-VCPKG"  , "configurePreset": "x64-Release-VCPKG" },
+
     { "name": "x64-Debug-Clang"    , "configurePreset": "x64-Debug-Clang" },
     { "name": "x64-Release-Clang"  , "configurePreset": "x64-Release-Clang" },
     { "name": "x86-Debug-Clang"    , "configurePreset": "x86-Debug-Clang" },

--- a/Inc/DirectXHelpers.h
+++ b/Inc/DirectXHelpers.h
@@ -118,9 +118,11 @@ namespace DirectX
 #if (defined(_XBOX_ONE) && defined(_TITLE)) || defined(_GAMING_XBOX)
     constexpr D3D12_RESOURCE_STATES c_initialCopyTargetState = D3D12_RESOURCE_STATE_COPY_DEST;
     constexpr D3D12_RESOURCE_STATES c_initialReadTargetState = D3D12_RESOURCE_STATE_GENERIC_READ;
+    constexpr D3D12_RESOURCE_STATES c_initialUAVTargetState = D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
 #else
     constexpr D3D12_RESOURCE_STATES c_initialCopyTargetState = D3D12_RESOURCE_STATE_COMMON;
     constexpr D3D12_RESOURCE_STATES c_initialReadTargetState = D3D12_RESOURCE_STATE_COMMON;
+    constexpr D3D12_RESOURCE_STATES c_initialUAVTargetState = D3D12_RESOURCE_STATE_COMMON;
 #endif
 
     constexpr D3D12_CPU_DESCRIPTOR_HANDLE D3D12_CPU_DESCRIPTOR_HANDLE_ZERO = {};

--- a/Inc/DirectXHelpers.h
+++ b/Inc/DirectXHelpers.h
@@ -117,8 +117,10 @@ namespace DirectX
 {
 #if (defined(_XBOX_ONE) && defined(_TITLE)) || defined(_GAMING_XBOX)
     constexpr D3D12_RESOURCE_STATES c_initialCopyTargetState = D3D12_RESOURCE_STATE_COPY_DEST;
+    constexpr D3D12_RESOURCE_STATES c_initialReadTargetState = D3D12_RESOURCE_STATE_GENERIC_READ;
 #else
     constexpr D3D12_RESOURCE_STATES c_initialCopyTargetState = D3D12_RESOURCE_STATE_COMMON;
+    constexpr D3D12_RESOURCE_STATES c_initialReadTargetState = D3D12_RESOURCE_STATE_COMMON;
 #endif
 
     constexpr D3D12_CPU_DESCRIPTOR_HANDLE D3D12_CPU_DESCRIPTOR_HANDLE_ZERO = {};


### PR DESCRIPTION
The PC debug layer will warn in places where you are using specific resource states when common-state promotion handles it. On Xbox, common-state is opt-in. To support this, there are some defines in DirectXHelpers.h to provide the optimal state for Xbox vs. PC. This PR two more.