### PR TITLE
Update ADO coverage for clang v12 

### DIFF
--- a/build/DirectXTK12-GitHub-CMake.yml
+++ b/build/DirectXTK12-GitHub-CMake.yml
@@ -102,92 +102,52 @@ jobs:
       cwd: '$(Build.SourcesDirectory)'
       cmakeArgs: --build out2 -v --config RelWithDebInfo
   - task: CMake@1
-    displayName: 'CMake (MSVC): Config ARM64'
-    inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A ARM64 -B out3 -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)'
-  - task: CMake@1
-    displayName: 'CMake (MSVC): Build ARM64 Debug'
-    inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out3 -v --config Debug
-  - task: CMake@1
-    displayName: 'CMake (MSVC): Build ARM64 Release'
-    inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out3 -v --config RelWithDebInfo
-  - task: CMake@1
     displayName: 'CMake (UWP): Config x64'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out4 -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=10.0'
+      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out3 -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=10.0'
   - task: CMake@1
     displayName: 'CMake (UWP): Build x64'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out4 -v
+      cmakeArgs: --build out3 -v
   - task: CMake@1
     displayName: 'CMake (ClangCl): Config x64'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -T clangcl -B out6 -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)'
+      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -T clangcl -B out4 -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)'
   - task: CMake@1
     displayName: 'CMake (ClangCl): Build x64 Debug'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out6 -v --config Debug
+      cmakeArgs: --build out4 -v --config Debug
   - task: CMake@1
     displayName: 'CMake (ClangCl): Build x64 Release'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out6 -v --config RelWithDebInfo
-  - task: CMake@1
-    displayName: 'CMake (ClangCl): Config ARM64'
-    inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A ARM64 -T clangcl -B out7 -DCMAKE_SYSTEM_VERSION=$(WIN11_SDK)'
-  - task: CMake@1
-    displayName: 'CMake (ClangCl): Build ARM64'
-    inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out7 -v --config Debug
+      cmakeArgs: --build out4 -v --config RelWithDebInfo
   - task: CMake@1
     displayName: 'CMake (MSVC Spectre): Config x64'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out8 -DENABLE_SPECTRE_MITIGATION=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)'
+      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out5 -DENABLE_SPECTRE_MITIGATION=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)'
   - task: CMake@1
     displayName: 'CMake (MSVC Spectre): Build x64 Debug'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out8 -v --config Debug
+      cmakeArgs: --build out5 -v --config Debug
   - task: CMake@1
     displayName: 'CMake (MSVC Spectre): Build x64 Release'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out8 -v --config RelWithDebInfo
-  - task: CMake@1
-    displayName: 'CMake (MSVC Spectre): Config ARM64'
-    inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A ARM64 -B out9 -DENABLE_SPECTRE_MITIGATION=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)'
-  - task: CMake@1
-    displayName: 'CMake (MSVC Spectre): Build ARM64 Debug'
-    inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out9 -v --config Debug
-  - task: CMake@1
-    displayName: 'CMake (MSVC Spectre): Build ARM64 Release'
-    inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out9 -v --config RelWithDebInfo
+      cmakeArgs: --build out5 -v --config RelWithDebInfo
   - task: CMake@1
     displayName: 'CMake (NO_WCHAR_T): Config'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out10 -DNO_WCHAR_T=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN11_SDK)'
+      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out6 -DNO_WCHAR_T=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN11_SDK)'
   - task: CMake@1
     displayName: 'CMake (NO_WCHAR_T): Build'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out10 -v --config Debug
+      cmakeArgs: --build out6 -v --config Debug

--- a/build/DirectXTK12-GitHub-Test-Dev17.yml
+++ b/build/DirectXTK12-GitHub-Test-Dev17.yml
@@ -241,7 +241,7 @@ jobs:
     displayName: Build solution DirectXTK_Tests_Windows10.sln 64dbg
     inputs:
       solution: Tests/DirectXTK_Tests_Windows10.sln
-      vsVersion: 16.0
+      vsVersion: 17.0
       msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
       platform: x64
       configuration: Debug
@@ -249,7 +249,7 @@ jobs:
     displayName: Build solution DirectXTK_Tests_Windows10.sln 64rel
     inputs:
       solution: Tests/DirectXTK_Tests_Windows10.sln
