### PR TITLE
Code review for Mouse CoreWindow implementation

### DIFF
--- a/Src/Mouse.cpp
+++ b/Src/Mouse.cpp
@@ -533,7 +533,7 @@ public:
     explicit Impl(Mouse* owner) noexcept(false) :
         mState{},
         mOwner(owner),
-        mDPI(96.f),
+        mDPI(USER_DEFAULT_SCREEN_DPI),
         mMode(MODE_ABSOLUTE),
         mAutoReset(true),
         mLastX(0),
@@ -906,8 +906,8 @@ private:
 
             const float dpi = s_mouse->mDPI;
 
-            s_mouse->mState.x = static_cast<int>(pos.X * dpi / 96.f + 0.5f);
-            s_mouse->mState.y = static_cast<int>(pos.Y * dpi / 96.f + 0.5f);
+            s_mouse->mState.x = static_cast<int>(pos.X * dpi / USER_DEFAULT_SCREEN_DPI + 0.5f);
+            s_mouse->mState.y = static_cast<int>(pos.Y * dpi / USER_DEFAULT_SCREEN_DPI + 0.5f);
         }
 
         return S_OK;
@@ -970,8 +970,8 @@ private:
 
                 float dpi = s_mouse->mDPI;
 
-                s_mouse->mState.x = static_cast<int>(pos.X * dpi / 96.f + 0.5f);
-                s_mouse->mState.y = static_cast<int>(pos.Y * dpi / 96.f + 0.5f);
+                s_mouse->mState.x = static_cast<int>(pos.X * dpi / USER_DEFAULT_SCREEN_DPI + 0.5f);
+                s_mouse->mState.y = static_cast<int>(pos.Y * dpi / USER_DEFAULT_SCREEN_DPI + 0.5f);
             }
         }
 

--- a/Src/Mouse.cpp
+++ b/Src/Mouse.cpp
@@ -909,8 +909,8 @@ private:
 
             const float dpi = s_mouse->mDPI;
 
-            s_mouse->mState.x = static_cast<int>(pos.X * dpi / float(USER_DEFAULT_SCREEN_DPI) + 0.5f);
-            s_mouse->mState.y = static_cast<int>(pos.Y * dpi / float(USER_DEFAULT_SCREEN_DPI) + 0.5f);
+            s_mouse->mState.x = static_cast<int>(pos.X * dpi / USER_DEFAULT_SCREEN_DPI + 0.5f);
+            s_mouse->mState.y = static_cast<int>(pos.Y * dpi / USER_DEFAULT_SCREEN_DPI + 0.5f);
         }
 
         return S_OK;
@@ -973,8 +973,8 @@ private:
 
                 float dpi = s_mouse->mDPI;
 
-                s_mouse->mState.x = static_cast<int>(pos.X * dpi / float(USER_DEFAULT_SCREEN_DPI) + 0.5f);
-                s_mouse->mState.y = static_cast<int>(pos.Y * dpi / float(USER_DEFAULT_SCREEN_DPI) + 0.5f);
+                s_mouse->mState.x = static_cast<int>(pos.X * dpi / USER_DEFAULT_SCREEN_DPI + 0.5f);
+                s_mouse->mState.y = static_cast<int>(pos.Y * dpi / USER_DEFAULT_SCREEN_DPI + 0.5f);
             }
         }
 

--- a/Src/Mouse.cpp
+++ b/Src/Mouse.cpp
@@ -527,6 +527,9 @@ void Mouse::SetWindow(HWND window)
 
 #include <Windows.Devices.Input.h>
 
+// This symbol is defined for Win32 desktop applications, but not for UWP
+constexpr float USER_DEFAULT_SCREEN_DPI = 96.f;
+
 class Mouse::Impl
 {
 public:
@@ -906,8 +909,8 @@ private:
 
             const float dpi = s_mouse->mDPI;
 
-            s_mouse->mState.x = static_cast<int>(pos.X * dpi / USER_DEFAULT_SCREEN_DPI + 0.5f);
-            s_mouse->mState.y = static_cast<int>(pos.Y * dpi / USER_DEFAULT_SCREEN_DPI + 0.5f);
+            s_mouse->mState.x = static_cast<int>(pos.X * dpi / float(USER_DEFAULT_SCREEN_DPI) + 0.5f);
+            s_mouse->mState.y = static_cast<int>(pos.Y * dpi / float(USER_DEFAULT_SCREEN_DPI) + 0.5f);
         }
 
         return S_OK;
@@ -970,8 +973,8 @@ private:
 
                 float dpi = s_mouse->mDPI;
 
-                s_mouse->mState.x = static_cast<int>(pos.X * dpi / USER_DEFAULT_SCREEN_DPI + 0.5f);
-                s_mouse->mState.y = static_cast<int>(pos.Y * dpi / USER_DEFAULT_SCREEN_DPI + 0.5f);
+                s_mouse->mState.x = static_cast<int>(pos.X * dpi / float(USER_DEFAULT_SCREEN_DPI) + 0.5f);
+                s_mouse->mState.y = static_cast<int>(pos.Y * dpi / float(USER_DEFAULT_SCREEN_DPI) + 0.5f);
             }
         }
 


### PR DESCRIPTION
Use USER_DEFAULT_SCREEN_DPI define instead of 96 value.