### PR TITLE
Keep asserts on in fuzz-testing builds

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,4 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly

--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -82,7 +82,7 @@ jobs:
       with:
         runVcpkgInstall: true
         vcpkgJsonGlob: '**/build/vcpkg.json'
-        vcpkgGitCommitId: '7516a02de04e8f8ff4e4beb8f5bac0565f9bf9da'
+        vcpkgGitCommitId: '3508985146f1b1d248c67ead13f8f54be5b4f5da'
 
     - name: 'Configure CMake'
       working-directory: ${{ github.workspace }}

--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -82,7 +82,7 @@ jobs:
       with:
         runVcpkgInstall: true
         vcpkgJsonGlob: '**/build/vcpkg.json'
-        vcpkgGitCommitId: '3508985146f1b1d248c67ead13f8f54be5b4f5da'
+        vcpkgGitCommitId: '${{ vars.VCPKG_COMMIT_ID }}'
 
     - name: 'Configure CMake'
       working-directory: ${{ github.workspace }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -447,11 +447,15 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
         target_compile_options(${PROJECT_NAME} PRIVATE "/Qspectre")
     endif()
 
-    if(BUILD_FUZZING
-        AND (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.32)
-        AND (NOT WINDOWS_STORE))
-          target_compile_options(${PROJECT_NAME} PRIVATE ${ASAN_SWITCHES})
-          target_link_libraries(${PROJECT_NAME} PRIVATE ${ASAN_LIBS})
+
+    if(BUILD_FUZZING AND (NOT WINDOWS_STORE))
+      string(REPLACE "/DNDEBUG" "" CMAKE_CXX_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE})
+      string(REPLACE "/DNDEBUG" "" CMAKE_CXX_FLAGS_RELWITHDEBINFO ${CMAKE_CXX_FLAGS_RELWITHDEBINFO})
+
+      if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.32)
+        target_compile_options(${PROJECT_NAME} PRIVATE ${ASAN_SWITCHES})
+        target_link_libraries(${PROJECT_NAME} PRIVATE ${ASAN_LIBS})
+      endif()
     endif()
 endif()
 

--- a/build/DirectXTK12-GitHub-GDK.yml
+++ b/build/DirectXTK12-GitHub-GDK.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# http://go.microsoft.com/fwlink/?LinkID=615561
+# https://go.microsoft.com/fwlink/?LinkID=615561
 
 # Builds the library and test suite using the Microsoft GDK.
 
@@ -52,6 +52,11 @@ resources:
   - repository: self
     type: git
     ref: refs/heads/main
+  - repository: testRepo
+    name: walbourn/directxtk12test
+    type: github
+    endpoint: microsoft
+    ref: refs/heads/main
 
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
@@ -63,7 +68,6 @@ variables:
   EXTRACTED_FOLDER: $(ExtractedFolder)
   GDK_EDITION: $(GDKEditionNumber)
   GDKEnableBWOI: true
-  GITHUB_PAT: $(GITHUBPUBLICTOKEN)
   URL_FEED: $(ADOFeedURL)
   skipNugetSecurityAnalysis: true # We explicitly call this task so we don't need it to be auto-injected
 
@@ -76,6 +80,7 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
+    fetchDepth: 1
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
   - task: PowerShell@2
@@ -188,12 +193,14 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --no-tags --quiet https://%GITHUB_PAT%@github.com/walbourn/directxtk12test.git Tests
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: true
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
   - task: PowerShell@2
@@ -276,12 +283,14 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet https://%GITHUB_PAT%@github.com/walbourn/directxtk12test.git Tests
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: true
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
   - task: PowerShell@2

--- a/build/DirectXTK12-GitHub-MinGW.yml
+++ b/build/DirectXTK12-GitHub-MinGW.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# http://go.microsoft.com/fwlink/?LinkID=615561
+# https://go.microsoft.com/fwlink/?LinkID=615561
 
 # Builds the library and test suite using the MinGW compiler.
 