-      vsVersion: 16.0
+      vsVersion: 17.0
       msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
       platform: x64
       configuration: Release
@@ -284,7 +284,7 @@ jobs:
     displayName: Build solution DirectXTK_Tests_Windows10.sln 32dbg
     inputs:
       solution: Tests/DirectXTK_Tests_Windows10.sln
-      vsVersion: 16.0
+      vsVersion: 17.0
       msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
       platform: x86
       configuration: Debug
@@ -292,7 +292,7 @@ jobs:
     displayName: Build solution DirectXTK_Tests_Windows10.sln 32rel
     inputs:
       solution: Tests/DirectXTK_Tests_Windows10.sln
-      vsVersion: 16.0
+      vsVersion: 17.0
       msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
       platform: x86
       configuration: Release
@@ -327,7 +327,7 @@ jobs:
     displayName: Build solution DirectXTK_Tests_Windows10.sln arm64dbg
     inputs:
       solution: Tests/DirectXTK_Tests_Windows10.sln
-      vsVersion: 16.0
+      vsVersion: 17.0
       msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
       platform: ARM64
       configuration: Debug
@@ -335,7 +335,7 @@ jobs:
     displayName: Build solution DirectXTK_Tests_Windows10.sln arm64rel
     inputs:
       solution: Tests/DirectXTK_Tests_Windows10.sln
-      vsVersion: 16.0
+      vsVersion: 17.0
       msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
       platform: ARM64
       configuration: Release

--- a/build/DirectXTK12-GitHub-Test-Dev17.yml
+++ b/build/DirectXTK12-GitHub-Test-Dev17.yml
@@ -210,6 +210,136 @@ jobs:
       configuration: Release
       msbuildArchitecture: x64
 
+- job: UWP_BUILD_X64
+  displayName: 'Universal Windows Platform (UWP) for x64'
+  timeoutInMinutes: 120
+  cancelTimeoutInMinutes: 1
+  steps:
+  - checkout: self
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
+    displayName: Fetch Tests
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
+  - task: NuGetToolInstaller@1
+    displayName: 'Use NuGet'
+  - task: NuGetAuthenticate@1
+    displayName: 'NuGet Auth'
+  - task: NuGetCommand@2
+    displayName: NuGet restore tests
+    inputs:
+      solution: Tests/D3D12Test/packages.config
+      feedRestore: $(GUID_FEED)
+      includeNuGetOrg: false
+      packagesDirectory: ../packages
+  - task: VSBuild@1
+    displayName: Build solution DirectXTK_Tests_Windows10.sln 64dbg
+    inputs:
+      solution: Tests/DirectXTK_Tests_Windows10.sln
+      vsVersion: 16.0
+      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
+      platform: x64
+      configuration: Debug
+  - task: VSBuild@1
+    displayName: Build solution DirectXTK_Tests_Windows10.sln 64rel
+    inputs:
+      solution: Tests/DirectXTK_Tests_Windows10.sln
+      vsVersion: 16.0
+      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
+      platform: x64
+      configuration: Release
+
+- job: UWP_BUILD_X86
+  displayName: 'Universal Windows Platform (UWP) for x86'
+  timeoutInMinutes: 120
+  steps:
+  - checkout: self
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
+    displayName: Fetch Tests
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
+  - task: NuGetToolInstaller@1
+    displayName: 'Use NuGet'
+  - task: NuGetAuthenticate@1
+    displayName: 'NuGet Auth'
+  - task: NuGetCommand@2
+    displayName: NuGet restore tests
+    inputs:
+      solution: Tests/D3D12Test/packages.config
+      feedRestore: $(GUID_FEED)
+      includeNuGetOrg: false
+      packagesDirectory: ../packages
+  - task: VSBuild@1
+    displayName: Build solution DirectXTK_Tests_Windows10.sln 32dbg
+    inputs:
+      solution: Tests/DirectXTK_Tests_Windows10.sln
+      vsVersion: 16.0
+      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
+      platform: x86
+      configuration: Debug
+  - task: VSBuild@1
+    displayName: Build solution DirectXTK_Tests_Windows10.sln 32rel
+    inputs:
+      solution: Tests/DirectXTK_Tests_Windows10.sln
+      vsVersion: 16.0
+      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
+      platform: x86
+      configuration: Release
+
+- job: UWP_BUILD_ARM64
+  displayName: 'Universal Windows Platform (UWP) for ARM64'
+  timeoutInMinutes: 120
+  steps:
+  - checkout: self
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
+    displayName: Fetch Tests
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
+  - task: NuGetToolInstaller@1
+    displayName: 'Use NuGet'
+  - task: NuGetAuthenticate@1
+    displayName: 'NuGet Auth'
+  - task: NuGetCommand@2
+    displayName: NuGet restore tests
+    inputs:
+      solution: Tests/D3D12Test/packages.config
+      feedRestore: $(GUID_FEED)
+      includeNuGetOrg: false
+      packagesDirectory: ../packages
+  - task: VSBuild@1
+    displayName: Build solution DirectXTK_Tests_Windows10.sln arm64dbg
+    inputs:
+      solution: Tests/DirectXTK_Tests_Windows10.sln
+      vsVersion: 16.0
+      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
+      platform: ARM64
+      configuration: Debug
+  - task: VSBuild@1
+    displayName: Build solution DirectXTK_Tests_Windows10.sln arm64rel
+    inputs:
+      solution: Tests/DirectXTK_Tests_Windows10.sln
+      vsVersion: 16.0
+      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
+      platform: ARM64
+      configuration: Release
+
 - job: CMAKE_BUILD_X64
   displayName: 'CMake for X64 BUILD_TESTING=ON'
   timeoutInMinutes: 60

