### PR TITLE
Fix /analyze warning

### DIFF
--- a/Src/ScreenGrab.cpp
+++ b/Src/ScreenGrab.cpp
@@ -177,7 +177,14 @@ namespace
             nullptr,
             IID_GRAPHICS_PPV_ARGS(pStaging));
         if (FAILED(hr))
+        {
+            if (*pStaging)
+            {
+                (*pStaging)->Release();
+                *pStaging = nullptr;
+            }
             return hr;
+        }
 
         SetDebugObjectName(*pStaging, L"ScreenGrab staging");
 
@@ -205,7 +212,11 @@ namespace
 
         hr = commandList->Close();
         if (FAILED(hr))
+        {
+            (*pStaging)->Release();
+            *pStaging = nullptr;
             return hr;
+        }
 
         // Execute the command list
         pCommandQ->ExecuteCommandLists(1, CommandListCast(commandList.GetAddressOf()));
@@ -213,7 +224,11 @@ namespace
         // Signal the fence
         hr = pCommandQ->Signal(fence.Get(), 1);
         if (FAILED(hr))
+        {
+            (*pStaging)->Release();
+            *pStaging = nullptr;
             return hr;
+        }
 
         // Block until the copy is complete
         while (fence->GetCompletedValue() < 1)


### PR DESCRIPTION
Fixes /analyze warning that only happens when building for Xbox due to slight differences in system header SAL annotation.

```
ScreenGrab.cpp(39): warning C6388: '*pStaging' might not be '0':  this does not adhere to the specification for the function 'CaptureTexture'. 
ScreenGrab.cpp(39): warning C28196: The requirement that '*_Param_(6)==0' is not satisfied. (The expression does not evaluate to true.)
```

The requirement for a `_COM_OutPtr_` parameter is that if the function returns a failed HRESULT, the parameter should be returning null. These code changes ensure that this happens for all failure paths.
