### PR TITLE
Code review for const auto vs auto const

### DIFF
--- a/Audio/SoundCommon.cpp
+++ b/Audio/SoundCommon.cpp
@@ -478,7 +478,7 @@ bool DirectX::IsValid(_In_ const WAVEFORMATEX* wfx) noexcept
 
             if (wfex->dwChannelMask)
             {
-                auto const channelBits = ChannelsSpecifiedInMask(wfex->dwChannelMask);
+                const auto channelBits = ChannelsSpecifiedInMask(wfex->dwChannelMask);
                 if (channelBits != wfx->nChannels)
                 {
                     DebugTrace("ERROR: WAVEFORMATEXTENSIBLE: nChannels=%u but ChannelMask has %u bits set\n",

--- a/Audio/SoundStreamInstance.cpp
+++ b/Audio/SoundStreamInstance.cpp
@@ -524,7 +524,7 @@ HRESULT SoundStreamInstance::Impl::ReadBuffers() noexcept
         {
             if (mCurrentPosition < mLengthInBytes)
             {
-                auto const cbValid = static_cast<uint32_t>(std::min(mPacketSize, mLengthInBytes - mCurrentPosition));
+                const auto cbValid = static_cast<uint32_t>(std::min(mPacketSize, mLengthInBytes - mCurrentPosition));
 
                 mPackets[entry].valid = cbValid;
                 mPackets[entry].audioBytes = 0;

--- a/Src/AlphaTestEffect.cpp
+++ b/Src/AlphaTestEffect.cpp
@@ -304,7 +304,7 @@ void AlphaTestEffect::Impl::Apply(_In_ ID3D12GraphicsCommandList* commandList)
     if (dirtyFlags & EffectDirtyFlags::AlphaTest)
     {
         // Convert reference alpha from 8 bit integer to 0-1 float format.
-        auto const reference = static_cast<float>(referenceAlpha) / 255.0f;
+        const auto reference = static_cast<float>(referenceAlpha) / 255.0f;
 
         // Comparison tolerance of half the 8 bit integer precision.
         constexpr float threshold = 0.5f / 255.0f;

--- a/Src/BufferHelpers.cpp
+++ b/Src/BufferHelpers.cpp
@@ -48,7 +48,7 @@ HRESULT DirectX::CreateStaticBuffer(
         return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
     }
 
-    auto const desc = CD3DX12_RESOURCE_DESC::Buffer(sizeInbytes, resFlags);
+    const auto desc = CD3DX12_RESOURCE_DESC::Buffer(sizeInbytes, resFlags);
 
     const CD3DX12_HEAP_PROPERTIES heapProperties(D3D12_HEAP_TYPE_DEFAULT);
 
@@ -111,7 +111,7 @@ HRESULT DirectX::CreateUAVBuffer(
         return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
     }
 
-    auto const desc = CD3DX12_RESOURCE_DESC::Buffer(bufferSize, D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS | additionalResFlags);
+    const auto desc = CD3DX12_RESOURCE_DESC::Buffer(bufferSize, D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS | additionalResFlags);
 
     const CD3DX12_HEAP_PROPERTIES heapProperties(D3D12_HEAP_TYPE_DEFAULT);
 
@@ -160,7 +160,7 @@ HRESULT DirectX::CreateUploadBuffer(
         return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
     }
 
-    auto const desc = CD3DX12_RESOURCE_DESC::Buffer(sizeInbytes, resFlags);
+    const auto desc = CD3DX12_RESOURCE_DESC::Buffer(sizeInbytes, resFlags);
 
     const CD3DX12_HEAP_PROPERTIES heapProperties(D3D12_HEAP_TYPE_UPLOAD);
 
@@ -220,7 +220,7 @@ HRESULT DirectX::CreateTextureFromMemory(
         return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
     }
 
-    auto const desc = CD3DX12_RESOURCE_DESC::Tex1D(format, static_cast<UINT64>(width), 1u, 1u, resFlags);
+    const auto desc = CD3DX12_RESOURCE_DESC::Tex1D(format, static_cast<UINT64>(width), 1u, 1u, resFlags);
 
     const CD3DX12_HEAP_PROPERTIES heapProperties(D3D12_HEAP_TYPE_DEFAULT);
 
@@ -296,7 +296,7 @@ HRESULT DirectX::CreateTextureFromMemory(
         }
     }
 
-    auto const desc = CD3DX12_RESOURCE_DESC::Tex2D(format, static_cast<UINT64>(width), static_cast<UINT>(height),
+    const auto desc = CD3DX12_RESOURCE_DESC::Tex2D(format, static_cast<UINT64>(width), static_cast<UINT>(height),
         1u, mipCount, 1u, 0u, resFlags);
 
     const CD3DX12_HEAP_PROPERTIES heapProperties(D3D12_HEAP_TYPE_DEFAULT);
@@ -368,7 +368,7 @@ HRESULT DirectX::CreateTextureFromMemory(
         return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
     }
 
-    auto const desc = CD3DX12_RESOURCE_DESC::Tex3D(format,
+    const auto desc = CD3DX12_RESOURCE_DESC::Tex3D(format,
         static_cast<UINT64>(width), static_cast<UINT>(height), static_cast<UINT16>(depth),
         1u, resFlags);
 

--- a/Src/EffectTextureFactory.cpp
+++ b/Src/EffectTextureFactory.cpp
@@ -200,7 +200,7 @@ size_t EffectTextureFactory::Impl::CreateTexture(_In_z_ const wchar_t* name, int
     assert(textureEntry.mResource != nullptr);
 
     // bind a new descriptor in slot
-    auto const textureDescriptor = mTextureDescriptorHeap.GetCpuHandle(static_cast<size_t>(descriptorSlot));
+    const auto textureDescriptor = mTextureDescriptorHeap.GetCpuHandle(static_cast<size_t>(descriptorSlot));
     DirectX::CreateShaderResourceView(mDevice.Get(), textureEntry.mResource.Get(), textureDescriptor, textureEntry.mIsCubeMap);
 
     return textureEntry.slot;

--- a/Src/GeometricPrimitive.cpp
+++ b/Src/GeometricPrimitive.cpp
@@ -75,7 +75,7 @@ void GeometricPrimitive::Impl::Initialize(
     if (sizeInBytes > uint64_t(D3D12_REQ_RESOURCE_SIZE_IN_MEGABYTES_EXPRESSION_A_TERM * 1024u * 1024u))
         throw std::invalid_argument("VB too large for DirectX 12");
 
-    auto const vertSizeBytes = static_cast<size_t>(sizeInBytes);
+    const auto vertSizeBytes = static_cast<size_t>(sizeInBytes);
 
     mVertexBuffer = GraphicsMemory::Get(device).Allocate(vertSizeBytes, 16, GraphicsMemory::TAG_VERTEX);
 
@@ -87,7 +87,7 @@ void GeometricPrimitive::Impl::Initialize(
     if (sizeInBytes > uint64_t(D3D12_REQ_RESOURCE_SIZE_IN_MEGABYTES_EXPRESSION_A_TERM * 1024u * 1024u))
         throw std::invalid_argument("IB too large for DirectX 12");
 
-    auto const indSizeBytes = static_cast<size_t>(sizeInBytes);
+    const auto indSizeBytes = static_cast<size_t>(sizeInBytes);
 
     mIndexBuffer = GraphicsMemory::Get(device).Allocate(indSizeBytes, 16, GraphicsMemory::TAG_INDEX);
 
@@ -121,7 +121,7 @@ void GeometricPrimitive::Impl::LoadStaticBuffers(
     {
         assert(mVertexBuffer);
 
-        auto const desc = CD3DX12_RESOURCE_DESC::Buffer(mVertexBuffer.Size());
+        const auto desc = CD3DX12_RESOURCE_DESC::Buffer(mVertexBuffer.Size());
 
         ThrowIfFailed(device->CreateCommittedResource(
             &heapProperties,
@@ -150,7 +150,7 @@ void GeometricPrimitive::Impl::LoadStaticBuffers(
     {
         assert(mIndexBuffer);
 
-        auto const desc = CD3DX12_RESOURCE_DESC::Buffer(mIndexBuffer.Size());
+        const auto desc = CD3DX12_RESOURCE_DESC::Buffer(mIndexBuffer.Size());
 
         ThrowIfFailed(device->CreateCommittedResource(
             &heapProperties,

--- a/Src/Geometry.cpp
+++ b/Src/Geometry.cpp
@@ -307,7 +307,7 @@ void DirectX::ComputeGeoSphere(VertexCollection& vertices, IndexCollection& indi
             uint16_t iv20; // index of v20
 
             // Function that, when given the index of two vertices, creates a new vertex at the midpoint of those vertices.
-            auto const divideEdge = [&](uint16_t i0, uint16_t i1, XMFLOAT3& outVertex, uint16_t& outIndex)
+            const auto divideEdge = [&](uint16_t i0, uint16_t i1, XMFLOAT3& outVertex, uint16_t& outIndex)
             {
                 const UndirectedEdge edge = makeUndirectedEdge(i0, i1);
 
@@ -372,8 +372,8 @@ void DirectX::ComputeGeoSphere(VertexCollection& vertices, IndexCollection& indi
     vertices.reserve(vertexPositions.size());
     for (const auto& it : vertexPositions)
     {
-        auto const normal = XMVector3Normalize(XMLoadFloat3(&it));
-        auto const pos = XMVectorScale(normal, radius);
+        const auto normal = XMVector3Normalize(XMLoadFloat3(&it));
+        const auto pos = XMVectorScale(normal, radius);
 
         XMFLOAT3 normalFloat3;
         XMStoreFloat3(&normalFloat3, normal);
@@ -385,7 +385,7 @@ void DirectX::ComputeGeoSphere(VertexCollection& vertices, IndexCollection& indi
         const float u = longitude / XM_2PI + 0.5f;
         const float v = latitude / XM_PI;
 
-        auto const texcoord = XMVectorSet(1.0f - u, v, 0.0f, 0.0f);
+        const auto texcoord = XMVectorSet(1.0f - u, v, 0.0f, 0.0f);
         vertices.push_back(VertexPositionNormalTexture(pos, normal, texcoord));
     }
 
@@ -468,7 +468,7 @@ void DirectX::ComputeGeoSphere(VertexCollection& vertices, IndexCollection& indi
     // onto a single point. In general there's no real way to do that right. But to match the behavior of non-geodesic
     // spheres, we need to duplicate the pole vertex for every triangle that uses it. This will introduce seams near the
     // poles, but reduce stretching.
-    auto const fixPole = [&](size_t poleIndex)
+    const auto fixPole = [&](size_t poleIndex)
     {
         const auto& poleVertex = vertices[poleIndex];
         bool overwrittenPoleVertex = false; // overwriting the original pole vertex saves us one vertex

--- a/Src/LoaderHelpers.h
+++ b/Src/LoaderHelpers.h
@@ -340,7 +340,7 @@ namespace DirectX
             }
 
             // DDS files always start with the same magic number ("DDS ")
-            auto const dwMagicNumber = *reinterpret_cast<const uint32_t*>(ddsData);
+            const auto dwMagicNumber = *reinterpret_cast<const uint32_t*>(ddsData);
             if (dwMagicNumber != DDS_MAGIC)
             {
                 return E_FAIL;
@@ -450,7 +450,7 @@ namespace DirectX
             }
 
             // DDS files always start with the same magic number ("DDS ")
-            auto const dwMagicNumber = *reinterpret_cast<const uint32_t*>(ddsData.get());
+            const auto dwMagicNumber = *reinterpret_cast<const uint32_t*>(ddsData.get());
             if (dwMagicNumber != DDS_MAGIC)
             {
                 ddsData.reset();
@@ -963,7 +963,7 @@ namespace DirectX
                 if (MAKEFOURCC('D', 'X', '1', '0') == header->ddspf.fourCC)
                 {
                     auto d3d10ext = reinterpret_cast<const DDS_HEADER_DXT10*>(reinterpret_cast<const uint8_t*>(header) + sizeof(DDS_HEADER));
-                    auto const mode = static_cast<DDS_ALPHA_MODE>(d3d10ext->miscFlags2 & DDS_MISC_FLAGS2_ALPHA_MODE_MASK);
+                    const auto mode = static_cast<DDS_ALPHA_MODE>(d3d10ext->miscFlags2 & DDS_MISC_FLAGS2_ALPHA_MODE_MASK);
                     switch (mode)
                     {
                     case DDS_ALPHA_MODE_STRAIGHT:

--- a/Src/Model.cpp
+++ b/Src/Model.cpp
@@ -352,7 +352,7 @@ void Model::LoadStaticBuffers(
 
             part->vertexBufferSize = static_cast<uint32_t>(part->vertexBuffer.Size());
 
-            auto const desc = CD3DX12_RESOURCE_DESC::Buffer(part->vertexBuffer.Size());
+            const auto desc = CD3DX12_RESOURCE_DESC::Buffer(part->vertexBuffer.Size());
 
             ThrowIfFailed(device->CreateCommittedResource(
                 &heapProperties,
@@ -408,7 +408,7 @@ void Model::LoadStaticBuffers(
 
             part->indexBufferSize = static_cast<uint32_t>(part->indexBuffer.Size());
 
-            auto const desc = CD3DX12_RESOURCE_DESC::Buffer(part->indexBuffer.Size());
+            const auto desc = CD3DX12_RESOURCE_DESC::Buffer(part->indexBuffer.Size());
 
             ThrowIfFailed(device->CreateCommittedResource(
                 &heapProperties,

--- a/Src/ModelLoadCMO.cpp
+++ b/Src/ModelLoadCMO.cpp
@@ -376,7 +376,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
                     throw std::runtime_error("IB too large for DirectX 12");
             }
 
-            auto const ibBytes = static_cast<size_t>(sizeInBytes);
+            const auto ibBytes = static_cast<size_t>(sizeInBytes);
 
             auto indexes = reinterpret_cast<const uint16_t*>(meshData + usedSize);
             usedSize += ibBytes;

--- a/Src/ModelLoadSDKMESH.cpp
+++ b/Src/ModelLoadSDKMESH.cpp
@@ -613,7 +613,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(
         // Create subsets
         for (size_t j = 0; j < mh.NumSubsets; ++j)
         {
-            auto const sIndex = subsets[j];
+            const auto sIndex = subsets[j];
             if (sIndex >= header->NumTotalSubsets)
                 throw std::out_of_range("Invalid mesh found");
 
@@ -679,14 +679,14 @@ std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(
 
             // Vertex data
             auto verts = bufferData + (vh.DataOffset - bufferDataOffset);
-            auto const vbytes = static_cast<size_t>(vh.SizeBytes);
+            const auto vbytes = static_cast<size_t>(vh.SizeBytes);
             part->vertexBufferSize = static_cast<uint32_t>(vh.SizeBytes);
             part->vertexBuffer = GraphicsMemory::Get(device).Allocate(vbytes, 16, GraphicsMemory::TAG_VERTEX);
             memcpy(part->vertexBuffer.Memory(), verts, vbytes);
 
             // Index data
             auto indices = bufferData + (ih.DataOffset - bufferDataOffset);
-            auto const ibytes = static_cast<size_t>(ih.SizeBytes);
+            const auto ibytes = static_cast<size_t>(ih.SizeBytes);
             part->indexBufferSize = static_cast<uint32_t>(ih.SizeBytes);
             part->indexBuffer = GraphicsMemory::Get(device).Allocate(ibytes, 16, GraphicsMemory::TAG_INDEX);
             memcpy(part->indexBuffer.Memory(), indices, ibytes);

--- a/Src/ModelLoadVBO.cpp
+++ b/Src/ModelLoadVBO.cpp
@@ -76,7 +76,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromVBO(
             throw std::runtime_error("VB too large for DirectX 12");
     }
 
-    auto const vertSize = static_cast<size_t>(sizeInBytes);
+    const auto vertSize = static_cast<size_t>(sizeInBytes);
 
     if (dataSize < (vertSize + sizeof(VBO::header_t)))
         throw std::runtime_error("End of file");
@@ -92,7 +92,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromVBO(
             throw std::runtime_error("IB too large for DirectX 12");
     }
 
-    auto const indexSize = static_cast<size_t>(sizeInBytes);
+    const auto indexSize = static_cast<size_t>(sizeInBytes);
 
     if (dataSize < (sizeof(VBO::header_t) + vertSize + indexSize))
         throw std::runtime_error("End of file");

--- a/Src/Mouse.cpp
+++ b/Src/Mouse.cpp
@@ -1443,8 +1443,8 @@ void Mouse::ProcessMessage(UINT message, WPARAM wParam, LPARAM lParam)
                     const int width = GetSystemMetrics(SM_CXVIRTUALSCREEN);
                     const int height = GetSystemMetrics(SM_CYVIRTUALSCREEN);
 
-                    auto const x = static_cast<int>((float(raw.data.mouse.lLastX) / 65535.0f) * float(width));
-                    auto const y = static_cast<int>((float(raw.data.mouse.lLastY) / 65535.0f) * float(height));
+                    const auto x = static_cast<int>((float(raw.data.mouse.lLastX) / 65535.0f) * float(width));
+                    const auto y = static_cast<int>((float(raw.data.mouse.lLastY) / 65535.0f) * float(height));
 
                     if (pImpl->mRelativeX == INT32_MAX)
                     {

--- a/Src/NormalMapEffect.cpp
+++ b/Src/NormalMapEffect.cpp
@@ -621,7 +621,7 @@ void NormalMapEffect::Impl::Apply(_In_ ID3D12GraphicsCommandList* commandList)
     }
 
     // Set constants
-    auto const cbuffer = GetConstantBufferGpuAddress();
+    const auto cbuffer = GetConstantBufferGpuAddress();
     commandList->SetGraphicsRootConstantBufferView(RootParameterIndex::ConstantBuffer, cbuffer);
     commandList->SetGraphicsRootConstantBufferView(RootParameterIndex::ConstantBufferBones,
         (weightsPerVertex > 0) ? mBones.GpuAddress() : cbuffer);

--- a/Src/PBREffect.cpp
+++ b/Src/PBREffect.cpp
@@ -641,7 +641,7 @@ void PBREffect::Impl::Apply(_In_ ID3D12GraphicsCommandList* commandList)
     }
 
     // Set constants
-    auto const cbuffer = GetConstantBufferGpuAddress();
+    const auto cbuffer = GetConstantBufferGpuAddress();
     commandList->SetGraphicsRootConstantBufferView(RootParameterIndex::ConstantBuffer, cbuffer);
     commandList->SetGraphicsRootConstantBufferView(RootParameterIndex::ConstantBufferBones,
         (weightsPerVertex > 0) ? mBones.GpuAddress() : cbuffer);

--- a/Src/ResourceUploadBatch.cpp
+++ b/Src/ResourceUploadBatch.cpp
@@ -374,7 +374,7 @@ public:
             numSubresources);
 
         const CD3DX12_HEAP_PROPERTIES heapProps(D3D12_HEAP_TYPE_UPLOAD);
-        auto const resDesc = CD3DX12_RESOURCE_DESC::Buffer(uploadSize);
+        const auto resDesc = CD3DX12_RESOURCE_DESC::Buffer(uploadSize);
 
         // Create a temporary buffer
         ComPtr<ID3D12Resource> scratchResource = nullptr;
@@ -706,7 +706,7 @@ private:
 
         SetDebugObjectName(descriptorHeap.Get(), L"ResourceUploadBatch");
 
-        auto const descriptorSize = static_cast<int>(mDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV));
+        const auto descriptorSize = static_cast<int>(mDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV));
 
         // Create the top-level SRV
     #if defined(_MSC_VER) || !defined(_WIN32)
@@ -947,7 +947,7 @@ private:
 
         D3D12_HEAP_DESC heapDesc = {};
     #if defined(_MSC_VER) || !defined(_WIN32)
-        auto const allocInfo = mDevice->GetResourceAllocationInfo(0, 1, &copyDesc);
+        const auto allocInfo = mDevice->GetResourceAllocationInfo(0, 1, &copyDesc);
     #else
         D3D12_RESOURCE_ALLOCATION_INFO allocInfo;
         std::ignore = mDevice->GetResourceAllocationInfo(&allocInfo, 0, 1, &copyDesc);

--- a/Src/SharedResourcePool.h
+++ b/Src/SharedResourcePool.h
@@ -93,7 +93,7 @@ namespace DirectX
             {
                 const std::lock_guard<std::mutex> lock(mResourceMap->mutex);
 
-                auto const pos = mResourceMap->find(mKey);
+                const auto pos = mResourceMap->find(mKey);
 
                 // Check for weak reference expiry before erasing, in case DemandCreate runs on
                 // a different thread at the same time as a previous instance is being destroyed.

--- a/Src/SpriteBatch.cpp
+++ b/Src/SpriteBatch.cpp
@@ -312,7 +312,7 @@ void SpriteBatch::Impl::DeviceResources::CreateIndexBuffer(_In_ ID3D12Device* de
     static_assert((MaxBatchSize * VerticesPerSprite) < USHRT_MAX, "MaxBatchSize too large for 16-bit indices");
 
     const CD3DX12_HEAP_PROPERTIES heapProps(D3D12_HEAP_TYPE_DEFAULT);
-    auto const bufferDesc = CD3DX12_RESOURCE_DESC::Buffer(sizeof(short) * MaxBatchSize * IndicesPerSprite);
+    const auto bufferDesc = CD3DX12_RESOURCE_DESC::Buffer(sizeof(short) * MaxBatchSize * IndicesPerSprite);
 
     // Create the constant buffer.
     ThrowIfFailed(device->CreateCommittedResource(
@@ -412,7 +412,7 @@ std::vector<short> SpriteBatch::Impl::DeviceResources::CreateIndexValues()
 
     for (size_t j = 0; j < MaxBatchSize * VerticesPerSprite; j += VerticesPerSprite)
     {
-        auto const i = static_cast<short>(j);
+        const auto i = static_cast<short>(j);
 
         indices.push_back(i);
         indices.push_back(i + 1);

--- a/Src/SpriteFont.cpp
+++ b/Src/SpriteFont.cpp
@@ -521,7 +521,7 @@ XMVECTOR XM_CALLCONV SpriteFont::MeasureString(_In_z_ wchar_t const* text, bool 
         {
             UNREFERENCED_PARAMETER(advance);
 
-            auto const w = static_cast<float>(glyph->Subrect.right - glyph->Subrect.left);
+            const auto w = static_cast<float>(glyph->Subrect.right - glyph->Subrect.left);
             auto h = static_cast<float>(glyph->Subrect.bottom - glyph->Subrect.top) + glyph->YOffset;
 
             h = iswspace(wchar_t(glyph->Character)) ?
@@ -541,9 +541,9 @@ RECT SpriteFont::MeasureDrawBounds(_In_z_ wchar_t const* text, XMFLOAT2 const& p
 
     pImpl->ForEachGlyph(text, [&](Glyph const* glyph, float x, float y, float advance) noexcept
         {
-            auto const isWhitespace = iswspace(wchar_t(glyph->Character));
-            auto const w = static_cast<float>(glyph->Subrect.right - glyph->Subrect.left);
-            auto const h = isWhitespace ?
+            const auto isWhitespace = iswspace(wchar_t(glyph->Character));
+            const auto w = static_cast<float>(glyph->Subrect.right - glyph->Subrect.left);
+            const auto h = isWhitespace ?
                 pImpl->lineSpacing :
                 static_cast<float>(glyph->Subrect.bottom - glyph->Subrect.top);
 

--- a/Src/WICTextureLoader.cpp
+++ b/Src/WICTextureLoader.cpp
@@ -422,8 +422,8 @@ namespace
         if (rowBytes > UINT32_MAX || numBytes > UINT32_MAX)
             return HRESULT_FROM_WIN32(ERROR_ARITHMETIC_OVERFLOW);
 
-        auto const rowPitch = static_cast<size_t>(rowBytes);
-        auto const imageSize = static_cast<size_t>(numBytes);
+        const auto rowPitch = static_cast<size_t>(rowBytes);
+        const auto imageSize = static_cast<size_t>(numBytes);
 
         decodedData.reset(new (std::nothrow) uint8_t[imageSize]);
         if (!decodedData)


### PR DESCRIPTION
Both ``const auto`` and ``auto const`` are equivalent in terms of the C++ compiler parser, but general coding guidelines suggest using ``const auto``. The primary reason for this PR is to be consistent since the codebase was using both.