--- a/build/DirectXTK12-GitHub-Test.yml
+++ b/build/DirectXTK12-GitHub-Test.yml
@@ -196,26 +196,3 @@ jobs:
   - task: DeleteFiles@1
     inputs:
       Contents: 'out'
-  - task: CMake@1
-    displayName: CMake (clang/LLVM; x64-Debug) Config
-    inputs:
-      cwd: $(Build.SourcesDirectory)
-      cmakeArgs: --preset=x64-Debug-Clang
-  - task: CMake@1
-    displayName: CMake (clang/LLVM; x64-Debug) Build
-    inputs:
-      cwd: $(Build.SourcesDirectory)
-      cmakeArgs: --build out/build/x64-Debug-Clang -v
-  - task: DeleteFiles@1
-    inputs:
-      Contents: 'out'
-  - task: CMake@1
-    displayName: CMake (clang/LLVM; x64-Release) Config
-    inputs:
-      cwd: $(Build.SourcesDirectory)
-      cmakeArgs: --preset=x64-Release-Clang
-  - task: CMake@1
-    displayName: CMake (clang/LLVM; x64-Release) Build
-    inputs:
-      cwd: $(Build.SourcesDirectory)
-      cmakeArgs: --build out/build/x64-Release-Clang -v

--- a/build/DirectXTK12-GitHub-Test.yml
+++ b/build/DirectXTK12-GitHub-Test.yml
@@ -196,3 +196,26 @@ jobs:
   - task: DeleteFiles@1
     inputs:
       Contents: 'out'
+  - task: CMake@1
+    displayName: CMake (clang/LLVM; x64-Debug) Config
+    inputs:
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: --preset=x64-Debug-Clang
+  - task: CMake@1
+    displayName: CMake (clang/LLVM; x64-Debug) Build
+    inputs:
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: --build out/build/x64-Debug-Clang -v
+  - task: DeleteFiles@1
+    inputs:
+      Contents: 'out'
+  - task: CMake@1
+    displayName: CMake (clang/LLVM; x64-Release) Config
+    inputs:
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: --preset=x64-Release-Clang
+  - task: CMake@1
+    displayName: CMake (clang/LLVM; x64-Release) Build
+    inputs:
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: --build out/build/x64-Release-Clang -v

--- a/build/DirectXTK12-GitHub-Test.yml
+++ b/build/DirectXTK12-GitHub-Test.yml
@@ -36,10 +36,11 @@ resources:
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
 pool:
-  vmImage: windows-2022
+  vmImage: windows-2019
 
 variables:
   Codeql.Enabled: false
+  VC_PATH: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC'
   GUID_FEED: $(ADOFeedGUID)
 
 jobs:
@@ -137,9 +138,11 @@ jobs:
       platform: x64
       configuration: Release
 
