### PR TITLE
Add DDS_LOADER_IGNORE_MIPS flag to DDSTextureLoader

### DIFF
--- a/Inc/DDSTextureLoader.h
+++ b/Inc/DDSTextureLoader.h
@@ -57,6 +57,7 @@ namespace DirectX
             DDS_LOADER_IGNORE_SRGB = 0x2,
             DDS_LOADER_MIP_AUTOGEN = 0x8,
             DDS_LOADER_MIP_RESERVE = 0x10,
+            DDS_LOADER_IGNORE_MIPS = 0x20,
         };
     }
 

--- a/Src/DDSTextureLoader.cpp
+++ b/Src/DDSTextureLoader.cpp
@@ -299,7 +299,7 @@ namespace
         bool isCubeMap = false;
 
         size_t mipCount = header->mipMapCount;
-        if (0 == mipCount)
+        if ((0 == mipCount) || (loadFlags & DDS_LOADER_IGNORE_MIPS))
         {
             mipCount = 1;
         }


### PR DESCRIPTION
Adds a flag option to DDSTextureLoader for only loading the first mip of a DDS file.

> This was added to DirectXTex as `DDS_FLAGS_IGNORE_MIPS` in July. It is useful for more than just corrupted files.