### PR TITLE
Rename Internal namespace to ToolKitInternal for some conformance issues

### DIFF
--- a/Src/ScreenGrab.cpp
+++ b/Src/ScreenGrab.cpp
@@ -443,7 +443,7 @@ namespace DirectX
 {
     inline namespace DX12
     {
-        namespace Internal
+        namespace ToolKitInternal
         {
             extern IWICImagingFactory2* GetWIC() noexcept;
         }
@@ -462,7 +462,7 @@ HRESULT DirectX::SaveWICTextureToFile(
     std::function<void(IPropertyBag2*)> setCustomProps,
     bool forceSRGB)
 {
-    using namespace DirectX::DX12::Internal;
+    using namespace DirectX::DX12::ToolKitInternal;
 
     if (!fileName)
         return E_INVALIDARG;

--- a/Src/WICTextureLoader.cpp
+++ b/Src/WICTextureLoader.cpp
@@ -164,7 +164,7 @@ namespace DirectX
 {
     inline namespace DX12
     {
-        namespace Internal
+        namespace ToolKitInternal
         {
             IWICImagingFactory2* GetWIC() noexcept;
             // Also used by ScreenGrab
@@ -172,7 +172,7 @@ namespace DirectX
     }
 }
 
-IWICImagingFactory2* DirectX::DX12::Internal::GetWIC() noexcept
+IWICImagingFactory2* DirectX::DX12::ToolKitInternal::GetWIC() noexcept
 {
     static INIT_ONCE s_initOnce = INIT_ONCE_STATIC_INIT;
 
@@ -189,7 +189,7 @@ IWICImagingFactory2* DirectX::DX12::Internal::GetWIC() noexcept
     return factory;
 }
 
-using namespace DirectX::DX12::Internal;
+using namespace DirectX::DX12::ToolKitInternal;
 
 namespace
 {


### PR DESCRIPTION
I used the ``DirectX::Internal`` namespace in some other contents, and in particular I used an inline namespace ``DirectX::DX12`` with an ``Internal`` namespace. This confuses some compilers and resulted in build failures. As a solution, I just renamed the internal namespaces to something more unique.