-- job: DESKTOP_BUILD_ARM64
-  displayName: 'Win32 Desktop for ARM64'
-  timeoutInMinutes: 120
+- job: CMAKE_BUILD_X64
+  displayName: 'CMake for X64 BUILD_TESTING=ON'
+  timeoutInMinutes: 60
+  workspace:
+    clean: all
   steps:
   - checkout: self
     clean: true
@@ -152,176 +155,67 @@ jobs:
     fetchTags: false
     fetchDepth: 1
     path: 's/Tests'
-  - task: NuGetToolInstaller@1
-    displayName: 'Use NuGet'
-  - task: NuGetAuthenticate@1
-    displayName: 'NuGet Auth'
-  - task: NuGetCommand@2
-    displayName: NuGet restore tests
+  - task: CmdLine@2
+    displayName: Setup environment for CMake to use VS
     inputs:
-      solution: Tests/D3D12Test/packages.config
-      feedRestore: $(GUID_FEED)
-      includeNuGetOrg: false
-      packagesDirectory: ../packages
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Desktop_2019_Win10.sln arm64dbg
-    inputs:
-      solution: Tests/DirectXTK_Tests_Desktop_2019_Win10.sln
-      vsVersion: 16.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Desktop_2019_Win10.sln arm64rel
-    inputs:
-      solution: Tests/DirectXTK_Tests_Desktop_2019_Win10.sln
-      vsVersion: 16.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Desktop_2019_AgilitySDK.sln arm64dbg
-    inputs:
-      solution: Tests/DirectXTK_Tests_Desktop_2019_AgilitySDK.sln
-      vsVersion: 16.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Desktop_2019_AgilitySDK.sln arm64rel
-    inputs:
-      solution: Tests/DirectXTK_Tests_Desktop_2019_AgilitySDK.sln
-      vsVersion: 16.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Release
+      script: |
+        call "$(VC_PATH)\Auxiliary\Build\vcvars64.bat"
+        echo ##vso[task.setvariable variable=WindowsSdkVerBinPath;]%WindowsSdkVerBinPath%
+        echo ##vso[task.prependpath]%VSINSTALLDIR%Common7\IDE\CommonExtensions\Microsoft\CMake\Ninja
+        echo ##vso[task.prependpath]%VCINSTALLDIR%Tools\Llvm\x64\bin
+        echo ##vso[task.prependpath]%WindowsSdkBinPath%x64
+        echo ##vso[task.prependpath]%WindowsSdkVerBinPath%x64
+        echo ##vso[task.prependpath]%VCToolsInstallDir%bin\Hostx64\x64
+        echo ##vso[task.setvariable variable=EXTERNAL_INCLUDE;]%EXTERNAL_INCLUDE%
+        echo ##vso[task.setvariable variable=INCLUDE;]%INCLUDE%
+        echo ##vso[task.setvariable variable=LIB;]%LIB%
 
-- job: UWP_BUILD_X64
-  displayName: 'Universal Windows Platform (UWP) for x64'
-  timeoutInMinutes: 120
-  cancelTimeoutInMinutes: 1
-  steps:
-  - checkout: self
-    clean: true
-    fetchTags: false
-    fetchDepth: 1
-    path: 's'
-  - checkout: testRepo
-    displayName: Fetch Tests
-    clean: true
-    fetchTags: false
-    fetchDepth: 1
-    path: 's/Tests'
-  - task: NuGetToolInstaller@1
-    displayName: 'Use NuGet'
-  - task: NuGetAuthenticate@1
-    displayName: 'NuGet Auth'
-  - task: NuGetCommand@2
-    displayName: NuGet restore tests
+  - task: CMake@1
+    displayName: CMake (MSVC; x64-Debug) Config
     inputs:
-      solution: Tests/D3D12Test/packages.config
-      feedRestore: $(GUID_FEED)
-      includeNuGetOrg: false
-      packagesDirectory: ../packages
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Windows10.sln 64dbg
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: --preset=x64-Debug
+  - task: CMake@1
+    displayName: CMake (MSVC; x64-Debug) Build
     inputs:
-      solution: Tests/DirectXTK_Tests_Windows10.sln
-      vsVersion: 16.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
-      platform: x64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Windows10.sln 64rel
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: --build out/build/x64-Debug -v
+  - task: DeleteFiles@1
     inputs:
