### PR TITLE
Added GitHub Actions for build and security analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,11 +48,11 @@ jobs:
         build-mode: manual
 
     - name: 'Configure CMake'
-      working-directory: ${{env.GITHUB_WORKSPACE}}
+      working-directory: ${{ github.workspace }}
       run: cmake --preset=x64-Debug
 
     - name: 'Build'
-      working-directory: ${{env.GITHUB_WORKSPACE}}
+      working-directory: ${{ github.workspace }}
       run: cmake --build out\build\x64-Debug
 
     - name: Perform CodeQL Analysis

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,61 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# http://go.microsoft.com/fwlink/?LinkID=615561
+
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.nuget/*'
+      - build/*.cmd
+      - build/*.json
+      - build/*.props
+      - build/*.ps1
+      - build/*.targets
+      - build/*.yml
+  schedule:
+    - cron: '19 7 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (C/C++)
+    runs-on: windows-latest
+    timeout-minutes: 360
+    permissions:
+      security-events: write
+      packages: read
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: 'Install Ninja'
+      run: choco install ninja
+
+    - uses: ilammy/msvc-dev-cmd@v1
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: c-cpp
+        build-mode: manual
+
+    - name: 'Configure CMake'
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: cmake --preset=x64-Debug
+
+    - name: 'Build'
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: cmake --build out\build\x64-Debug
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:c-cpp"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,9 +81,9 @@ jobs:
         arch: ${{ matrix.arch }}
 
     - name: 'Configure CMake'
-      working-directory: ${{env.GITHUB_WORKSPACE}}
+      working-directory: ${{ github.workspace }}
       run: cmake --preset=${{ matrix.build_type }}
 
     - name: 'Build'
-      working-directory: ${{env.GITHUB_WORKSPACE}}
+      working-directory: ${{ github.workspace }}
       run: cmake --build out\build\${{ matrix.build_type }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,3 +87,13 @@ jobs:
     - name: 'Build'
       working-directory: ${{ github.workspace }}
       run: cmake --build out\build\${{ matrix.build_type }}
+
+    - if: matrix.arch != 'amd64_arm64'
+      name: 'Configure CMake (Spectre)'
+      working-directory: ${{ github.workspace }}
+      run: cmake --preset=${{ matrix.build_type }} -DENABLE_SPECTRE_MITIGATION=ON
+
+    - if: matrix.arch != 'amd64_arm64'
+      name: 'Build (Spectre)'
+      working-directory: ${{ github.workspace }}
+      run: cmake --build out\build\${{ matrix.build_type }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,89 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# http://go.microsoft.com/fwlink/?LinkID=615561
+
+name: 'CMake (Windows)'
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.nuget/*'
+      - build/*.cmd
+      - build/*.json
+      - build/*.props
+      - build/*.ps1
+      - build/*.targets
+      - build/*.yml
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        os: [windows-2019, windows-2022]
+        build_type: [x64-Debug, x64-Release, x64-Debug-Clang, x64-Release-Clang]
+        arch: [amd64]
+        include:
+          - os: windows-2019
+            build_type: x86-Debug
+            arch: amd64_x86
+          - os: windows-2019
+            build_type: x86-Release
+            arch: amd64_x86
+          - os: windows-2019
+            build_type: x86-Debug-Clang
+            arch: amd64_x86
+          - os: windows-2019
+            build_type: x86-Release-Clang
+            arch: amd64_x86
+          - os: windows-2022
+            build_type: x86-Debug
+            arch: amd64_x86
+          - os: windows-2022
+            build_type: x86-Release
+            arch: amd64_x86
+          - os: windows-2022
+            build_type: x86-Debug-Clang
+            arch: amd64_x86
+          - os: windows-2022
+            build_type: x86-Release-Clang
+            arch: amd64_x86
+          - os: windows-2022
+            build_type: arm64-Debug
+            arch: amd64_arm64
+          - os: windows-2022
+            build_type: arm64-Release
+            arch: amd64_arm64
+          - os: windows-2022
+            build_type: arm64ec-Debug
+            arch: amd64_arm64
+          - os: windows-2022
+            build_type: arm64ec-Release
+            arch: amd64_arm64
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: 'Install Ninja'
+      run: choco install ninja
+
+    - uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: ${{ matrix.arch }}
+
+    - name: 'Configure CMake'
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: cmake --preset=${{ matrix.build_type }}
+
+    - name: 'Build'
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: cmake --build out\build\${{ matrix.build_type }}

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -47,11 +47,6 @@ jobs:
       run: msbuild /m /p:Configuration=${{ matrix.build_type }} /p:Platform=${{ matrix.platform }} ./DirectXTK_Windows10_2022.sln
 
     - if: matrix.platform != 'ARM64'
-      name: 'Build (Spectre)'
-      working-directory: ${{ github.workspace }}
-      run: msbuild /m /p:SpectreMitigation=Spectre /p:Configuration=${{ matrix.build_type }} /p:Platform=${{ matrix.platform }} ./DirectXTK_Desktop_${{ matrix.vs }}.sln
-
-    - if: matrix.platform != 'ARM64'
       name: 'Build (Spectre Windows 10)'
       working-directory: ${{ github.workspace }}
       run: msbuild /m /p:SpectreMitigation=Spectre /p:Configuration=${{ matrix.build_type }} /p:Platform=${{ matrix.platform }} ./DirectXTK_Desktop_${{ matrix.vs }}_Win10.sln

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -1,0 +1,47 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# http://go.microsoft.com/fwlink/?LinkID=615561
+
+name: MSBuild
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.nuget/*'
+      - build/*
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: windows-${{ matrix.vs }}
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        vs: [2019, 2022]
+        build_type: [Debug, Release]
+        platform: [x86, x64, ARM64]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v2
+
+    - name: 'Build'
+      working-directory: ${{ github.workspace }}
+      run: msbuild /m /p:Configuration=${{ matrix.build_type }} /p:Platform=${{ matrix.platform }} ./DirectXMesh_Desktop_${{ matrix.vs }}_Win10.sln
+
+    - if: matrix.vs == '2022'
+      name: 'Build (UWP)'
+      working-directory: ${{ github.workspace }}
+      run: msbuild /m /p:Configuration=${{ matrix.build_type }} /p:Platform=${{ matrix.platform }} ./DirectXMesh_Windows10_2022.sln

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -39,9 +39,9 @@ jobs:
 
     - name: 'Build'
       working-directory: ${{ github.workspace }}
-      run: msbuild /m /p:Configuration=${{ matrix.build_type }} /p:Platform=${{ matrix.platform }} ./DirectXMesh_Desktop_${{ matrix.vs }}_Win10.sln
+      run: msbuild /m /p:Configuration=${{ matrix.build_type }} /p:Platform=${{ matrix.platform }} ./DirectXTK_Desktop_${{ matrix.vs }}_Win10.sln
 
     - if: matrix.vs == '2022'
       name: 'Build (UWP)'
       working-directory: ${{ github.workspace }}
-      run: msbuild /m /p:Configuration=${{ matrix.build_type }} /p:Platform=${{ matrix.platform }} ./DirectXMesh_Windows10_2022.sln
+      run: msbuild /m /p:Configuration=${{ matrix.build_type }} /p:Platform=${{ matrix.platform }} ./DirectXTK_Windows10_2022.sln

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -45,3 +45,13 @@ jobs:
       name: 'Build (UWP)'
       working-directory: ${{ github.workspace }}
       run: msbuild /m /p:Configuration=${{ matrix.build_type }} /p:Platform=${{ matrix.platform }} ./DirectXTK_Windows10_2022.sln
+
+    - if: matrix.platform != 'ARM64'
+      name: 'Build (Spectre)'
+      working-directory: ${{ github.workspace }}
+      run: msbuild /m /p:SpectreMitigation=Spectre /p:Configuration=${{ matrix.build_type }} /p:Platform=${{ matrix.platform }} ./DirectXTK_Desktop_${{ matrix.vs }}.sln
+
+    - if: matrix.platform != 'ARM64'
+      name: 'Build (Spectre Windows 10)'
+      working-directory: ${{ github.workspace }}
+      run: msbuild /m /p:SpectreMitigation=Spectre /p:Configuration=${{ matrix.build_type }} /p:Platform=${{ matrix.platform }} ./DirectXTK_Desktop_${{ matrix.vs }}_Win10.sln

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -39,6 +39,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: amd64
+
       - name: Configure CMake
         working-directory: ${{ github.workspace }}
         run: cmake -B out -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON
@@ -46,7 +50,7 @@ jobs:
       - name: 'Build Shaders'
         shell: cmd
         working-directory: ./Src/Shaders
-        run: CompileShaders.cmd
+        run: CompileShaders.cmd dxil
         env:
           CompileShadersOutput: ${{ github.workspace }}/out/Shaders/Compiled
 

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -40,8 +40,15 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Configure CMake
-        working-directory: ${{env.GITHUB_WORKSPACE}}
+        working-directory: ${{ github.workspace }}
         run: cmake -B out -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON
+
+      - name: 'Build Shaders'
+        shell: cmd
+        working-directory: ./Src/Shaders
+        run: CompileShaders.cmd
+        env:
+          CompileShadersOutput: ${{ github.workspace }}/out/Shaders/Compiled
 
       - name: Initialize MSVC Code Analysis
         uses: microsoft/msvc-code-analysis-action@v0.1.1

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -1,0 +1,58 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# http://go.microsoft.com/fwlink/?LinkID=615561
+
+name: Microsoft C++ Code Analysis
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.nuget/*'
+      - build/*.cmd
+      - build/*.json
+      - build/*.props
+      - build/*.ps1
+      - build/*.targets
+      - build/*.yml
+  schedule:
+    - cron: '20 21 * * 2'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    name: Analyze
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Configure CMake
+        working-directory: ${{env.GITHUB_WORKSPACE}}
+        run: cmake -B out -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON
+
+      - name: Initialize MSVC Code Analysis
+        uses: microsoft/msvc-code-analysis-action@v0.1.1
+        id: run-analysis
+        with:
+          cmakeBuildDirectory: ./out
+          buildConfiguration: Debug
+          ruleset: NativeRecommendedRules.ruleset
+
+      # Upload SARIF file to GitHub Code Scanning Alerts
+      - name: Upload SARIF to GitHub
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ${{ steps.run-analysis.outputs.sarif }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,103 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# http://go.microsoft.com/fwlink/?LinkID=615561
+
+name: 'CTest (Windows)'
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.nuget/*'
+      - build/*.cmd
+      - build/*.json
+      - build/*.props
+      - build/*.ps1
+      - build/*.targets
+      - build/*.yml
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        os: [windows-2019, windows-2022]
+        build_type: [x64-Debug, x64-Release, x64-Debug-Clang, x64-Release-Clang]
+        arch: [amd64]
+        include:
+          - os: windows-2019
+            build_type: x86-Debug
+            arch: amd64_x86
+          - os: windows-2019
+            build_type: x86-Release
+            arch: amd64_x86
+          - os: windows-2019
+            build_type: x86-Debug-Clang
+            arch: amd64_x86
+          - os: windows-2019
+            build_type: x86-Release-Clang
+            arch: amd64_x86
+          - os: windows-2022
+            build_type: x86-Debug
+            arch: amd64_x86
+          - os: windows-2022
+            build_type: x86-Release
+            arch: amd64_x86
+          - os: windows-2022
+            build_type: x86-Debug-Clang
+            arch: amd64_x86
+          - os: windows-2022
+            build_type: x86-Release-Clang
+            arch: amd64_x86
+          - os: windows-2022
+            build_type: arm64-Debug
+            arch: amd64_arm64
+          - os: windows-2022
+            build_type: arm64-Release
+            arch: amd64_arm64
+          - os: windows-2022
+            build_type: arm64ec-Debug
+            arch: amd64_arm64
+          - os: windows-2022
+            build_type: arm64ec-Release
+            arch: amd64_arm64
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Clone test repository
+      uses: actions/checkout@v4
+      with:
+        repository: walbourn/directxtk12test
+        path: Tests
+        ref: main
+
+    - name: 'Install Ninja'
+      run: choco install ninja
+
+    - uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: ${{ matrix.arch }}
+
+    - name: 'Configure CMake'
+      working-directory: ${{ github.workspace }}
+      run: cmake --preset=${{ matrix.build_type }} -DBUILD_TESTING=ON
+
+    - name: 'Build'
+      working-directory: ${{ github.workspace }}
+      run: cmake --build out\build\${{ matrix.build_type }}
+
+    - if: (matrix.build_type == 'x64-Release') || (matrix.build_type == 'x86-Release')
+      timeout-minutes: 10
+      name: 'Test (Math only)'
+      working-directory: ${{ github.workspace }}
+      run: ctest --preset=${{ matrix.build_type }} -L Math

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -320,6 +320,8 @@
     { "name": "x86-Release"  , "configurePreset": "x86-Release" },
     { "name": "arm64-Debug"  , "configurePreset": "arm64-Debug" },
     { "name": "arm64-Release", "configurePreset": "arm64-Release" },
+    { "name": "arm64ec-Debug"  , "configurePreset": "arm64ec-Debug" },
+    { "name": "arm64ec-Release", "configurePreset": "arm64ec-Release" },
 
     { "name": "x64-Debug-VCPKG"    , "configurePreset": "x64-Debug-VCPKG" },
     { "name": "x64-Release-VCPKG"  , "configurePreset": "x64-Release-VCPKG" },

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -172,6 +172,15 @@
       }
     },
     {
+      "name": "X64_ARM64EC",
+      "hidden": true,
+      "cacheVariables": {
+        "VCPKG_TARGET_TRIPLET": "arm64ec-windows",
+        "VCPKG_HOST_TRIPLET": "x64-windows",
+        "DIRECTX_DXC_PATH": "$env{VCPKG_ROOT}/installed/x64-windows/tools/directx-dxc"
+      }
+    },
+    {
       "name": "ARM64_ARM64",
       "hidden": true,
       "cacheVariables": {
@@ -279,6 +288,8 @@
     { "name": "arm64-Release-VCPKG"       , "description": "MSVC for ARM64 (Release)", "inherits": [ "base", "ARM64", "Release", "MSVC", "VCPKG", "X64_ARM64" ] },
     { "name": "arm64-Native-Debug-VCPKG"  , "description": "MSVC for ARM64 Native (Debug)", "inherits": [ "base", "ARM64", "Debug", "MSVC", "VCPKG", "ARM64_ARM64" ] },
     { "name": "arm64-Native-Release-VCPKG", "description": "MSVC for ARM64 Native (Release)", "inherits": [ "base", "ARM64", "Release", "MSVC", "VCPKG", "ARM64_ARM64" ] },
+    { "name": "arm64ec-Debug-VCPKG"       , "description": "MSVC for ARM64EC (Debug)", "inherits": [ "base", "ARM64EC", "Debug", "MSVC", "VCPKG", "X64_ARM64EC" ], "environment": { "CXXFLAGS": "/arm64EC" } },
+    { "name": "arm64ec-Release-VCPKG"     , "description": "MSVC for ARM64EC (Release)", "inherits": [ "base", "ARM64EC", "Release", "MSVC", "VCPKG", "X64_ARM64EC" ], "environment": { "CXXFLAGS": "/arm64EC" } },
 
     { "name": "x64-Debug-Clang"    , "description": "Clang/LLVM for x64 (Debug) for Windows 10", "inherits": [ "base", "x64", "Debug", "Clang" ] },
     { "name": "x64-Release-Clang"  , "description": "Clang/LLVM for x64 (Release) for Windows 10", "inherits": [ "base", "x64", "Release", "Clang" ] },

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -249,8 +249,8 @@
     { "name": "x86-Release"      , "description": "MSVC for x86 (Release) for Windows 10", "inherits": [ "base", "x86", "Release", "MSVC" ] },
     { "name": "arm64-Debug"      , "description": "MSVC for ARM64 (Debug) for Windows 10", "inherits": [ "base", "ARM64", "Debug", "MSVC" ] },
     { "name": "arm64-Release"    , "description": "MSVC for ARM64 (Release) for Windows 10", "inherits": [ "base", "ARM64", "Release", "MSVC" ] },
-    { "name": "arm64ec-Debug"      , "description": "MSVC for ARM64EC (Debug) for Windows 10", "inherits": [ "base", "ARM64EC", "Debug", "MSVC" ], "environment": { "CXXFLAGS": "/arm64EC" } },
-    { "name": "arm64ec-Release"    , "description": "MSVC for ARM64EC (Release) for Windows 10", "inherits": [ "base", "ARM64EC", "Release", "MSVC" ], "environment": { "CXXFLAGS": "/arm64EC" } },
+    { "name": "arm64ec-Debug"    , "description": "MSVC for ARM64EC (Debug) for Windows 10", "inherits": [ "base", "ARM64EC", "Debug", "MSVC" ], "environment": { "CXXFLAGS": "/arm64EC" } },
+    { "name": "arm64ec-Release"  , "description": "MSVC for ARM64EC (Release) for Windows 10", "inherits": [ "base", "ARM64EC", "Release", "MSVC" ], "environment": { "CXXFLAGS": "/arm64EC" } },
 
     { "name": "x64-Debug-UWP"    , "description": "MSVC for x64 (Debug) for UWP", "inherits": [ "base", "x64", "Debug", "MSVC", "UWP" ] },
     { "name": "x64-Release-UWP"  , "description": "MSVC for x64 (Release) for UWP", "inherits": [ "base", "x64", "Release", "MSVC", "UWP" ] },
@@ -285,7 +285,7 @@
     { "name": "x86-Debug-Clang"    , "description": "Clang/LLVM for x86 (Debug) for Windows 10", "inherits": [ "base", "x86", "Debug", "Clang" ], "environment": { "CXXFLAGS": "-m32" } },
     { "name": "x86-Release-Clang"  , "description": "Clang/LLVM for x86 (Debug) for Windows 10", "inherits": [ "base", "x86", "Release", "Clang" ], "environment": { "CXXFLAGS": "-m32" } },
     { "name": "arm64-Debug-Clang"  , "description": "Clang/LLVM for AArch64 (Debug) for Windows 10", "inherits": [ "base", "ARM64", "Debug", "Clang" ], "environment": { "CXXFLAGS": "--target=arm64-pc-windows-msvc" } },
-    { "name": "arm64-Release-Clang", "description": "Clang/LLVM for AArch64 (Debug) for Windows 10", "inherits": [ "base", "ARM64", "Release", "Clang" ], "environment": { "CXXFLAGS": "--target=arm64-pc-windows-msvc" } },
+    { "name": "arm64-Release-Clang", "description": "Clang/LLVM for AArch64 (Release) for Windows 10", "inherits": [ "base", "ARM64", "Release", "Clang" ], "environment": { "CXXFLAGS": "--target=arm64-pc-windows-msvc" } },
 
     { "name": "x64-Debug-UWP-Clang"    , "description": "Clang/LLVM for x64 (Debug) for UWP", "inherits": [ "base", "x64", "Debug", "Clang", "UWP" ] },
     { "name": "x64-Release-UWP-Clang"  , "description": "Clang/LLVM for x64 (Release) for UWP", "inherits": [ "base", "x64", "Release", "Clang", "UWP" ] },
@@ -314,12 +314,12 @@
     { "name": "x64-Fuzzing"      , "description": "MSVC for x64 (Release) with ASan", "inherits": [ "base", "x64", "Release", "MSVC", "Fuzzing" ] }
   ],
   "testPresets": [
-    { "name": "x64-Debug"    , "configurePreset": "x64-Debug" },
-    { "name": "x64-Release"  , "configurePreset": "x64-Release" },
-    { "name": "x86-Debug"    , "configurePreset": "x86-Debug" },
-    { "name": "x86-Release"  , "configurePreset": "x86-Release" },
-    { "name": "arm64-Debug"  , "configurePreset": "arm64-Debug" },
-    { "name": "arm64-Release", "configurePreset": "arm64-Release" },
+    { "name": "x64-Debug"      , "configurePreset": "x64-Debug" },
+    { "name": "x64-Release"    , "configurePreset": "x64-Release" },
+    { "name": "x86-Debug"      , "configurePreset": "x86-Debug" },
+    { "name": "x86-Release"    , "configurePreset": "x86-Release" },
+    { "name": "arm64-Debug"    , "configurePreset": "arm64-Debug" },
+    { "name": "arm64-Release"  , "configurePreset": "arm64-Release" },
     { "name": "arm64ec-Debug"  , "configurePreset": "arm64ec-Debug" },
     { "name": "arm64ec-Release", "configurePreset": "arm64ec-Release" },
 

--- a/build/DirectXTK12-GitHub-CMake-Dev17.yml
+++ b/build/DirectXTK12-GitHub-CMake-Dev17.yml
@@ -3,7 +3,7 @@
 #
 # http://go.microsoft.com/fwlink/?LinkID=615561
 
-# Builds the library using CMake.
+# Builds the library using CMake with VS Generator (GitHub Actions covers Ninja).
 
 schedules:
 - cron: "0 6 * * *"

--- a/build/DirectXTK12-GitHub-CMake-Dev17.yml
+++ b/build/DirectXTK12-GitHub-CMake-Dev17.yml
@@ -20,6 +20,7 @@ trigger:
     exclude:
     - '*.md'
     - LICENSE
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmd
     - build/*.json
@@ -36,6 +37,7 @@ pr:
     exclude:
     - '*.md'
     - LICENSE
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmd
     - build/*.json

--- a/build/DirectXTK12-GitHub-CMake.yml
+++ b/build/DirectXTK12-GitHub-CMake.yml
@@ -3,7 +3,7 @@
 #
 # http://go.microsoft.com/fwlink/?LinkID=615561
 
-# Builds the library using CMake.
+# Builds the library using CMake with VS Generator (GitHub Actions covers Ninja).
 
 schedules:
 - cron: "0 6 * * *"

--- a/build/DirectXTK12-GitHub-CMake.yml
+++ b/build/DirectXTK12-GitHub-CMake.yml
@@ -20,6 +20,7 @@ trigger:
     exclude:
     - '*.md'
     - LICENSE
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmd
     - build/*.json
@@ -36,6 +37,7 @@ pr:
     exclude:
     - '*.md'
     - LICENSE
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmd
     - build/*.json

--- a/build/DirectXTK12-GitHub-Dev17.yml
+++ b/build/DirectXTK12-GitHub-Dev17.yml
@@ -21,6 +21,7 @@ trigger:
     - '*.md'
     - LICENSE
     - CMake*
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmake
     - build/*.cmd
@@ -40,6 +41,7 @@ pr:
     - '*.md'
     - LICENSE
     - CMake*
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmake
     - build/*.cmd

--- a/build/DirectXTK12-GitHub-Dev17.yml
+++ b/build/DirectXTK12-GitHub-Dev17.yml
@@ -12,46 +12,15 @@ schedules:
     include:
     - main
 
-trigger:
-  branches:
-    include:
-    - main
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - CMake*
-    - '.github/*'
-    - '.nuget/*'
-    - build/*.cmake
-    - build/*.cmd
-    - build/*.in
-    - build/*.json
-    - build/*.props
-    - build/*.ps1
-    - build/*.targets
-    - build/*.xvd
-
+# GitHub Actions handles MSBuild for CI/PR
+trigger: none
 pr:
   branches:
     include:
     - main
   paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - CMake*
-    - '.github/*'
-    - '.nuget/*'
-    - build/*.cmake
-    - build/*.cmd
-    - build/*.in
-    - build/*.json
-    - build/*.props
-    - build/*.ps1
-    - build/*.targets
-    - build/*.xvd
-  drafts: false
+    include:
+    - build/DirectXTK12-GitHub-Dev17.yml
 
 resources:
   repositories:

--- a/build/DirectXTK12-GitHub-GDK.yml
+++ b/build/DirectXTK12-GitHub-GDK.yml
@@ -23,6 +23,7 @@ trigger:
     - '*.md'
     - LICENSE
     - CMake*
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmake
     - build/*.in
@@ -38,6 +39,7 @@ pr:
     - '*.md'
     - LICENSE
     - CMake*
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmake
     - build/*.in

--- a/build/DirectXTK12-GitHub-MinGW.yml
+++ b/build/DirectXTK12-GitHub-MinGW.yml
@@ -20,6 +20,7 @@ trigger:
     exclude:
     - '*.md'
     - LICENSE
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmd
     - build/*.json
@@ -36,6 +37,7 @@ pr:
     exclude:
     - '*.md'
     - LICENSE
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmd
     - build/*.json

--- a/build/DirectXTK12-GitHub-Test-Dev17.yml
+++ b/build/DirectXTK12-GitHub-Test-Dev17.yml
@@ -12,8 +12,8 @@ schedules:
     include:
     - main
 
+# GitHub Actions handles test suite for CI/PR
 trigger: none
-
 pr:
   branches:
     include:

--- a/build/DirectXTK12-GitHub-Test.yml
+++ b/build/DirectXTK12-GitHub-Test.yml
@@ -21,6 +21,7 @@ trigger:
     - '*.md'
     - LICENSE
     - CMake*
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmake
     - build/*.cmd
@@ -40,6 +41,7 @@ pr:
     - '*.md'
     - LICENSE
     - CMake*
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmake
     - build/*.cmd

--- a/build/DirectXTK12-GitHub-Test.yml
+++ b/build/DirectXTK12-GitHub-Test.yml
@@ -12,46 +12,15 @@ schedules:
     include:
     - main
 
-trigger:
-  branches:
-    include:
-    - main
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - CMake*
-    - '.github/*'
-    - '.nuget/*'
-    - build/*.cmake
-    - build/*.cmd
-    - build/*.in
-    - build/*.json
-    - build/*.props
-    - build/*.ps1
-    - build/*.targets
-    - build/*.xvd
-
+# GitHub Actions handles test suite for CI/PR
+trigger: none
 pr:
   branches:
     include:
     - main
   paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - CMake*
-    - '.github/*'
-    - '.nuget/*'
-    - build/*.cmake
-    - build/*.cmd
-    - build/*.in
-    - build/*.json
-    - build/*.props
-    - build/*.ps1
-    - build/*.targets
-    - build/*.xvd
-  drafts: false
+    include:
+    - build/DirectXTK12-GitHub-Test.yml
 
 resources:
   repositories:

--- a/build/DirectXTK12-GitHub.yml
+++ b/build/DirectXTK12-GitHub.yml
@@ -21,6 +21,7 @@ trigger:
     - '*.md'
     - LICENSE
     - CMake*
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmake
     - build/*.cmd
@@ -40,6 +41,7 @@ pr:
     - '*.md'
     - LICENSE
     - CMake*
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmake
     - build/*.cmd

--- a/build/DirectXTK12-GitHub.yml
+++ b/build/DirectXTK12-GitHub.yml
@@ -6,52 +6,21 @@
 # Builds the library for Windows Desktop and UWP.
 
 schedules:
-- cron: "0 5 * * *"
+- cron: "5 5 * * *"
   displayName: 'Nightly build'
   branches:
     include:
     - main
 
-trigger:
-  branches:
-    include:
-    - main
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - CMake*
-    - '.github/*'
-    - '.nuget/*'
-    - build/*.cmake
-    - build/*.cmd
-    - build/*.in
-    - build/*.json
-    - build/*.props
-    - build/*.ps1
-    - build/*.targets
-    - build/*.xvd
-
+# GitHub Actions handles MSBuild for CI/PR
+trigger: none
 pr:
   branches:
     include:
     - main
   paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - CMake*
-    - '.github/*'
-    - '.nuget/*'
-    - build/*.cmake
-    - build/*.cmd
-    - build/*.in
-    - build/*.json
-    - build/*.props
-    - build/*.ps1
-    - build/*.targets
-    - build/*.xvd
-  drafts: false
+    include:
+    - build/DirectXTK12-GitHub.yml
 
 resources:
   repositories:

--- a/build/DirectXTK12-SDL.yml
+++ b/build/DirectXTK12-SDL.yml
@@ -12,8 +12,15 @@ schedules:
     include:
     - main
 
+# GitHub Actions handles CodeQL and PREFAST for CI/PR
 trigger: none
-pr: none
+pr:
+  branches:
+    include:
+    - main
+  paths:
+    include:
+    - build/DirectXTK12-SDL.yml
 
 resources:
   repositories:


### PR DESCRIPTION
While most pipelines are hosted on ADO, this adds GitHub build actions that are available to everyone who forks the repo. This also uses GitHub actions to validate PRs where possible rather than ADO for security reasons.

Also enables the GitHub Action based CodeQL and PREfast analysis.