### PR TITLE
Support using C++17 std::byte for FromMemory functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,13 +318,13 @@ endif()
 
 if(directxmath_FOUND)
     message(STATUS "Using DirectXMath package")
-    target_link_libraries(${PROJECT_NAME} PUBLIC Microsoft::DirectXMath)
+    target_link_libraries(${PROJECT_NAME} PRIVATE Microsoft::DirectXMath)
 endif()
 
 if(directx-headers_FOUND)
     message(STATUS "Using DirectX-Headers package")
-    target_link_libraries(${PROJECT_NAME} PUBLIC Microsoft::DirectX-Headers)
-    target_compile_definitions(${PROJECT_NAME} PUBLIC USING_DIRECTX_HEADERS)
+    target_link_libraries(${PROJECT_NAME} PRIVATE Microsoft::DirectX-Headers)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE USING_DIRECTX_HEADERS)
 endif()
 
 if(BUILD_XAUDIO_REDIST

--- a/Inc/DDSTextureLoader.h
+++ b/Inc/DDSTextureLoader.h
@@ -63,7 +63,7 @@ namespace DirectX
 
     // Standard version
     HRESULT __cdecl LoadDDSTextureFromMemory(
-        _In_ ID3D12Device* d3dDevice,
+        _In_ ID3D12Device* device,
         _In_reads_bytes_(ddsDataSize) const uint8_t* ddsData,
         size_t ddsDataSize,
         _Outptr_ ID3D12Resource** texture,
@@ -73,7 +73,7 @@ namespace DirectX
         _Out_opt_ bool* isCubeMap = nullptr);
 
     HRESULT __cdecl LoadDDSTextureFromFile(
-        _In_ ID3D12Device* d3dDevice,
+        _In_ ID3D12Device* device,
         _In_z_ const wchar_t* szFileName,
         _Outptr_ ID3D12Resource** texture,
         std::unique_ptr<uint8_t[]>& ddsData,
@@ -106,7 +106,7 @@ namespace DirectX
 
     // Extended version
     HRESULT __cdecl LoadDDSTextureFromMemoryEx(
-        _In_ ID3D12Device* d3dDevice,
+        _In_ ID3D12Device* device,
         _In_reads_bytes_(ddsDataSize) const uint8_t* ddsData,
         size_t ddsDataSize,
         size_t maxsize,
@@ -118,7 +118,7 @@ namespace DirectX
         _Out_opt_ bool* isCubeMap = nullptr);
 
     HRESULT __cdecl LoadDDSTextureFromFileEx(
-        _In_ ID3D12Device* d3dDevice,
+        _In_ ID3D12Device* device,
         _In_z_ const wchar_t* szFileName,
         size_t maxsize,
         D3D12_RESOURCE_FLAGS resFlags,
@@ -152,6 +152,65 @@ namespace DirectX
         _Outptr_ ID3D12Resource** texture,
         _Out_opt_ DDS_ALPHA_MODE* alphaMode = nullptr,
         _Out_opt_ bool* isCubeMap = nullptr);
+
+#ifdef __cpp_lib_byte
+    inline HRESULT __cdecl LoadDDSTextureFromMemory(
+        _In_ ID3D12Device* device,
+        _In_reads_bytes_(ddsDataSize) const std::byte* ddsData,
+        size_t ddsDataSize,
+        _Outptr_ ID3D12Resource** texture,
+        std::vector<D3D12_SUBRESOURCE_DATA>& subresources,
+        size_t maxsize = 0,
+        _Out_opt_ DDS_ALPHA_MODE* alphaMode = nullptr,
+        _Out_opt_ bool* isCubeMap = nullptr)
+    {
+        return LoadDDSTextureFromMemory(device, reinterpret_cast<const uint8_t*>(ddsData), ddsDataSize, texture, subresources, maxsize, alphaMode, isCubeMap);
+    }
+
+    inline HRESULT __cdecl CreateDDSTextureFromMemory(
+        _In_ ID3D12Device* device,
+        ResourceUploadBatch& resourceUpload,
+        _In_reads_bytes_(ddsDataSize) const std::byte* ddsData,
+        size_t ddsDataSize,
+        _Outptr_ ID3D12Resource** texture,
+        bool generateMipsIfMissing = false,
+        size_t maxsize = 0,
+        _Out_opt_ DDS_ALPHA_MODE* alphaMode = nullptr,
+        _Out_opt_ bool* isCubeMap = nullptr)
+    {
+        return CreateDDSTextureFromMemory(device, resourceUpload, reinterpret_cast<const uint8_t*>(ddsData), ddsDataSize, texture, generateMipsIfMissing, maxsize, alphaMode, isCubeMap);
+    }
+
+    inline HRESULT __cdecl LoadDDSTextureFromMemoryEx(
+        _In_ ID3D12Device* device,
+        _In_reads_bytes_(ddsDataSize) const std::byte* ddsData,
+        size_t ddsDataSize,
+        size_t maxsize,
+        D3D12_RESOURCE_FLAGS resFlags,
+        DDS_LOADER_FLAGS loadFlags,
+        _Outptr_ ID3D12Resource** texture,
+        std::vector<D3D12_SUBRESOURCE_DATA>& subresources,
+        _Out_opt_ DDS_ALPHA_MODE* alphaMode = nullptr,
+        _Out_opt_ bool* isCubeMap = nullptr)
+    {
+        return LoadDDSTextureFromMemoryEx(device, reinterpret_cast<const uint8_t*>(ddsData), ddsDataSize, maxsize, resFlags, loadFlags, texture, subresources, alphaMode, isCubeMap);
+    }
+
+    inline HRESULT __cdecl CreateDDSTextureFromMemoryEx(
+        _In_ ID3D12Device* device,
+        ResourceUploadBatch& resourceUpload,
+        _In_reads_bytes_(ddsDataSize) const std::byte* ddsData,
+        size_t ddsDataSize,
+        size_t maxsize,
+        D3D12_RESOURCE_FLAGS resFlags,
+        DDS_LOADER_FLAGS loadFlags,
+        _Outptr_ ID3D12Resource** texture,
+        _Out_opt_ DDS_ALPHA_MODE* alphaMode = nullptr,
+        _Out_opt_ bool* isCubeMap = nullptr)
+    {
+        return CreateDDSTextureFromMemoryEx(device, resourceUpload, reinterpret_cast<const uint8_t*>(ddsData), ddsDataSize, maxsize, resFlags, loadFlags, texture, alphaMode, isCubeMap);
+    }
+#endif //  __cpp_lib_byte
 
 #ifdef __clang__
 #pragma clang diagnostic push

--- a/Inc/Model.h
+++ b/Inc/Model.h
@@ -527,6 +527,33 @@ namespace DirectX
                 _In_z_ const wchar_t* szFileName,
                 ModelLoaderFlags flags = ModelLoader_Default);
 
+#ifdef __cpp_lib_byte
+            static std::unique_ptr<Model> __cdecl CreateFromCMO(
+                _In_opt_ ID3D12Device* device,
+                _In_reads_bytes_(dataSize) const std::byte* meshData, _In_ size_t dataSize,
+                ModelLoaderFlags flags = ModelLoader_Default,
+                _Out_opt_ size_t* animsOffset = nullptr)
+            {
+                return CreateFromCMO(device, reinterpret_cast<const uint8_t*>(meshData), dataSize, flags, animsOffset);
+            }
+
+            static std::unique_ptr<Model> __cdecl CreateFromSDKMESH(
+                _In_opt_ ID3D12Device* device,
+                _In_reads_bytes_(dataSize) const std::byte* meshData, _In_ size_t dataSize,
+                ModelLoaderFlags flags = ModelLoader_Default)
+            {
+                return CreateFromSDKMESH(device, reinterpret_cast<const uint8_t*>(meshData), dataSize, flags);
+            }
+
+            static std::unique_ptr<Model> __cdecl CreateFromVBO(
+                _In_opt_ ID3D12Device* device,
+                _In_reads_bytes_(dataSize) const std::byte* meshData, _In_ size_t dataSize,
+                ModelLoaderFlags flags = ModelLoader_Default)
+            {
+                return CreateFromVBO(device, reinterpret_cast<const uint8_t*>(meshData), dataSize, flags);
+            }
+#endif //  __cpp_lib_byte
+
             // Utility function for getting a GPU descriptor for a mesh part/material index. If there is no texture the
             // descriptor will be zero.
             D3D12_GPU_DESCRIPTOR_HANDLE __cdecl GetGpuTextureHandleForMaterialIndex(uint32_t materialIndex, _In_ ID3D12DescriptorHeap* heap, _In_ size_t descriptorSize, _In_ size_t descriptorOffset) const

--- a/Inc/WICTextureLoader.h
+++ b/Inc/WICTextureLoader.h
@@ -61,7 +61,7 @@ namespace DirectX
 
     // Standard version
     HRESULT __cdecl LoadWICTextureFromMemory(
-        _In_ ID3D12Device* d3dDevice,
+        _In_ ID3D12Device* device,
         _In_reads_bytes_(wicDataSize) const uint8_t* wicData,
         size_t wicDataSize,
         _Outptr_ ID3D12Resource** texture,
@@ -70,7 +70,7 @@ namespace DirectX
         size_t maxsize = 0) noexcept;
 
     HRESULT __cdecl LoadWICTextureFromFile(
-        _In_ ID3D12Device* d3dDevice,
+        _In_ ID3D12Device* device,
         _In_z_ const wchar_t* szFileName,
         _Outptr_ ID3D12Resource** texture,
         std::unique_ptr<uint8_t[]>& decodedData,
@@ -79,7 +79,7 @@ namespace DirectX
 
     // Standard version with resource upload
     HRESULT __cdecl CreateWICTextureFromMemory(
-        _In_ ID3D12Device* d3dDevice,
+        _In_ ID3D12Device* device,
         ResourceUploadBatch& resourceUpload,
         _In_reads_bytes_(wicDataSize) const uint8_t* wicData,
         size_t wicDataSize,
@@ -88,7 +88,7 @@ namespace DirectX
         size_t maxsize = 0);
 
     HRESULT __cdecl CreateWICTextureFromFile(
-        _In_ ID3D12Device* d3dDevice,
+        _In_ ID3D12Device* device,
         ResourceUploadBatch& resourceUpload,
         _In_z_ const wchar_t* szFileName,
         _Outptr_ ID3D12Resource** texture,
@@ -97,7 +97,7 @@ namespace DirectX
 
     // Extended version
     HRESULT __cdecl LoadWICTextureFromMemoryEx(
-        _In_ ID3D12Device* d3dDevice,
+        _In_ ID3D12Device* device,
         _In_reads_bytes_(wicDataSize) const uint8_t* wicData,
         size_t wicDataSize,
         size_t maxsize,
@@ -108,7 +108,7 @@ namespace DirectX
         D3D12_SUBRESOURCE_DATA& subresource) noexcept;
 
     HRESULT __cdecl LoadWICTextureFromFileEx(
-        _In_ ID3D12Device* d3dDevice,
+        _In_ ID3D12Device* device,
         _In_z_ const wchar_t* szFileName,
         size_t maxsize,
         D3D12_RESOURCE_FLAGS resFlags,
@@ -119,7 +119,7 @@ namespace DirectX
 
     // Extended version with resource upload
     HRESULT __cdecl CreateWICTextureFromMemoryEx(
-        _In_ ID3D12Device* d3dDevice,
+        _In_ ID3D12Device* device,
         ResourceUploadBatch& resourceUpload,
         _In_reads_bytes_(wicDataSize) const uint8_t* wicData,
         size_t wicDataSize,
@@ -129,13 +129,66 @@ namespace DirectX
         _Outptr_ ID3D12Resource** texture);
 
     HRESULT __cdecl CreateWICTextureFromFileEx(
-        _In_ ID3D12Device* d3dDevice,
+        _In_ ID3D12Device* device,
         ResourceUploadBatch& resourceUpload,
         _In_z_ const wchar_t* szFileName,
         size_t maxsize,
         D3D12_RESOURCE_FLAGS resFlags,
         WIC_LOADER_FLAGS loadFlags,
         _Outptr_ ID3D12Resource** texture);
+
+#ifdef __cpp_lib_byte
+    inline HRESULT __cdecl LoadWICTextureFromMemory(
+        _In_ ID3D12Device* device,
+        _In_reads_bytes_(wicDataSize) const std::byte* wicData,
+        size_t wicDataSize,
+        _Outptr_ ID3D12Resource** texture,
+        std::unique_ptr<uint8_t[]>& decodedData,
+        D3D12_SUBRESOURCE_DATA& subresource,
+        size_t maxsize = 0) noexcept
+    {
+        return LoadWICTextureFromMemory(device, reinterpret_cast<const uint8_t*>(wicData), wicDataSize, texture, decodedData, subresource, maxsize);
+    }
+
+    inline HRESULT __cdecl CreateWICTextureFromMemory(
+        _In_ ID3D12Device* device,
+        ResourceUploadBatch& resourceUpload,
+        _In_reads_bytes_(wicDataSize) const std::byte* wicData,
+        size_t wicDataSize,
+        _Outptr_ ID3D12Resource** texture,
+        bool generateMips = false,
+        size_t maxsize = 0)
+    {
+        return CreateWICTextureFromMemory(device, resourceUpload, reinterpret_cast<const uint8_t*>(wicData), wicDataSize, texture, generateMips, maxsize);
+    }
+
+    inline HRESULT __cdecl LoadWICTextureFromMemoryEx(
+        _In_ ID3D12Device* device,
+        _In_reads_bytes_(wicDataSize) const std::byte* wicData,
+        size_t wicDataSize,
+        size_t maxsize,
+        D3D12_RESOURCE_FLAGS resFlags,
+        WIC_LOADER_FLAGS loadFlags,
+        _Outptr_ ID3D12Resource** texture,
+        std::unique_ptr<uint8_t[]>& decodedData,
+        D3D12_SUBRESOURCE_DATA& subresource) noexcept
+    {
+        return LoadWICTextureFromMemoryEx(device, reinterpret_cast<const uint8_t*>(wicData), wicDataSize, maxsize, resFlags, loadFlags, texture, decodedData, subresource);
+    }
+
+    inline HRESULT __cdecl CreateWICTextureFromMemoryEx(
+        _In_ ID3D12Device* device,
+        ResourceUploadBatch& resourceUpload,
+        _In_reads_bytes_(wicDataSize) const std::byte* wicData,
+        size_t wicDataSize,
+        size_t maxsize,
+        D3D12_RESOURCE_FLAGS resFlags,
+        WIC_LOADER_FLAGS loadFlags,
+        _Outptr_ ID3D12Resource** texture)
+    {
+        return CreateWICTextureFromMemoryEx(device, resourceUpload, reinterpret_cast<const uint8_t*>(wicData), wicDataSize, maxsize, resFlags, loadFlags, texture);
+    }
+#endif //  __cpp_lib_byte
 
 #ifdef __clang__
 #pragma clang diagnostic push

--- a/Inc/XboxDDSTextureLoader.h
+++ b/Inc/XboxDDSTextureLoader.h
@@ -75,7 +75,7 @@ namespace Xbox
     //
 
     HRESULT __cdecl CreateDDSTextureFromMemory(
-        _In_ ID3D12Device* d3dDevice,
+        _In_ ID3D12Device* device,
         _In_reads_bytes_(ddsDataSize) const uint8_t* ddsData,
         _In_ size_t ddsDataSize,
         _Outptr_opt_ ID3D12Resource** texture,
@@ -85,7 +85,7 @@ namespace Xbox
         _Out_opt_ bool* isCubeMap = nullptr) noexcept;
 
     HRESULT __cdecl CreateDDSTextureFromFile(
-        _In_ ID3D12Device* d3dDevice,
+        _In_ ID3D12Device* device,
         _In_z_ const wchar_t* szFileName,
         _Outptr_opt_ ID3D12Resource** texture,
         _Outptr_ void** grfxMemory,
@@ -94,4 +94,19 @@ namespace Xbox
         _Out_opt_ bool* isCubeMap = nullptr) noexcept;
 
     void FreeDDSTextureMemory(_In_opt_ void* grfxMemory) noexcept;
+
+#ifdef __cpp_lib_byte
+    inline HRESULT __cdecl CreateDDSTextureFromMemory(
+        _In_ ID3D12Device* device,
+        _In_reads_bytes_(ddsDataSize) const std::byte* ddsData,
+        _In_ size_t ddsDataSize,
+        _Outptr_opt_ ID3D12Resource** texture,
+        _Outptr_ void** grfxMemory,
+        _Out_opt_ DDS_ALPHA_MODE* alphaMode = nullptr,
+        _In_ bool forceSRGB = false,
+        _Out_opt_ bool* isCubeMap = nullptr) noexcept
+    {
+        return CreateDDSTextureFromMemory(device, reinterpret_cast<const uint8_t*>(ddsData), ddsDataSize, texture, grfxMemory, alphaMode, forceSRGB, isCubeMap);
+    }
+#endif //  __cpp_lib_byte
 }

--- a/Src/DDSTextureLoader.cpp
+++ b/Src/DDSTextureLoader.cpp
@@ -218,7 +218,7 @@ namespace
 
     //--------------------------------------------------------------------------------------
     HRESULT CreateTextureResource(
-        _In_ ID3D12Device* d3dDevice,
+        _In_ ID3D12Device* device,
         D3D12_RESOURCE_DIMENSION resDim,
         size_t width,
         size_t height,
@@ -230,7 +230,7 @@ namespace
         DDS_LOADER_FLAGS loadFlags,
         _Outptr_ ID3D12Resource** texture) noexcept
     {
-        if (!d3dDevice)
+        if (!device)
             return E_POINTER;
 
         HRESULT hr = E_FAIL;
@@ -257,7 +257,7 @@ namespace
 
         const CD3DX12_HEAP_PROPERTIES defaultHeapProperties(D3D12_HEAP_TYPE_DEFAULT);
 
-        hr = d3dDevice->CreateCommittedResource(
+        hr = device->CreateCommittedResource(
             &defaultHeapProperties,
             D3D12_HEAP_FLAG_NONE,
             &desc,
@@ -276,7 +276,7 @@ namespace
     }
 
     //--------------------------------------------------------------------------------------
-    HRESULT CreateTextureFromDDS(_In_ ID3D12Device* d3dDevice,
+    HRESULT CreateTextureFromDDS(_In_ ID3D12Device* device,
         _In_ const DDS_HEADER* header,
         _In_reads_bytes_(bitSize) const uint8_t* bitData,
         size_t bitSize,
@@ -517,7 +517,7 @@ namespace
             return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
         }
 
-        const UINT numberOfPlanes = D3D12GetFormatPlaneCount(d3dDevice, format);
+        const UINT numberOfPlanes = D3D12GetFormatPlaneCount(device, format);
         if (!numberOfPlanes)
             return E_INVALIDARG;
 
@@ -561,7 +561,7 @@ namespace
                     LoaderHelpers::CountMips(width, height));
             }
 
-            hr = CreateTextureResource(d3dDevice, resDim, twidth, theight, tdepth, reservedMips - skipMip, arraySize,
+            hr = CreateTextureResource(device, resDim, twidth, theight, tdepth, reservedMips - skipMip, arraySize,
                 format, resFlags, loadFlags, texture);
 
             if (FAILED(hr) && !maxsize && (mipCount > 1))
@@ -579,7 +579,7 @@ namespace
                     twidth, theight, tdepth, skipMip, subresources);
                 if (SUCCEEDED(hr))
                 {
-                    hr = CreateTextureResource(d3dDevice, resDim, twidth, theight, tdepth, mipCount - skipMip, arraySize,
+                    hr = CreateTextureResource(device, resDim, twidth, theight, tdepth, mipCount - skipMip, arraySize,
                         format, resFlags, loadFlags, texture);
                 }
             }
@@ -633,7 +633,7 @@ namespace
 //--------------------------------------------------------------------------------------
 _Use_decl_annotations_
 HRESULT DirectX::LoadDDSTextureFromMemory(
-    ID3D12Device* d3dDevice,
+    ID3D12Device* device,
     const uint8_t* ddsData,
     size_t ddsDataSize,
     ID3D12Resource** texture,
@@ -643,7 +643,7 @@ HRESULT DirectX::LoadDDSTextureFromMemory(
     bool* isCubeMap)
 {
     return LoadDDSTextureFromMemoryEx(
-        d3dDevice,
+        device,
         ddsData,
         ddsDataSize,
         maxsize,
@@ -658,7 +658,7 @@ HRESULT DirectX::LoadDDSTextureFromMemory(
 
 _Use_decl_annotations_
 HRESULT DirectX::LoadDDSTextureFromMemoryEx(
-    ID3D12Device* d3dDevice,
+    ID3D12Device* device,
     const uint8_t* ddsData,
     size_t ddsDataSize,
     size_t maxsize,
@@ -682,7 +682,7 @@ HRESULT DirectX::LoadDDSTextureFromMemoryEx(
         *isCubeMap = false;
     }
 
-    if (!d3dDevice || !ddsData || !texture)
+    if (!device || !ddsData || !texture)
     {
         return E_INVALIDARG;
     }
@@ -703,7 +703,7 @@ HRESULT DirectX::LoadDDSTextureFromMemoryEx(
         return hr;
     }
 
-    hr = CreateTextureFromDDS(d3dDevice,
+    hr = CreateTextureFromDDS(device,
         header, bitData, bitSize, maxsize,
         resFlags, loadFlags,
         texture, subresources, isCubeMap);
@@ -722,7 +722,7 @@ HRESULT DirectX::LoadDDSTextureFromMemoryEx(
 //--------------------------------------------------------------------------------------
 _Use_decl_annotations_
 HRESULT DirectX::LoadDDSTextureFromFile(
-    ID3D12Device* d3dDevice,
+    ID3D12Device* device,
     const wchar_t* fileName,
     ID3D12Resource** texture,
     std::unique_ptr<uint8_t[]>& ddsData,
@@ -732,7 +732,7 @@ HRESULT DirectX::LoadDDSTextureFromFile(
     bool* isCubeMap)
 {
     return LoadDDSTextureFromFileEx(
-        d3dDevice,
+        device,
         fileName,
         maxsize,
         D3D12_RESOURCE_FLAG_NONE,
@@ -746,7 +746,7 @@ HRESULT DirectX::LoadDDSTextureFromFile(
 
 _Use_decl_annotations_
 HRESULT DirectX::LoadDDSTextureFromFileEx(
-    ID3D12Device* d3dDevice,
+    ID3D12Device* device,
     const wchar_t* fileName,
     size_t maxsize,
     D3D12_RESOURCE_FLAGS resFlags,
@@ -770,7 +770,7 @@ HRESULT DirectX::LoadDDSTextureFromFileEx(
         *isCubeMap = false;
     }
 
-    if (!d3dDevice || !fileName || !texture)
+    if (!device || !fileName || !texture)
     {
         return E_INVALIDARG;
     }
@@ -790,7 +790,7 @@ HRESULT DirectX::LoadDDSTextureFromFileEx(
         return hr;
     }
 
-    hr = CreateTextureFromDDS(d3dDevice,
+    hr = CreateTextureFromDDS(device,
         header, bitData, bitSize, maxsize,
         resFlags, loadFlags,
         texture, subresources, isCubeMap);
@@ -809,7 +809,7 @@ HRESULT DirectX::LoadDDSTextureFromFileEx(
 //--------------------------------------------------------------------------------------
 _Use_decl_annotations_
 HRESULT DirectX::CreateDDSTextureFromMemory(
-    ID3D12Device* d3dDevice,
+    ID3D12Device* device,
     ResourceUploadBatch& resourceUpload,
     const uint8_t* ddsData,
     size_t ddsDataSize,
@@ -820,7 +820,7 @@ HRESULT DirectX::CreateDDSTextureFromMemory(
     bool* isCubeMap)
 {
     return CreateDDSTextureFromMemoryEx(
-        d3dDevice,
+        device,
         resourceUpload,
         ddsData,
         ddsDataSize,
@@ -835,7 +835,7 @@ HRESULT DirectX::CreateDDSTextureFromMemory(
 
 _Use_decl_annotations_
 HRESULT DirectX::CreateDDSTextureFromMemoryEx(
-    ID3D12Device* d3dDevice,
+    ID3D12Device* device,
     ResourceUploadBatch& resourceUpload,
     const uint8_t* ddsData,
     size_t ddsDataSize,
@@ -859,7 +859,7 @@ HRESULT DirectX::CreateDDSTextureFromMemoryEx(
         *isCubeMap = false;
     }
 
-    if (!d3dDevice || !ddsData || !texture)
+    if (!device || !ddsData || !texture)
     {
         return E_INVALIDARG;
     }
@@ -891,7 +891,7 @@ HRESULT DirectX::CreateDDSTextureFromMemoryEx(
     }
 
     std::vector<D3D12_SUBRESOURCE_DATA> subresources;
-    hr = CreateTextureFromDDS(d3dDevice,
+    hr = CreateTextureFromDDS(device,
         header, bitData, bitSize, maxsize,
         resFlags, loadFlags,
         texture, subresources, isCubeMap);
@@ -935,7 +935,7 @@ HRESULT DirectX::CreateDDSTextureFromMemoryEx(
 //--------------------------------------------------------------------------------------
 _Use_decl_annotations_
 HRESULT DirectX::CreateDDSTextureFromFile(
-    ID3D12Device* d3dDevice,
+    ID3D12Device* device,
     ResourceUploadBatch& resourceUpload,
     const wchar_t* fileName,
     ID3D12Resource** texture,
@@ -945,7 +945,7 @@ HRESULT DirectX::CreateDDSTextureFromFile(
     bool* isCubeMap)
 {
     return CreateDDSTextureFromFileEx(
-        d3dDevice,
+        device,
         resourceUpload,
         fileName,
         maxsize,
@@ -958,7 +958,7 @@ HRESULT DirectX::CreateDDSTextureFromFile(
 
 _Use_decl_annotations_
 HRESULT DirectX::CreateDDSTextureFromFileEx(
-    ID3D12Device* d3dDevice,
+    ID3D12Device* device,
     ResourceUploadBatch& resourceUpload,
     const wchar_t* fileName,
     size_t maxsize,
@@ -981,7 +981,7 @@ HRESULT DirectX::CreateDDSTextureFromFileEx(
         *isCubeMap = false;
     }
 
-    if (!d3dDevice || !fileName || !texture)
+    if (!device || !fileName || !texture)
     {
         return E_INVALIDARG;
     }
@@ -1013,7 +1013,7 @@ HRESULT DirectX::CreateDDSTextureFromFileEx(
     }
 
     std::vector<D3D12_SUBRESOURCE_DATA> subresources;
-    hr = CreateTextureFromDDS(d3dDevice,
+    hr = CreateTextureFromDDS(device,
         header, bitData, bitSize, maxsize,
         resFlags, loadFlags,
         texture, subresources, isCubeMap);
@@ -1062,7 +1062,7 @@ HRESULT DirectX::CreateDDSTextureFromFileEx(
 namespace DirectX
 {
     HRESULT __cdecl LoadDDSTextureFromFile(
-        _In_ ID3D12Device* d3dDevice,
+        _In_ ID3D12Device* device,
         _In_z_ const __wchar_t* szFileName,
         _Outptr_ ID3D12Resource** texture,
         std::unique_ptr<uint8_t[]>& ddsData,
@@ -1071,7 +1071,7 @@ namespace DirectX
         _Out_opt_ DDS_ALPHA_MODE* alphaMode,
         _Out_opt_ bool* isCubeMap)
     {
-        return LoadDDSTextureFromFile(d3dDevice,
+        return LoadDDSTextureFromFile(device,
             reinterpret_cast<const unsigned short*>(szFileName),
             texture, ddsData, subresources, maxsize, alphaMode, isCubeMap);
     }
@@ -1092,7 +1092,7 @@ namespace DirectX
     }
 
     HRESULT __cdecl LoadDDSTextureFromFileEx(
-        _In_ ID3D12Device* d3dDevice,
+        _In_ ID3D12Device* device,
         _In_z_ const __wchar_t* szFileName,
         size_t maxsize,
         D3D12_RESOURCE_FLAGS resFlags,
@@ -1103,7 +1103,7 @@ namespace DirectX
         _Out_opt_ DDS_ALPHA_MODE* alphaMode,
         _Out_opt_ bool* isCubeMap)
     {
-        return LoadDDSTextureFromFileEx(d3dDevice,
+        return LoadDDSTextureFromFileEx(device,
             reinterpret_cast<const unsigned short*>(szFileName),
             maxsize, resFlags, loadFlags, texture, ddsData, subresources, alphaMode, isCubeMap);
     }

--- a/Src/WICTextureLoader.cpp
+++ b/Src/WICTextureLoader.cpp
@@ -235,7 +235,7 @@ namespace
     }
 
     //---------------------------------------------------------------------------------
-    HRESULT CreateTextureFromWIC(_In_ ID3D12Device* d3dDevice,
+    HRESULT CreateTextureFromWIC(_In_ ID3D12Device* device,
         _In_ IWICBitmapFrameDecode *frame,
         size_t maxsize,
         D3D12_RESOURCE_FLAGS resFlags,
@@ -537,7 +537,7 @@ namespace
         const CD3DX12_HEAP_PROPERTIES defaultHeapProperties(D3D12_HEAP_TYPE_DEFAULT);
 
         ID3D12Resource* tex = nullptr;
-        hr = d3dDevice->CreateCommittedResource(
+        hr = device->CreateCommittedResource(
             &defaultHeapProperties,
             D3D12_HEAP_FLAG_NONE,
             &desc,
@@ -609,7 +609,7 @@ namespace
 //--------------------------------------------------------------------------------------
 _Use_decl_annotations_
 HRESULT DirectX::LoadWICTextureFromMemory(
-    ID3D12Device* d3dDevice,
+    ID3D12Device* device,
     const uint8_t* wicData,
     size_t wicDataSize,
     ID3D12Resource** texture,
@@ -618,7 +618,7 @@ HRESULT DirectX::LoadWICTextureFromMemory(
     size_t maxsize) noexcept
 {
     return LoadWICTextureFromMemoryEx(
-        d3dDevice,
+        device,
         wicData,
         wicDataSize,
         maxsize,
@@ -631,7 +631,7 @@ HRESULT DirectX::LoadWICTextureFromMemory(
 
 _Use_decl_annotations_
 HRESULT DirectX::CreateWICTextureFromMemory(
-    ID3D12Device* d3dDevice,
+    ID3D12Device* device,
     ResourceUploadBatch& resourceUpload,
     const uint8_t* wicData,
     size_t wicDataSize,
@@ -640,7 +640,7 @@ HRESULT DirectX::CreateWICTextureFromMemory(
     size_t maxsize)
 {
     return CreateWICTextureFromMemoryEx(
-        d3dDevice,
+        device,
         resourceUpload,
         wicData,
         wicDataSize,
@@ -654,7 +654,7 @@ HRESULT DirectX::CreateWICTextureFromMemory(
 //--------------------------------------------------------------------------------------
 _Use_decl_annotations_
 HRESULT DirectX::LoadWICTextureFromMemoryEx(
-    ID3D12Device* d3dDevice,
+    ID3D12Device* device,
     const uint8_t* wicData,
     size_t wicDataSize,
     size_t maxsize,
@@ -669,7 +669,7 @@ HRESULT DirectX::LoadWICTextureFromMemoryEx(
         *texture = nullptr;
     }
 
-    if (!d3dDevice || !wicData || !texture)
+    if (!device || !wicData || !texture)
         return E_INVALIDARG;
 
     if (!wicDataSize)
@@ -703,7 +703,7 @@ HRESULT DirectX::LoadWICTextureFromMemoryEx(
     if (FAILED(hr))
         return hr;
 
-    hr = CreateTextureFromWIC(d3dDevice,
+    hr = CreateTextureFromWIC(device,
         frame.Get(), maxsize,
         resFlags, loadFlags,
         texture, decodedData, subresource);
@@ -718,7 +718,7 @@ HRESULT DirectX::LoadWICTextureFromMemoryEx(
 
 _Use_decl_annotations_
 HRESULT DirectX::CreateWICTextureFromMemoryEx(
-    ID3D12Device* d3dDevice,
+    ID3D12Device* device,
     ResourceUploadBatch& resourceUpload,
     const uint8_t* wicData,
     size_t wicDataSize,
@@ -732,7 +732,7 @@ HRESULT DirectX::CreateWICTextureFromMemoryEx(
         *texture = nullptr;
     }
 
-    if (!d3dDevice || !wicData || !texture)
+    if (!device || !wicData || !texture)
         return E_INVALIDARG;
 
     if (!wicDataSize)
@@ -778,7 +778,7 @@ HRESULT DirectX::CreateWICTextureFromMemoryEx(
 
     std::unique_ptr<uint8_t[]> decodedData;
     D3D12_SUBRESOURCE_DATA initData;
-    hr = CreateTextureFromWIC(d3dDevice,
+    hr = CreateTextureFromWIC(device,
         frame.Get(), maxsize,
         resFlags, loadFlags,
         texture, decodedData, initData);
@@ -814,7 +814,7 @@ HRESULT DirectX::CreateWICTextureFromMemoryEx(
 //--------------------------------------------------------------------------------------
 _Use_decl_annotations_
 HRESULT DirectX::LoadWICTextureFromFile(
-    ID3D12Device* d3dDevice,
+    ID3D12Device* device,
     const wchar_t* fileName,
     ID3D12Resource** texture,
     std::unique_ptr<uint8_t[]>& wicData,
@@ -822,7 +822,7 @@ HRESULT DirectX::LoadWICTextureFromFile(
     size_t maxsize) noexcept
 {
     return LoadWICTextureFromFileEx(
-        d3dDevice,
+        device,
         fileName,
         maxsize,
         D3D12_RESOURCE_FLAG_NONE,
@@ -834,7 +834,7 @@ HRESULT DirectX::LoadWICTextureFromFile(
 
 _Use_decl_annotations_
 HRESULT DirectX::CreateWICTextureFromFile(
-    ID3D12Device* d3dDevice,
+    ID3D12Device* device,
     ResourceUploadBatch& resourceUpload,
     const wchar_t* fileName,
     ID3D12Resource** texture,
@@ -842,7 +842,7 @@ HRESULT DirectX::CreateWICTextureFromFile(
     size_t maxsize)
 {
     return CreateWICTextureFromFileEx(
-        d3dDevice,
+        device,
         resourceUpload,
         fileName,
         maxsize,
@@ -855,7 +855,7 @@ HRESULT DirectX::CreateWICTextureFromFile(
 //--------------------------------------------------------------------------------------
 _Use_decl_annotations_
 HRESULT DirectX::LoadWICTextureFromFileEx(
-    ID3D12Device* d3dDevice,
+    ID3D12Device* device,
     const wchar_t* fileName,
     size_t maxsize,
     D3D12_RESOURCE_FLAGS resFlags,
@@ -869,7 +869,7 @@ HRESULT DirectX::LoadWICTextureFromFileEx(
         *texture = nullptr;
     }
 
-    if (!d3dDevice || !fileName || !texture)
+    if (!device || !fileName || !texture)
         return E_INVALIDARG;
 
     auto pWIC = GetWIC();
@@ -891,7 +891,7 @@ HRESULT DirectX::LoadWICTextureFromFileEx(
     if (FAILED(hr))
         return hr;
 
-    hr = CreateTextureFromWIC(d3dDevice, frame.Get(), maxsize,
+    hr = CreateTextureFromWIC(device, frame.Get(), maxsize,
         resFlags, loadFlags,
         texture, decodedData, subresource);
 
@@ -905,7 +905,7 @@ HRESULT DirectX::LoadWICTextureFromFileEx(
 
 _Use_decl_annotations_
 HRESULT DirectX::CreateWICTextureFromFileEx(
-    ID3D12Device* d3dDevice,
+    ID3D12Device* device,
     ResourceUploadBatch& resourceUpload,
     const wchar_t* fileName,
     size_t maxsize,
@@ -918,7 +918,7 @@ HRESULT DirectX::CreateWICTextureFromFileEx(
         *texture = nullptr;
     }
 
-    if (!d3dDevice || !fileName || !texture)
+    if (!device || !fileName || !texture)
         return E_INVALIDARG;
 
     auto pWIC = GetWIC();
@@ -952,7 +952,7 @@ HRESULT DirectX::CreateWICTextureFromFileEx(
 
     std::unique_ptr<uint8_t[]> decodedData;
     D3D12_SUBRESOURCE_DATA initData;
-    hr = CreateTextureFromWIC(d3dDevice, frame.Get(), maxsize,
+    hr = CreateTextureFromWIC(device, frame.Get(), maxsize,
         resFlags, loadFlags,
         texture, decodedData, initData);
 
@@ -990,33 +990,33 @@ HRESULT DirectX::CreateWICTextureFromFileEx(
 namespace DirectX
 {
     HRESULT __cdecl LoadWICTextureFromFile(
-        _In_ ID3D12Device* d3dDevice,
+        _In_ ID3D12Device* device,
         _In_z_ const __wchar_t* szFileName,
         _Outptr_ ID3D12Resource** texture,
         std::unique_ptr<uint8_t[]>& decodedData,
         D3D12_SUBRESOURCE_DATA& subresource,
         size_t maxsize) noexcept
     {
-        return LoadWICTextureFromFile(d3dDevice,
+        return LoadWICTextureFromFile(device,
             reinterpret_cast<const unsigned short*>(szFileName),
             texture, decodedData, subresource, maxsize);
     }
 
     HRESULT __cdecl CreateWICTextureFromFile(
-        _In_ ID3D12Device* d3dDevice,
+        _In_ ID3D12Device* device,
         ResourceUploadBatch& resourceUpload,
         _In_z_ const __wchar_t* szFileName,
         _Outptr_ ID3D12Resource** texture,
         bool generateMips,
         size_t maxsize)
     {
-        return CreateWICTextureFromFile(d3dDevice, resourceUpload,
+        return CreateWICTextureFromFile(device, resourceUpload,
             reinterpret_cast<const unsigned short*>(szFileName),
             texture, generateMips, maxsize);
     }
 
     HRESULT __cdecl LoadWICTextureFromFileEx(
-        _In_ ID3D12Device* d3dDevice,
+        _In_ ID3D12Device* device,
         _In_z_ const __wchar_t* szFileName,
         size_t maxsize,
         D3D12_RESOURCE_FLAGS resFlags,
@@ -1025,13 +1025,13 @@ namespace DirectX
         std::unique_ptr<uint8_t[]>& decodedData,
         D3D12_SUBRESOURCE_DATA& subresource) noexcept
     {
-        return LoadWICTextureFromFileEx(d3dDevice,
+        return LoadWICTextureFromFileEx(device,
             reinterpret_cast<const unsigned short*>(szFileName),
             maxsize, resFlags, loadFlags, texture, decodedData, subresource);
     }
 
     HRESULT __cdecl CreateWICTextureFromFileEx(
-        _In_ ID3D12Device* d3dDevice,
+        _In_ ID3D12Device* device,
         ResourceUploadBatch& resourceUpload,
         _In_z_ const __wchar_t* szFileName,
         size_t maxsize,
@@ -1039,7 +1039,7 @@ namespace DirectX
         WIC_LOADER_FLAGS loadFlags,
         _Outptr_ ID3D12Resource** texture)
     {
-        return CreateWICTextureFromFileEx(d3dDevice, resourceUpload,
+        return CreateWICTextureFromFileEx(device, resourceUpload,
             reinterpret_cast<const unsigned short*>(szFileName),
             maxsize, resFlags, loadFlags, texture);
     }

--- a/Src/XboxDDSTextureLoader.cpp
+++ b/Src/XboxDDSTextureLoader.cpp
@@ -182,7 +182,7 @@ namespace
     }
 
     //--------------------------------------------------------------------------------------
-    HRESULT CreateD3DResources(_In_ ID3D12Device* d3dDevice,
+    HRESULT CreateD3DResources(_In_ ID3D12Device* device,
         _In_ const DDS_HEADER_XBOX* xboxext,
         _In_ uint32_t width,
         _In_ uint32_t height,
@@ -193,7 +193,7 @@ namespace
         _In_ void* grfxMemory,
         _Outptr_ ID3D12Resource** texture) noexcept
     {
-        if (!d3dDevice || !grfxMemory)
+        if (!device || !grfxMemory)
             return E_POINTER;
 
         HRESULT hr = E_FAIL;
@@ -216,7 +216,7 @@ namespace
         desc.Dimension = static_cast<D3D12_RESOURCE_DIMENSION>(xboxext->resourceDimension);
         desc.Layout = static_cast<D3D12_TEXTURE_LAYOUT>((0x100 | xboxext->tileMode) & ~XBOX_TILEMODE_SCARLETT);
 
-        hr = d3dDevice->CreatePlacedResourceX(
+        hr = device->CreatePlacedResourceX(
             reinterpret_cast<D3D12_GPU_VIRTUAL_ADDRESS>(grfxMemory),
             &desc,
             D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
@@ -232,7 +232,7 @@ namespace
     }
 
     //--------------------------------------------------------------------------------------
-    HRESULT CreateTextureFromDDS(_In_ ID3D12Device* d3dDevice,
+    HRESULT CreateTextureFromDDS(_In_ ID3D12Device* device,
         _In_ const DDS_HEADER* header,
         _In_reads_bytes_(bitSize) const uint8_t* bitData,
         _In_ size_t bitSize,
@@ -393,7 +393,7 @@ namespace
         memcpy(*grfxMemory, bitData, xboxext->dataSize);
 
         // Create the texture
-        hr = CreateD3DResources(d3dDevice, xboxext,
+        hr = CreateD3DResources(device, xboxext,
             width, height, depth, mipCount, arraySize,
             forceSRGB, *grfxMemory,
             texture);
@@ -442,7 +442,7 @@ namespace
 //--------------------------------------------------------------------------------------
 _Use_decl_annotations_
 HRESULT Xbox::CreateDDSTextureFromMemory(
-    ID3D12Device* d3dDevice,
+    ID3D12Device* device,
     const uint8_t* ddsData,
     size_t ddsDataSize,
     ID3D12Resource** texture,
@@ -471,7 +471,7 @@ HRESULT Xbox::CreateDDSTextureFromMemory(
         *isCubeMap = false;
     }
 
-    if ( !d3dDevice || !ddsData || !texture || !grfxMemory )
+    if ( !device || !ddsData || !texture || !grfxMemory )
     {
         return E_INVALIDARG;
     }
@@ -513,7 +513,7 @@ HRESULT Xbox::CreateDDSTextureFromMemory(
 
     auto offset = DDS_XBOX_HEADER_SIZE;
 
-    HRESULT hr = CreateTextureFromDDS( d3dDevice, header,
+    HRESULT hr = CreateTextureFromDDS( device, header,
                                        ddsData + offset, ddsDataSize - offset, forceSRGB,
                                        texture, grfxMemory, isCubeMap );
     if ( SUCCEEDED(hr) )
@@ -531,7 +531,7 @@ HRESULT Xbox::CreateDDSTextureFromMemory(
 //--------------------------------------------------------------------------------------
 _Use_decl_annotations_
 HRESULT Xbox::CreateDDSTextureFromFile(
-    ID3D12Device* d3dDevice,
+    ID3D12Device* device,
     const wchar_t* fileName,
     ID3D12Resource** texture,
     void** grfxMemory,
@@ -559,7 +559,7 @@ HRESULT Xbox::CreateDDSTextureFromFile(
         *isCubeMap = false;
     }
 
-    if ( !d3dDevice || !fileName || !texture || !grfxMemory )
+    if ( !device || !fileName || !texture || !grfxMemory )
     {
         return E_INVALIDARG;
     }
@@ -580,7 +580,7 @@ HRESULT Xbox::CreateDDSTextureFromFile(
         return hr;
     }
 
-    hr = CreateTextureFromDDS( d3dDevice, header,
+    hr = CreateTextureFromDDS( device, header,
                                bitData, bitSize, forceSRGB,
                                texture, grfxMemory, isCubeMap );
 


### PR DESCRIPTION
When #274 was added to make the type of `FromMemory` operations use something other than `void*`, this turns out to result in code-breaks for clients using C++17's ``std::byte*``.

This PR adds compat inlines to avoid requiring the client code add casts.

> Minor tweak to CMake to avoid requiring all clients use directxmath and directx-headers packages externally.