-      solution: Tests/DirectXTK_Tests_Windows10.sln
-      vsVersion: 16.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
-      platform: x64
-      configuration: Release
-
-- job: UWP_BUILD_X86
-  displayName: 'Universal Windows Platform (UWP) for x86'
-  timeoutInMinutes: 120
-  steps:
-  - checkout: self
-    clean: true
-    fetchTags: false
-    fetchDepth: 1
-    path: 's'
-  - checkout: testRepo
-    displayName: Fetch Tests
-    clean: true
-    fetchTags: false
-    fetchDepth: 1
-    path: 's/Tests'
-  - task: NuGetToolInstaller@1
-    displayName: 'Use NuGet'
-  - task: NuGetAuthenticate@1
-    displayName: 'NuGet Auth'
-  - task: NuGetCommand@2
-    displayName: NuGet restore tests
+      Contents: 'out'
+  - task: CMake@1
+    displayName: CMake (MSVC; x64-Release) Config
     inputs:
-      solution: Tests/D3D12Test/packages.config
-      feedRestore: $(GUID_FEED)
-      includeNuGetOrg: false
-      packagesDirectory: ../packages
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Windows10.sln 32dbg
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: --preset=x64-Release
+  - task: CMake@1
+    displayName: CMake (MSVC; x64-Release) Build
     inputs:
-      solution: Tests/DirectXTK_Tests_Windows10.sln
-      vsVersion: 16.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
-      platform: x86
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Windows10.sln 32rel
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: --build out/build/x64-Release -v
+  - task: DeleteFiles@1
     inputs:
-      solution: Tests/DirectXTK_Tests_Windows10.sln
-      vsVersion: 16.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
-      platform: x86
-      configuration: Release
-
-- job: UWP_BUILD_ARM64
-  displayName: 'Universal Windows Platform (UWP) for ARM64'
-  timeoutInMinutes: 120
-  steps:
-  - checkout: self
-    clean: true
-    fetchTags: false
-    fetchDepth: 1
-    path: 's'
-  - checkout: testRepo
-    displayName: Fetch Tests
-    clean: true
-    fetchTags: false
-    fetchDepth: 1
-    path: 's/Tests'
-  - task: NuGetToolInstaller@1
-    displayName: 'Use NuGet'
-  - task: NuGetAuthenticate@1
-    displayName: 'NuGet Auth'
-  - task: NuGetCommand@2
-    displayName: NuGet restore tests
+      Contents: 'out'
+  - task: CMake@1
+    displayName: CMake (clang/LLVM; x64-Debug) Config
     inputs:
-      solution: Tests/D3D12Test/packages.config
-      feedRestore: $(GUID_FEED)
-      includeNuGetOrg: false
-      packagesDirectory: ../packages
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Windows10.sln arm64dbg
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: --preset=x64-Debug-Clang
+  - task: CMake@1
+    displayName: CMake (clang/LLVM; x64-Debug) Build
     inputs:
-      solution: Tests/DirectXTK_Tests_Windows10.sln
-      vsVersion: 16.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
-      platform: ARM64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Windows10.sln arm64rel
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: --build out/build/x64-Debug-Clang -v
+  - task: DeleteFiles@1
     inputs:
-      solution: Tests/DirectXTK_Tests_Windows10.sln
-      vsVersion: 16.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
-      platform: ARM64
-      configuration: Release
+      Contents: 'out'
+  - task: CMake@1
+    displayName: CMake (clang/LLVM; x64-Release) Config
+    inputs:
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: --preset=x64-Release-Clang
+  - task: CMake@1
+    displayName: CMake (clang/LLVM; x64-Release) Build
+    inputs:
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: --build out/build/x64-Release-Clang -v

--- a/build/DirectXTK12-GitHub.yml
+++ b/build/DirectXTK12-GitHub.yml
@@ -74,17 +74,3 @@ jobs:
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: x64
       configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019_Win10.sln arm64dbg
-    inputs:
-      solution: DirectXTK_Desktop_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019_Win10.sln arm64rel
-    inputs:
-      solution: DirectXTK_Desktop_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Release


### PR DESCRIPTION
Remove cases of building for ARM64 with VS 2019 due to changes to Windows SDK (26100).

Also cleans up the original #220 quick fix for UWP which should be building in the Dev17 pipeline.