@@ -23,7 +23,7 @@ trigger:
     - '.github/*'
     - '.nuget/*'
     - build/*.cmd
-    - build/*.json
+    - build/OneFuzz*.json
     - build/*.props
     - build/*.ps1
     - build/*.targets
@@ -40,7 +40,7 @@ pr:
     - '.github/*'
     - '.nuget/*'
     - build/*.cmd
-    - build/*.json
+    - build/OneFuzz*.json
     - build/*.props
     - build/*.ps1
     - build/*.targets
@@ -52,6 +52,16 @@ resources:
   - repository: self
     type: git
     ref: refs/heads/main
+  - repository: vcpkgRepo
+    name: Microsoft/vcpkg
+    type: github
+    endpoint: microsoft
+    ref: refs/tags/$(VCPKG_TAG)
+  - repository: testRepo
+    name: walbourn/directxtk12test
+    type: github
+    endpoint: microsoft
+    ref: refs/heads/main
 
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
@@ -60,9 +70,10 @@ pool:
 
 variables:
   Codeql.Enabled: false
-  DIRECTX_DXC_DIR: '$(VCPKG_ROOT)/installed/x64-mingw-static/tools/directx-dxc'
-  VCPKG_CMAKE_DIR: '$(VCPKG_ROOT)/scripts/buildsystems/vcpkg.cmake'
-  GITHUB_PAT: $(GITHUBPUBLICTOKEN)
+  VCPKG_ROOT: $(Build.SourcesDirectory)/vcpkg
+  VCPKG_CMAKE_DIR: $(Build.SourcesDirectory)/vcpkg/scripts/buildsystems/vcpkg.cmake
+  VCPKG_MANIFEST_DIR: $(Build.SourcesDirectory)/build
+  DIRECTX_DXC_DIR: $(Build.SourcesDirectory)/vcpkg/installed/x64-mingw-static/tools/directx-dxc
   WIN11_SDK: '10.0.22000.0'
   URL_MINGW32: https://github.com/brechtsanders/winlibs_mingw/releases/download/12.2.0-14.0.6-10.0.0-ucrt-r2/winlibs-i686-posix-dwarf-gcc-12.2.0-llvm-14.0.6-mingw-w64ucrt-10.0.0-r2.zip
   HASH_MINGW32: 'fcd1e11b896190da01c83d5b5fb0d37b7c61585e53446c2dab0009debc3915e757213882c35e35396329338de6f0222ba012e23a5af86932db45186a225d1272'
@@ -74,15 +85,14 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: vcpkgRepo
     displayName: Fetch VCPKG
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/vcpkg.git
-      workingDirectory: $(Build.SourcesDirectory)
-  - task: CmdLine@2
-    displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxtk12test.git Tests
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/vcpkg'
   - task: CmdLine@2
     # Note we have to use x64-mingw-static for the host to use the directx-dxc port.
     displayName: VCPKG Bootstrap
@@ -94,7 +104,7 @@ jobs:
 
       workingDirectory: $(Build.SourcesDirectory)\vcpkg
   - task: PowerShell@2
-    displayName: Install MinGW32 and setup for Windows 11 SDK
+    displayName: Install MinGW32
     inputs:
       targetType: inline
       script: |
@@ -113,14 +123,6 @@ jobs:
         Write-Host "Extracted."
         Write-Host "Added to path: $env:BUILD_SOURCESDIRECTORY\gw32\mingw32\bin"
         Write-Host "##vso[task.prependpath]$env:BUILD_SOURCESDIRECTORY\gw32\mingw32\bin"
-        $sdkroot = Get-ItemProperty -Path 'HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows Kits\Installed Roots' | Select-Object -ExpandProperty KitsRoot10
-        $windows11sdk = "{0}bin\$(WIN11_SDK)\" -f $sdkroot
-        if (Test-Path "$windows11sdk") {
-            Write-Host "##vso[task.setvariable variable=WindowsSdkVerBinPath;]$windows11sdk"
-        }
-        else {
-            Write-Error -Message "##[error]Can't find Windows SDK ($(WIN11_SDK))" -ErrorAction Stop
-        }
 
       workingDirectory: $(Build.SourcesDirectory)
   - task: CmdLine@2
@@ -128,34 +130,23 @@ jobs:
     inputs:
       script: g++ --version
   - task: CmdLine@2
-    displayName: VCPKG install headers
+    displayName: VCPKG install packages
     inputs:
-      script: |
-        call vcpkg install directxmath
-        @if ERRORLEVEL 1 goto error
-        call vcpkg install directx-headers
-        @if ERRORLEVEL 1 goto error
-        call vcpkg install xaudio2redist
-        @if ERRORLEVEL 1 goto error
-        call vcpkg install directx-dxc:x64-mingw-static
-        @if ERRORLEVEL 1 goto error
-        :finish
-        @echo --- VCPKG COMPLETE ---
-        exit /b 0
-        :error
-        @echo --- ERROR: VCPKG FAILED ---
-        exit /b 1
-
-      workingDirectory: $(Build.SourcesDirectory)\vcpkg
+      script: call vcpkg install --x-manifest-root=$(VCPKG_MANIFEST_DIR) --triplet=x86-mingw-static
+      workingDirectory: $(VCPKG_ROOT)
   - task: CMake@1
     displayName: CMake (MinGW32)
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out -DCMAKE_BUILD_TYPE="Debug" -DDIRECTX_ARCH=x86 -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DVCPKG_TARGET_TRIPLET=x86-mingw-static -DVCPKG_HOST_TRIPLET=x64-mingw-static -DBUILD_XAUDIO_REDIST=ON -DDIRECTX_DXC_PATH="$(DIRECTX_DXC_DIR)"
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: >
+        -B out -DCMAKE_BUILD_TYPE="Debug" -DDIRECTX_ARCH=x86 -DBUILD_XAUDIO_REDIST=ON
+        -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
+        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x86-mingw-static
+        -DVCPKG_HOST_TRIPLET=x64-mingw-static -DDIRECTX_DXC_PATH="$(DIRECTX_DXC_DIR)"
   - task: CMake@1
     displayName: CMake (MinGW32) Build
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out
 
 - job: MINGW64_BUILD
@@ -164,15 +155,20 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: vcpkgRepo
     displayName: Fetch VCPKG
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/vcpkg.git
-      workingDirectory: $(Build.SourcesDirectory)
-  - task: CmdLine@2
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/vcpkg'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxtk12test.git Tests
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: CmdLine@2
     displayName: VCPKG Bootstrap
     inputs:
@@ -187,32 +183,21 @@ jobs:
     inputs:
       script: g++ --version
   - task: CmdLine@2
-    displayName: VCPKG install headers
+    displayName: VCPKG install packages
     inputs:
-      script: |
-        call vcpkg install directxmath
-        @if ERRORLEVEL 1 goto error
-        call vcpkg install directx-headers
-        @if ERRORLEVEL 1 goto error
-        call vcpkg install xaudio2redist
-        @if ERRORLEVEL 1 goto error
-        call vcpkg install directx-dxc
-        @if ERRORLEVEL 1 goto error
-        :finish
-        @echo --- VCPKG COMPLETE ---
-        exit /b 0
-        :error
-        @echo --- ERROR: VCPKG FAILED ---
-        exit /b 1
-
-      workingDirectory: $(Build.SourcesDirectory)\vcpkg
+      script: call vcpkg install --x-manifest-root=$(VCPKG_MANIFEST_DIR) --triplet=x64-mingw-static
+      workingDirectory: $(VCPKG_ROOT)
   - task: CMake@1
     displayName: CMake (MinGW-W64)
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out -DCMAKE_BUILD_TYPE="Debug" -DDIRECTX_ARCH=x64 -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DVCPKG_TARGET_TRIPLET=x64-mingw-static -DBUILD_XAUDIO_REDIST=ON -DDIRECTX_DXC_PATH="$(DIRECTX_DXC_DIR)"
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: >
+        -B out -DCMAKE_BUILD_TYPE="Debug" -DDIRECTX_ARCH=x64 -DBUILD_XAUDIO_REDIST=ON
+        -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
+        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-mingw-static
+        -DDIRECTX_DXC_PATH="$(DIRECTX_DXC_DIR)"
   - task: CMake@1
     displayName: CMake (MinGW-W64) Build
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out

--- a/build/DirectXTK12-GitHub-MinGW.yml
+++ b/build/DirectXTK12-GitHub-MinGW.yml
@@ -195,7 +195,7 @@ jobs:
         -B out -DCMAKE_BUILD_TYPE="Debug" -DDIRECTX_ARCH=x64 -DBUILD_XAUDIO_REDIST=ON
         -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
         -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-mingw-static
-        -DDIRECTX_DXC_PATH="$(DIRECTX_DXC_DIR)"
+        -DVCPKG_HOST_TRIPLET=x64-mingw-static -DDIRECTX_DXC_PATH="$(DIRECTX_DXC_DIR)"
   - task: CMake@1
     displayName: CMake (MinGW-W64) Build
     inputs:

--- a/build/DirectXTK12-GitHub-Test-Dev17.yml
+++ b/build/DirectXTK12-GitHub-Test-Dev17.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# http://go.microsoft.com/fwlink/?LinkID=615561
+# https://go.microsoft.com/fwlink/?LinkID=615561
 
 # Builds the library and test suite.
 
@@ -28,6 +28,11 @@ resources:
     type: git
     ref: refs/heads/main
     trigger: none
+  - repository: testRepo
+    name: walbourn/directxtk12test
+    type: github
+    endpoint: microsoft
+    ref: refs/heads/main
 
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
@@ -37,7 +42,6 @@ pool:
 variables:
   Codeql.Enabled: false
   VC_PATH: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC'
-  GITHUB_PAT: $(GITHUBPUBLICTOKEN)
   GUID_FEED: $(ADOFeedGUID)
 
 jobs:
@@ -51,19 +55,14 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: DeleteFiles@1
-    displayName: Delete files from Tests
-    inputs:
-      SourceFolder: Tests
-      Contents: '**'
-      RemoveSourceFolder: true
-      RemoveDotFiles: true
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxtk12test.git Tests
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: true
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
   - task: NuGetAuthenticate@1
@@ -155,19 +154,14 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: DeleteFiles@1
-    displayName: Delete files from Tests
-    inputs:
-      SourceFolder: Tests
-      Contents: '**'
-      RemoveSourceFolder: true
-      RemoveDotFiles: true
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxtk12test.git Tests
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: true
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
   - task: NuGetAuthenticate@1
@@ -225,19 +219,14 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: DeleteFiles@1
-    displayName: Delete files from Tests
-    inputs:
-      SourceFolder: Tests
-      Contents: '**'
-      RemoveSourceFolder: true
-      RemoveDotFiles: true
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxtk12test.git Tests
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: true
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: CmdLine@2
     displayName: Setup environment for CMake to use VS
     inputs:
@@ -256,12 +245,12 @@ jobs:
   - task: CMake@1
     displayName: CMake (MSVC; x64-Debug) Config
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --preset=x64-Debug
   - task: CMake@1
     displayName: CMake (MSVC; x64-Debug) Build
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out/build/x64-Debug -v
   - task: DeleteFiles@1
     inputs:
@@ -269,12 +258,12 @@ jobs:
   - task: CMake@1
     displayName: CMake (MSVC; x64-Release) Config
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --preset=x64-Release
   - task: CMake@1
     displayName: CMake (MSVC; x64-Release) Build
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out/build/x64-Release -v
   - task: DeleteFiles@1
     inputs:
@@ -282,12 +271,12 @@ jobs:
   - task: CMake@1
     displayName: CMake (clang/LLVM; x64-Debug) Config
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --preset=x64-Debug-Clang
   - task: CMake@1
     displayName: CMake (clang/LLVM; x64-Debug) Build
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out/build/x64-Debug-Clang -v
   - task: DeleteFiles@1
     inputs:
@@ -295,12 +284,12 @@ jobs:
   - task: CMake@1
     displayName: CMake (clang/LLVM; x64-Release) Config
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --preset=x64-Release-Clang
   - task: CMake@1
     displayName: CMake (clang/LLVM; x64-Release) Build
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out/build/x64-Release-Clang -v
 
 - job: CMAKE_BUILD_ARM64
@@ -312,19 +301,14 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: DeleteFiles@1
-    displayName: Delete files from Tests
-    inputs:
-      SourceFolder: Tests
-      Contents: '**'
-      RemoveSourceFolder: true
-      RemoveDotFiles: true
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxtk12test.git Tests
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: true
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: CmdLine@2
     displayName: Setup environment for CMake to use VS
     inputs:
@@ -343,12 +327,12 @@ jobs:
   - task: CMake@1
     displayName: CMake (MSVC; arm64-Debug) Config
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --preset=arm64-Debug
   - task: CMake@1
     displayName: CMake (MSVC; arm64-Debug) Build
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out/build/arm64-Debug -v
   - task: DeleteFiles@1
     inputs:
@@ -356,12 +340,12 @@ jobs:
   - task: CMake@1
     displayName: CMake (MSVC; arm64-Release) Config
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --preset=arm64-Release
   - task: CMake@1
     displayName: CMake (MSVC; arm64-Release) Build
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out/build/arm64-Release -v
   - task: DeleteFiles@1
     inputs:
@@ -369,12 +353,12 @@ jobs:
   - task: CMake@1
     displayName: CMake (clang/LLVM; arm64-Debug) Config
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --preset=arm64-Debug-Clang
   - task: CMake@1
     displayName: CMake (clang/LLVM; arm64-Debug) Build
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out/build/arm64-Debug-Clang -v
   - task: DeleteFiles@1
     inputs:
@@ -382,12 +366,12 @@ jobs:
   - task: CMake@1
     displayName: CMake (clang/LLVM; arm64-Release) Config
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --preset=arm64-Release-Clang
   - task: CMake@1
     displayName: CMake (clang/LLVM; arm64-Release) Build
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out/build/arm64-Release-Clang -v
   - task: DeleteFiles@1
     inputs:
@@ -395,12 +379,12 @@ jobs:
   - task: CMake@1
     displayName: CMake (MSVC; arm64ec-Debug) Config
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --preset=arm64ec-Debug
   - task: CMake@1
     displayName: CMake (MSVC; arm64ec-Debug) Build
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out/build/arm64ec-Debug -v
   - task: DeleteFiles@1
     inputs:
@@ -408,10 +392,10 @@ jobs:
   - task: CMake@1
     displayName: CMake (MSVC; arm64ec-Release) Config
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --preset=arm64ec-Release
   - task: CMake@1
     displayName: CMake (MSVC; arm64ec-Release) Build
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out/build/arm64ec-Release -v

--- a/build/DirectXTK12-GitHub-Test.yml
+++ b/build/DirectXTK12-GitHub-Test.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# http://go.microsoft.com/fwlink/?LinkID=615561
+# https://go.microsoft.com/fwlink/?LinkID=615561
 
 # Builds the library and test suite.
 
@@ -27,6 +27,11 @@ resources:
   - repository: self
     type: git
     ref: refs/heads/main
+  - repository: testRepo
+    name: walbourn/directxtk12test
+    type: github
+    endpoint: microsoft
+    ref: refs/heads/main
 
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
@@ -35,7 +40,6 @@ pool:
 
 variables:
   Codeql.Enabled: false
-  GITHUB_PAT: $(GITHUBPUBLICTOKEN)
   GUID_FEED: $(ADOFeedGUID)
 
 jobs:
@@ -43,25 +47,24 @@ jobs:
   displayName: 'Win32 Desktop for x64/x86'
   timeoutInMinutes: 120
   cancelTimeoutInMinutes: 1
+  workspace:
+    clean: all
   steps:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: DeleteFiles@1
-    displayName: Delete files from Tests
-    inputs:
-      SourceFolder: Tests
-      Contents: '**'
-      RemoveSourceFolder: true
-      RemoveDotFiles: true
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxtk12test.git Tests
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: true
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
+  - task: NuGetAuthenticate@1
+    displayName: 'NuGet Auth'
   - task: NuGetCommand@2
     displayName: NuGet restore tests
     inputs:
@@ -141,21 +144,18 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: DeleteFiles@1
-    displayName: Delete files from Tests
-    inputs:
-      SourceFolder: Tests
-      Contents: '**'
-      RemoveSourceFolder: true
-      RemoveDotFiles: true
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxtk12test.git Tests
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: true
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
+  - task: NuGetAuthenticate@1
+    displayName: 'NuGet Auth'
   - task: NuGetCommand@2
     displayName: NuGet restore tests
     inputs:
@@ -204,21 +204,18 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: DeleteFiles@1
-    displayName: Delete files from Tests
-    inputs:
-      SourceFolder: Tests
-      Contents: '**'
-      RemoveSourceFolder: true
-      RemoveDotFiles: true
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxtk12test.git Tests
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: true
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
+  - task: NuGetAuthenticate@1
+    displayName: 'NuGet Auth'
   - task: NuGetCommand@2
     displayName: NuGet restore tests
     inputs:
@@ -250,21 +247,18 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: DeleteFiles@1
-    displayName: Delete files from Tests
-    inputs:
-      SourceFolder: Tests
-      Contents: '**'
-      RemoveSourceFolder: true
-      RemoveDotFiles: true
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxtk12test.git Tests
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: true
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
+  - task: NuGetAuthenticate@1
+    displayName: 'NuGet Auth'
   - task: NuGetCommand@2
     displayName: NuGet restore tests
     inputs:
@@ -296,21 +290,18 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: DeleteFiles@1
-    displayName: Delete files from Tests
-    inputs:
-      SourceFolder: Tests
-      Contents: '**'
-      RemoveSourceFolder: true
-      RemoveDotFiles: true
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxtk12test.git Tests
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: true
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
+  - task: NuGetAuthenticate@1
+    displayName: 'NuGet Auth'
   - task: NuGetCommand@2
     displayName: NuGet restore tests
     inputs:

--- a/build/DirectXTK12-OneFuzz-Coverage.yml
+++ b/build/DirectXTK12-OneFuzz-Coverage.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# http://go.microsoft.com/fwlink/?LinkID=615561
+# https://go.microsoft.com/fwlink/?LinkID=615561
 
 # OneFuzz code coverage pipeline
 
@@ -10,6 +10,17 @@ trigger: none
 
 pool:
   vmImage: windows-latest
+
+resources:
+  repositories:
+  - repository: self
+    type: git
+    ref: refs/heads/main
+  - repository: testRepo
+    name: walbourn/directxtk12test
+    type: github
+    endpoint: microsoft
+    ref: refs/heads/main
 
 parameters:
   - name: sasUrl
@@ -48,17 +59,17 @@ jobs:
   workspace:
     clean: all
   steps:
-  - task: CmdLine@2
-    displayName: 'Fetch source'
-    inputs:
-      script: |
-        git clone --quiet --no-tags https://%GITHUBPUBLICTOKEN%@github.com/microsoft/DirectXTK12.git
-        cd DirectXTK
-        git checkout $(commit-ID)
-        git clone --quiet --no-tags https://%GITHUBPUBLICTOKEN%@github.com/walbourn/directxtk12test.git Tests
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: true
-
+  - checkout: self
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
+    displayName: Fetch Tests
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - powershell: |
       Write-Host "Job ID: $(job-ID), Build Date: $(build-date), Branch: $(branch)"
       $SASUrl = [System.Uri]::new("$(sas-url)")

--- a/build/DirectXTK12-OneFuzz.yml
+++ b/build/DirectXTK12-OneFuzz.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# http://go.microsoft.com/fwlink/?LinkID=615561
+# https://go.microsoft.com/fwlink/?LinkID=615561
 
 # Builds the library using CMake and submit for file fuzzing
 
@@ -21,6 +21,11 @@ resources:
   - repository: self
     type: git
     ref: refs/heads/main
+  - repository: testRepo
+    name: walbourn/directxtk12test
+    type: github
+    endpoint: microsoft
+    ref: refs/heads/main
 
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
@@ -28,7 +33,6 @@ variables:
   Codeql.Enabled: false
   VS_GENERATOR: 'Visual Studio 17 2022'
   WIN11_SDK: '10.0.22000.0'
-  GITHUB_PAT: $(GITHUBPUBLICTOKEN)
 
 pool:
   vmImage: windows-2022
@@ -40,28 +44,23 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: DeleteFiles@1
-    displayName: Delete files from Tests
-    inputs:
-      SourceFolder: Tests
-      Contents: '**'
-      RemoveSourceFolder: true
-      RemoveDotFiles: true
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxtk12test.git Tests
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: true
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: CMake@1
     displayName: 'CMake (MSVC): Config with ASan'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out -DCMAKE_SYSTEM_VERSION=$(WIN11_SDK) -DBUILD_XAUDIO_WIN10=ON -DBUILD_FUZZING=ON -DBUILD_TESTING=OFF'
   - task: CMake@1
     displayName: 'CMake (MSVC): Build with ASan'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out -v --config RelWithDebInfo
   - task: CopyFiles@2
     displayName: Copy fuzzer

--- a/build/DirectXTK12-SDL.yml
+++ b/build/DirectXTK12-SDL.yml
@@ -11,6 +11,7 @@ schedules:
   branches:
     include:
     - main
+  always: true
 
 # GitHub Actions handles CodeQL and PREFAST for CI/PR
 trigger: none


### PR DESCRIPTION
This PR makes sure ``assert`` macros in the library built for fuzz-testing remain in place even in release builds.

> Includes ADO YAML code review to clean up use of PATs, and to convert all use of vcpkg in the pipelines to 'manifest mode'.

> Also sets the dependabot to not spam quite so often for GHA.