### PR TITLE
Update shared components from DirectXTK

### DIFF
--- a/Audio/SoundStreamInstance.cpp
+++ b/Audio/SoundStreamInstance.cpp
@@ -579,11 +579,7 @@ HRESULT SoundStreamInstance::Impl::PlayBuffers() noexcept
         if (mPackets[j].state == State::PENDING)
         {
             DWORD cb = 0;
-        #if (_WIN32_WINNT >= _WIN32_WINNT_WIN8)
             const BOOL result = GetOverlappedResultEx(async, &mPackets[j].request, &cb, 0, FALSE);
-        #else
-            const BOOL result = GetOverlappedResult(async, &mPackets[j].request, &cb, FALSE);
-        #endif
             if (result)
             {
                 mPackets[j].state = State::READY;

--- a/Audio/WAVFileReader.cpp
+++ b/Audio/WAVFileReader.cpp
@@ -540,20 +540,10 @@ namespace
             return E_INVALIDARG;
 
         // open the file
-    #if (_WIN32_WINNT >= _WIN32_WINNT_WIN8)
         ScopedHandle hFile(safe_handle(CreateFile2(
             szFileName,
             GENERIC_READ, FILE_SHARE_READ, OPEN_EXISTING,
             nullptr)));
-    #else
-        ScopedHandle hFile(safe_handle(CreateFileW(
-            szFileName,
-            GENERIC_READ, FILE_SHARE_READ,
-            nullptr,
-            OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL,
-            nullptr)));
-    #endif
-
         if (!hFile)
         {
             return HRESULT_FROM_WIN32(GetLastError());

--- a/Inc/Audio.h
+++ b/Inc/Audio.h
@@ -36,7 +36,7 @@
 
 #if defined(USING_XAUDIO2_REDIST) || (_WIN32_WINNT >= 0x0A00 /*_WIN32_WINNT_WIN10*/) || defined(_XBOX_ONE)
 #define USING_XAUDIO2_9
-#elif (_WIN32_WINNT >= 0x0602 /*_WIN32_WINNT_WIN8*/)
+#elif (_WIN32_WINNT >= 0x0603 /*_WIN32_WINNT_WINBLUE*/)
 #define USING_XAUDIO2_8
 #else
 #error DirectX Tool Kit for Audio not supported on this platform

--- a/Inc/Audio.h
+++ b/Inc/Audio.h
@@ -38,8 +38,6 @@
 #define USING_XAUDIO2_9
 #elif (_WIN32_WINNT >= 0x0602 /*_WIN32_WINNT_WIN8*/)
 #define USING_XAUDIO2_8
-#elif (_WIN32_WINNT >= 0x0601 /*_WIN32_WINNT_WIN7*/)
-#error Windows 7 SP1 requires the XAudio2Redist NuGet package https://aka.ms/xaudio2redist
 #else
 #error DirectX Tool Kit for Audio not supported on this platform
 #endif

--- a/Inc/GamePad.h
+++ b/Inc/GamePad.h
@@ -43,11 +43,7 @@
 
 #elif defined(USING_XINPUT)
 #ifdef _MSC_VER
-#if (_WIN32_WINNT >= 0x0602 /*_WIN32_WINNT_WIN8*/ )
 #pragma comment(lib,"xinput.lib")
-#else
-#pragma comment(lib,"xinput9_1_0.lib")
-#endif
 #endif
 #endif
 

--- a/Src/BinaryReader.cpp
+++ b/Src/BinaryReader.cpp
@@ -55,20 +55,10 @@ HRESULT BinaryReader::ReadEntireFile(
     *dataSize = 0;
 
     // Open the file.
-#if (_WIN32_WINNT >= _WIN32_WINNT_WIN8)
     ScopedHandle hFile(safe_handle(CreateFile2(
         fileName,
         GENERIC_READ, FILE_SHARE_READ, OPEN_EXISTING,
         nullptr)));
-#else
-    ScopedHandle hFile(safe_handle(CreateFileW(
-        fileName,
-        GENERIC_READ, FILE_SHARE_READ,
-        nullptr,
-        OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL,
-        nullptr)));
-#endif
-
     if (!hFile)
         return HRESULT_FROM_WIN32(GetLastError());
 

--- a/Src/GamePad.cpp
+++ b/Src/GamePad.cpp
@@ -1286,11 +1286,6 @@ public:
         mOwner(owner),
         mConnected{},
         mLastReadTime{}
-    #if (_WIN32_WINNT < _WIN32_WINNT_WIN8)
-        , mLeftMotor{}
-        , mRightMotor{}
-        , mSuspended(false)
-    #endif
     {
         for (int j = 0; j < XUSER_MAX_COUNT; ++j)
         {
@@ -1319,15 +1314,6 @@ public:
 
         if (!ThrottleRetry(player, time))
         {
-        #if (_WIN32_WINNT < _WIN32_WINNT_WIN8)
-            if (mSuspended)
-            {
-                memset(&state, 0, sizeof(State));
-                state.connected = mConnected[player];
-                return;
-            }
-        #endif
-
             XINPUT_STATE xstate;
             const DWORD result = XInputGetState(DWORD(player), &xstate);
             if (result == ERROR_DEVICE_NOT_CONNECTED)
@@ -1414,7 +1400,6 @@ public:
                 if (xcaps.Type == XINPUT_DEVTYPE_GAMEPAD)
                 {
                     static_assert(Capabilities::GAMEPAD == XINPUT_DEVSUBTYPE_GAMEPAD, "xinput.h mismatch");
-                #if (_WIN32_WINNT >= _WIN32_WINNT_WIN8)
                     static_assert(XINPUT_DEVSUBTYPE_WHEEL == Capabilities::WHEEL, "xinput.h mismatch");
                     static_assert(XINPUT_DEVSUBTYPE_ARCADE_STICK == Capabilities::ARCADE_STICK, "xinput.h mismatch");
                 #ifndef __MINGW32__
@@ -1426,19 +1411,13 @@ public:
                     static_assert(XINPUT_DEVSUBTYPE_DRUM_KIT == Capabilities::DRUM_KIT, "xinput.h mismatch");
                     static_assert(XINPUT_DEVSUBTYPE_GUITAR_BASS == Capabilities::GUITAR_BASS, "xinput.h mismatch");
                     static_assert(XINPUT_DEVSUBTYPE_ARCADE_PAD == Capabilities::ARCADE_PAD, "xinput.h mismatch");
-                #endif
 
                     caps.gamepadType = Capabilities::Type(xcaps.SubType);
                 }
 
                 // Hard-coded VID/PID
                 caps.vid = 0x045E;
-            #if (_WIN32_WINNT >= _WIN32_WINNT_WIN8)
                 caps.pid = (xcaps.Flags & XINPUT_CAPS_WIRELESS) ? 0x0719 : 0;
-            #else
-                caps.pid = 0;
-            #endif
-
                 return;
             }
         }
@@ -1463,14 +1442,6 @@ public:
         UNREFERENCED_PARAMETER(leftTrigger);
         UNREFERENCED_PARAMETER(rightTrigger);
 
-    #if (_WIN32_WINNT < _WIN32_WINNT_WIN8)
-        mLeftMotor[player] = leftMotor;
-        mRightMotor[player] = rightMotor;
-
-        if (mSuspended)
-            return mConnected[player];
-    #endif
-
         XINPUT_VIBRATION xvibration;
         xvibration.wLeftMotorSpeed = WORD(leftMotor * 0xFFFF);
         xvibration.wRightMotorSpeed = WORD(rightMotor * 0xFFFF);
@@ -1494,24 +1465,8 @@ public:
     {
     #if (_WIN32_WINNT >= _WIN32_WINNT_WIN10)
         // XInput focus is handled automatically on Windows 10
-    #elif (_WIN32_WINNT >= _WIN32_WINNT_WIN8)
-        XInputEnable(FALSE);
     #else
-        // For XInput 9.1.0, we have to emulate the behavior of XInputEnable( FALSE )
-        if (!mSuspended)
-        {
-            for (size_t j = 0; j < XUSER_MAX_COUNT; ++j)
-            {
-                if (mConnected[j])
-                {
-                    XINPUT_VIBRATION xvibration;
-                    xvibration.wLeftMotorSpeed = xvibration.wRightMotorSpeed = 0;
-                    std::ignore = XInputSetState(DWORD(j), &xvibration);
-                }
-            }
-
-            mSuspended = true;
-        }
+        XInputEnable(FALSE);
     #endif
     }
 
@@ -1519,31 +1474,8 @@ public:
     {
     #if (_WIN32_WINNT >= _WIN32_WINNT_WIN10)
         // XInput focus is handled automatically on Windows 10
-    #elif (_WIN32_WINNT >= _WIN32_WINNT_WIN8)
-        XInputEnable(TRUE);
     #else
-        // For XInput 9.1.0, we have to emulate the behavior of XInputEnable( TRUE )
-        if (mSuspended)
-        {
-            const ULONGLONG time = GetTickCount64();
-
-            for (int j = 0; j < XUSER_MAX_COUNT; ++j)
-            {
-                if (mConnected[j])
-                {
-                    XINPUT_VIBRATION xvibration;
-                    xvibration.wLeftMotorSpeed = WORD(mLeftMotor[j] * 0xFFFF);
-                    xvibration.wRightMotorSpeed = WORD(mRightMotor[j] * 0xFFFF);
-                    const DWORD result = XInputSetState(DWORD(j), &xvibration);
-                    if (result == ERROR_DEVICE_NOT_CONNECTED)
-                    {
-                        ClearSlot(j, time);
-                    }
-                }
-            }
-
-            mSuspended = false;
-        }
+        XInputEnable(TRUE);
     #endif
     }
 
@@ -1554,13 +1486,6 @@ public:
 private:
     bool        mConnected[XUSER_MAX_COUNT];
     ULONGLONG   mLastReadTime[XUSER_MAX_COUNT];
-
-#if (_WIN32_WINNT < _WIN32_WINNT_WIN8)
-    // Variables for emulating XInputEnable on XInput 9.1.0
-    float       mLeftMotor[XUSER_MAX_COUNT];
-    float       mRightMotor[XUSER_MAX_COUNT];
-    bool        mSuspended;
-#endif
 
     bool ThrottleRetry(int player, ULONGLONG time)
     {
@@ -1596,9 +1521,6 @@ private:
     {
         mConnected[player] = false;
         mLastReadTime[player] = time;
-    #if (_WIN32_WINNT < _WIN32_WINNT_WIN8)
-        mLeftMotor[player] = mRightMotor[player] = 0.f;
-    #endif
     }
 
     int GetMostRecent()

--- a/Src/LoaderHelpers.h
+++ b/Src/LoaderHelpers.h
@@ -395,20 +395,10 @@ namespace DirectX
             *bitSize = 0;
 
             // open the file
-        #if (_WIN32_WINNT >= _WIN32_WINNT_WIN8)
             ScopedHandle hFile(safe_handle(CreateFile2(
                 fileName,
                 GENERIC_READ, FILE_SHARE_READ, OPEN_EXISTING,
                 nullptr)));
-        #else
-            ScopedHandle hFile(safe_handle(CreateFileW(
-                fileName,
-                GENERIC_READ, FILE_SHARE_READ,
-                nullptr,
-                OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL,
-                nullptr)));
-        #endif
-
             if (!hFile)
             {
                 return HRESULT_FROM_WIN32(GetLastError());


### PR DESCRIPTION
Removed Windows 7 support for *DirectX Tool Kit for Audio* and shared components with *DirectX Tool Kit for DX11*. That library now requires Windows 8.1 or later.

GamePad always uses XInput 1.4 rather than XInput 9.1.0

Always uses CreateFile2, GetOverlappedResultEx, and WIC2

> Note that Steam dropped support in January 2024 for Windows 7, Windows 8.0, and Windows 8.1 so this cleanup was overdue. 
