### PR TITLE
GameInput implementation updates for for GAMEINPUT_API_VERSION = 1

### DIFF
--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -30,39 +30,63 @@ jobs:
         build_type: [x64-Debug-VCPKG]
         arch: [amd64]
         shared: [OFF]
+        gameinput: [OFF]
         include:
+          - os: windows-2022
+            build_type: x64-Debug-VCPKG
+            arch: amd64
+            shared: OFF
+            gameinput: ON
           - os: windows-2022
             build_type: x64-Debug-Clang-VCPKG
             arch: amd64
             shared: OFF
+            gameinput: OFF
+          - os: windows-2022
+            build_type: x64-Debug-Clang-VCPKG
+            arch: amd64
+            shared: OFF
+            gameinput: ON
           - os: windows-2022
             build_type: x86-Debug-VCPKG
             arch: amd64_x86
             shared: OFF
+            gameinput: OFF
           - os: windows-2022
             build_type: arm64-Debug-VCPKG
             arch: amd64_arm64
             shared: OFF
+            gameinput: OFF
           - os: windows-2022
             build_type: arm64ec-Debug-VCPKG
             arch: amd64_arm64
             shared: OFF
+            gameinput: OFF
           - os: windows-2022
             build_type: x64-Debug-MinGW
             arch: amd64
             shared: OFF
+            gameinput: OFF
+          - os: windows-2022
+            build_type: x64-Debug-VCPKG
+            arch: amd64
+            shared: ON
+            gameinput: ON
           - os: windows-2022
             build_type: x64-Release-MinGW
             arch: amd64
             shared: OFF
+            gameinput: OFF
           - os: windows-2022
             build_type: x64-Debug-MinGW
             arch: amd64
             shared: ON
+            gameinput: OFF
           - os: windows-2022
             build_type: x64-Release-MinGW
             arch: amd64
             shared: ON
+            gameinput: OFF
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -53,6 +53,16 @@ jobs:
             shared: OFF
             gameinput: OFF
           - os: windows-2022
+            build_type: x64-Debug-Redist
+            arch: amd64
+            shared: OFF
+            gameinput: OFF
+          - os: windows-2022
+            build_type: x64-Release-Redist
+            arch: amd64
+            shared: OFF
+            gameinput: OFF
+          - os: windows-2022
             build_type: arm64-Debug-VCPKG
             arch: amd64_arm64
             shared: OFF
@@ -68,15 +78,20 @@ jobs:
             shared: OFF
             gameinput: OFF
           - os: windows-2022
-            build_type: x64-Debug-VCPKG
-            arch: amd64
-            shared: ON
-            gameinput: ON
-          - os: windows-2022
             build_type: x64-Release-MinGW
             arch: amd64
             shared: OFF
             gameinput: OFF
+          - os: windows-2022
+            build_type: x64-Debug-MinGW
+            arch: amd64
+            shared: OFF
+            gameinput: ON
+          - os: windows-2022
+            build_type: x64-Debug-VCPKG
+            arch: amd64
+            shared: ON
+            gameinput: ON
           - os: windows-2022
             build_type: x64-Debug-MinGW
             arch: amd64
@@ -159,7 +174,7 @@ jobs:
     - name: 'Configure CMake'
       working-directory: ${{ github.workspace }}
       run: >
-        cmake --preset=${{ matrix.build_type }} -DBUILD_TESTING=OFF -DBUILD_XAUDIO_WIN10=OFF -DBUILD_XAUDIO_REDIST=ON
+        cmake --preset=${{ matrix.build_type }} -DBUILD_TESTING=OFF
         -DBUILD_SHARED_LIBS=${{ matrix.shared }} -DBUILD_GAMEINPUT=${{ matrix.gameinput }}
         -DCMAKE_TOOLCHAIN_FILE="${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake" -DVCPKG_MANIFEST_DIR="${{ github.workspace }}/build"
         -DVCPKG_TARGET_TRIPLET="${env:VCPKG_DEFAULT_TRIPLET}"

--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -160,7 +160,7 @@ jobs:
       working-directory: ${{ github.workspace }}
       run: >
         cmake --preset=${{ matrix.build_type }} -DBUILD_TESTING=OFF -DBUILD_XAUDIO_WIN10=OFF -DBUILD_XAUDIO_REDIST=ON
-        -DBUILD_SHARED_LIBS=${{ matrix.shared }}
+        -DBUILD_SHARED_LIBS=${{ matrix.shared }} -DBUILD_GAMEINPUT=${{ matrix.gameinput }}
         -DCMAKE_TOOLCHAIN_FILE="${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake" -DVCPKG_MANIFEST_DIR="${{ github.workspace }}/build"
         -DVCPKG_TARGET_TRIPLET="${env:VCPKG_DEFAULT_TRIPLET}"
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -118,6 +118,14 @@
     },
 
     {
+      "name": "XAudio2Redist",
+      "cacheVariables": {
+        "BUILD_XAUDIO_WIN10": false,
+        "BUILD_XAUDIO_REDIST": true
+      },
+      "hidden": true
+    },
+    {
       "name": "UWP",
       "cacheVariables": {
         "CMAKE_SYSTEM_NAME": "WindowsStore",
@@ -255,14 +263,6 @@
         "strategy": "external"
       }
     },
-    {
-      "name": "XAudio2Redist",
-      "cacheVariables": {
-        "BUILD_XAUDIO_WIN10": false,
-        "BUILD_XAUDIO_REDIST": true
-      },
-      "hidden": true
-    },
 
     {
       "name": "Analyze",
@@ -305,6 +305,11 @@
     { "name": "arm64-Debug-UWP"  , "description": "MSVC for ARM64 (Debug) for UWP", "inherits": [ "base", "ARM64", "Debug", "MSVC", "UWP" ] },
     { "name": "arm64-Release-UWP", "description": "MSVC for ARM64 (Release) for UWP", "inherits": [ "base", "ARM64", "Release", "MSVC", "UWP" ] },
 
+    { "name": "x64-Debug-Redist"  , "description": "MSVC for x64 (Debug) with XAudio2Redist", "inherits": [ "base", "x64", "Debug", "MSVC", "XAudio2Redist", "VCPKG", "X64_X64" ] },
+    { "name": "x64-Release-Redist", "description": "MSVC for x64 (Release) with XAudio2Redist", "inherits": [ "base", "x64", "Release", "MSVC", "XAudio2Redist", "VCPKG", "X64_X64" ] },
+    { "name": "x86-Debug-Redist"  , "description": "MSVC for x86 (Debug) with XAudio2Redist", "inherits": [ "base", "x86", "Debug", "MSVC", "XAudio2Redist", "VCPKG", "X64_X86" ] },
+    { "name": "x86-Release-Redist", "description": "MSVC for x86 (Release) with XAudio2Redist", "inherits": [ "base", "x86", "Release", "MSVC", "XAudio2Redist", "VCPKG", "X64_X86" ] },
+
     { "name": "x64-Debug-GDK"    , "description": "MSVC for x64 (Debug) with Microsoft GDK", "inherits": [ "base", "x64", "Debug", "MSVC", "GDK" ] },
     { "name": "x64-Release-GDK"  , "description": "MSVC for x64 (Release) with Microsoft GDK", "inherits": [ "base", "x64", "Release", "MSVC", "GDK" ] },
 
@@ -317,10 +322,10 @@
     { "name": "x64-Debug-Durango"    , "description": "MSVC for x64 (Debug) for legacy Xbox One XDK", "inherits": [ "base", "x64", "Debug", "MSVC", "Durango" ] },
     { "name": "x64-Release-Durango"  , "description": "MSVC for x64 (Release) for legacy Xbox One XDK", "inherits": [ "base", "x64", "Release", "MSVC", "Durango" ] },
 
-    { "name": "x64-Debug-VCPKG"           , "description": "MSVC for x64 (Debug) using VCPKG", "inherits": [ "base", "x64", "Debug", "MSVC", "VCPKG", "XAudio2Redist", "X64_X64" ] },
-    { "name": "x64-Release-VCPKG"         , "description": "MSVC for x64 (Release) using VCPKG", "inherits": [ "base", "x64", "Release", "MSVC", "VCPKG", "XAudio2Redist", "X64_X64" ] },
-    { "name": "x86-Debug-VCPKG"           , "description": "MSVC for x86 (Debug) using VCPKG", "inherits": [ "base", "x86", "Debug", "MSVC", "VCPKG", "XAudio2Redist", "X64_X86" ] },
-    { "name": "x86-Release-VCPKG"         , "description": "MSVC for x86 (Release) using VCPKG", "inherits": [ "base", "x86", "Release", "MSVC", "VCPKG", "XAudio2Redist", "X64_X86" ] },
+    { "name": "x64-Debug-VCPKG"           , "description": "MSVC for x64 (Debug) using VCPKG", "inherits": [ "base", "x64", "Debug", "MSVC", "VCPKG", "X64_X64" ] },
+    { "name": "x64-Release-VCPKG"         , "description": "MSVC for x64 (Release) using VCPKG", "inherits": [ "base", "x64", "Release", "MSVC", "VCPKG", "X64_X64" ] },
+    { "name": "x86-Debug-VCPKG"           , "description": "MSVC for x86 (Debug) using VCPKG", "inherits": [ "base", "x86", "Debug", "MSVC", "VCPKG", "X64_X86" ] },
+    { "name": "x86-Release-VCPKG"         , "description": "MSVC for x86 (Release) using VCPKG", "inherits": [ "base", "x86", "Release", "MSVC", "VCPKG", "X64_X86" ] },
     { "name": "arm64-Debug-VCPKG"         , "description": "MSVC for ARM64 (Debug) using VCPKG", "inherits": [ "base", "ARM64", "Debug", "MSVC", "VCPKG", "X64_ARM64" ] },
     { "name": "arm64-Release-VCPKG"       , "description": "MSVC for ARM64 (Release) using VCPKG", "inherits": [ "base", "ARM64", "Release", "MSVC", "VCPKG", "X64_ARM64" ] },
     { "name": "arm64-Native-Debug-VCPKG"  , "description": "MSVC for ARM64 Native (Debug) using VCPKG", "inherits": [ "base", "ARM64", "Debug", "MSVC", "VCPKG", "ARM64_ARM64" ] },
@@ -335,10 +340,10 @@
     { "name": "arm64-Debug-Clang"  , "description": "Clang/LLVM for AArch64 (Debug) for Windows 10", "inherits": [ "base", "ARM64", "Debug", "Clang", "Clang-AArch64" ] },
     { "name": "arm64-Release-Clang", "description": "Clang/LLVM for AArch64 (Release) for Windows 10", "inherits": [ "base", "ARM64", "Release", "Clang", "Clang-AArch64" ] },
 
-    { "name": "x64-Debug-Clang-VCPKG"   , "description": "Clang/LLVM for x64 (Debug) using VCPKG", "inherits": [ "base", "x64", "Debug", "Clang", "VCPKG", "XAudio2Redist", "X64_X64" ] },
-    { "name": "x64-Release-Clang-VCPKG" , "description": "Clang/LLVM for x64 (Release) using VCPKG", "inherits": [ "base", "x64", "Release", "Clang", "VCPKG", "XAudio2Redist", "X64_X64" ] },
-    { "name": "x86-Debug-Clang-VCPKG"   , "description": "Clang/LLVM for x86 (Debug) using VCPKG", "inherits": [ "base", "x86", "Debug", "Clang", "Clang-X86", "VCPKG", "XAudio2Redist", "X64_X86" ] },
-    { "name": "x86-Release-Clang-VCPKG" , "description": "Clang/LLVM for x86 (Debug) using VCPKG", "inherits": [ "base", "x86", "Release", "Clang", "Clang-X86", "VCPKG", "XAudio2Redist", "X64_X86" ] },
+    { "name": "x64-Debug-Clang-VCPKG"   , "description": "Clang/LLVM for x64 (Debug) using VCPKG", "inherits": [ "base", "x64", "Debug", "Clang", "VCPKG", "X64_X64" ] },
+    { "name": "x64-Release-Clang-VCPKG" , "description": "Clang/LLVM for x64 (Release) using VCPKG", "inherits": [ "base", "x64", "Release", "Clang", "VCPKG", "X64_X64" ] },
+    { "name": "x86-Debug-Clang-VCPKG"   , "description": "Clang/LLVM for x86 (Debug) using VCPKG", "inherits": [ "base", "x86", "Debug", "Clang", "Clang-X86", "VCPKG", "X64_X86" ] },
+    { "name": "x86-Release-Clang-VCPKG" , "description": "Clang/LLVM for x86 (Debug) using VCPKG", "inherits": [ "base", "x86", "Release", "Clang", "Clang-X86", "VCPKG", "X64_X86" ] },
 
     { "name": "x64-Debug-UWP-Clang"    , "description": "Clang/LLVM for x64 (Debug) for UWP", "inherits": [ "base", "x64", "Debug", "Clang", "UWP" ] },
     { "name": "x64-Release-UWP-Clang"  , "description": "Clang/LLVM for x64 (Release) for UWP", "inherits": [ "base", "x64", "Release", "Clang", "UWP" ] },
@@ -346,6 +351,11 @@
     { "name": "x86-Release-UWP-Clang"  , "description": "Clang/LLVM for x86 (Release) for UWP", "inherits": [ "base", "x86", "Release", "Clang", "Clang-X86", "UWP" ] },
     { "name": "arm64-Debug-UWP-Clang"  , "description": "Clang/LLVM for AArch64 (Debug) for UWP", "inherits": [ "base", "ARM64", "Debug", "Clang", "Clang-AArch64", "UWP" ] },
     { "name": "arm64-Release-UWP-Clang", "description": "Clang/LLVM for AArch64 (Release) for UWP", "inherits": [ "base", "ARM64", "Release", "Clang", "Clang-AArch64", "UWP" ] },
+
+    { "name": "x64-Debug-Redist-Clang"  , "description": "Clang/LLVM for x64 (Debug) with XAudio2Redist", "inherits": [ "base", "x64", "Debug", "Clang", "XAudio2Redist", "VCPKG", "X64_X64" ] },
+    { "name": "x64-Release-Redist-Clang", "description": "Clang/LLVM for x64 (Release) with XAudio2Redist", "inherits": [ "base", "x64", "Release", "Clang", "XAudio2Redist", "VCPKG", "X64_X64" ] },
+    { "name": "x86-Debug-Redist-Clang"  , "description": "Clang/LLVM for x86 (Debug) with XAudio2Redist", "inherits": [ "base", "x86", "Debug", "Clang", "Clang-X86", "XAudio2Redist", "VCPKG", "X64_X86" ] },
+    { "name": "x86-Release-Redist-Clang", "description": "Clang/LLVM for x86 (Release) with XAudio2Redist", "inherits": [ "base", "x86", "Release", "Clang", "Clang-X86", "XAudio2Redist", "VCPKG", "X64_X86" ] },
 
     { "name": "x64-Debug-Scarlett-Clang"  , "description": "Clang/LLVM for x64 (Debug) for Xbox Series X|S", "inherits": [ "base", "x64", "Debug", "Clang", "Scarlett" ] },
     { "name": "x64-Release-Scarlett-Clang", "description": "Clang/LLVM for x64 (Release) for Xbox Series X|S", "inherits": [ "base", "x64", "Release", "Clang", "Scarlett" ] },
@@ -378,6 +388,11 @@
     { "name": "arm64-Release"  , "configurePreset": "arm64-Release" },
     { "name": "arm64ec-Debug"  , "configurePreset": "arm64ec-Debug" },
     { "name": "arm64ec-Release", "configurePreset": "arm64ec-Release" },
+
+    { "name": "x64-Debug-Redist"    , "configurePreset": "x64-Debug-Redist" },
+    { "name": "x64-Release-Redist"  , "configurePreset": "x64-Release-Redist" },
+    { "name": "x86-Debug-Redist"    , "configurePreset": "x86-Debug-Redist" },
+    { "name": "x86-Release-Redist"  , "configurePreset": "x86-Release-Redist" },
 
     { "name": "x64-Debug-VCPKG"    , "configurePreset": "x64-Debug-VCPKG" },
     { "name": "x64-Release-VCPKG"  , "configurePreset": "x64-Release-VCPKG" },

--- a/Inc/GamePad.h
+++ b/Inc/GamePad.h
@@ -325,7 +325,13 @@ namespace DirectX
         // Underlying device access
         _Success_(return)
         DIRECTX_TOOLKIT_API
-        bool __cdecl GetDevice(int player, _Outptr_ IGameInputDevice * *device) noexcept;
+        bool __cdecl GetDevice(int player,
+        #if defined(GAMEINPUT_API_VERSION) && (GAMEINPUT_API_VERSION == 1)
+            _Outptr_ GameInput::v1::IGameInputDevice * *device
+        #else
+            _Outptr_ IGameInputDevice * *device
+        #endif
+            ) noexcept;
     #elif defined(USING_WINDOWS_GAMING_INPUT) || defined(_XBOX_ONE)
         DIRECTX_TOOLKIT_API void __cdecl RegisterEvents(void* ctrlChanged, void* userChanged) noexcept;
     #endif

--- a/Src/GamePad.cpp
+++ b/Src/GamePad.cpp
@@ -198,7 +198,7 @@ public:
             {
                 state.connected = true;
             #if defined(GAMEINPUT_API_VERSION) && (GAMEINPUT_API_VERSION == 1)
-                state.packet = mGameInput->GetCurrentTimestamp();
+                state.packet = reading->GetTimestamp();
             #else
                 state.packet = reading->GetSequenceNumber(GameInputKindGamepad);
             #endif

--- a/Src/GamePad.cpp
+++ b/Src/GamePad.cpp
@@ -256,9 +256,6 @@ public:
                     caps.id = deviceInfo->deviceId;
                     caps.vid = deviceInfo->vendorId;
                     caps.pid = deviceInfo->productId;
-                #if defined(GAMEINPUT_API_VERSION) && (GAMEINPUT_API_VERSION == 1)
-                    // TODO - How do I free deviceInfo?
-                #endif
                     return;
                 }
                 else

--- a/Src/GamePad.cpp
+++ b/Src/GamePad.cpp
@@ -16,10 +16,6 @@
 using namespace DirectX;
 using Microsoft::WRL::ComPtr;
 
-#if defined(USING_GAMEINPUT) && defined(GAMEINPUT_API_VERSION) && (GAMEINPUT_API_VERSION == 1)
-using namespace GameInput::v1;
-#endif
-
 
 namespace
 {
@@ -87,6 +83,10 @@ namespace
 
 #pragma region Implementations
 #ifdef USING_GAMEINPUT
+
+#if defined(GAMEINPUT_API_VERSION) && (GAMEINPUT_API_VERSION == 1)
+using namespace GameInput::v1;
+#endif
 
 //======================================================================================
 // GameInput

--- a/Src/GamePad.cpp
+++ b/Src/GamePad.cpp
@@ -16,6 +16,10 @@
 using namespace DirectX;
 using Microsoft::WRL::ComPtr;
 
+#if defined(USING_GAMEINPUT) && defined(GAMEINPUT_API_VERSION) && (GAMEINPUT_API_VERSION == 1)
+using namespace GameInput::v1;
+#endif
+
 
 namespace
 {
@@ -141,7 +145,11 @@ public:
         {
             if (mGameInput)
             {
+            #if defined(GAMEINPUT_API_VERSION) && (GAMEINPUT_API_VERSION == 1)
+                if (!mGameInput->UnregisterCallback(mDeviceToken))
+            #else
                 if (!mGameInput->UnregisterCallback(mDeviceToken, UINT64_MAX))
+            #endif
                 {
                     DebugTrace("ERROR: GameInput::UnregisterCallback [gamepad] failed");
                 }
@@ -189,7 +197,11 @@ public:
             if (reading->GetGamepadState(&pad))
             {
                 state.connected = true;
+            #if defined(GAMEINPUT_API_VERSION) && (GAMEINPUT_API_VERSION == 1)
+                state.packet = mGameInput->GetCurrentTimestamp();
+            #else
                 state.packet = reading->GetSequenceNumber(GameInputKindGamepad);
+            #endif
 
                 state.buttons.a = (pad.buttons & GameInputGamepadA) != 0;
                 state.buttons.b = (pad.buttons & GameInputGamepadB) != 0;
@@ -233,12 +245,20 @@ public:
             {
                 if (device->GetDeviceStatus() & GameInputDeviceConnected)
                 {
+                #if defined(GAMEINPUT_API_VERSION) && (GAMEINPUT_API_VERSION == 1)
+                    const GameInputDeviceInfo* deviceInfo = nullptr;
+                    device->GetDeviceInfo(&deviceInfo);
+                #else
                     auto deviceInfo = device->GetDeviceInfo();
+                #endif
                     caps.connected = true;
                     caps.gamepadType = Capabilities::GAMEPAD;
                     caps.id = deviceInfo->deviceId;
                     caps.vid = deviceInfo->vendorId;
                     caps.pid = deviceInfo->productId;
+                #if defined(GAMEINPUT_API_VERSION) && (GAMEINPUT_API_VERSION == 1)
+                    // TODO - How do I free deviceInfo?
+                #endif
                     return;
                 }
                 else

--- a/Src/Keyboard.cpp
+++ b/Src/Keyboard.cpp
@@ -53,6 +53,11 @@ namespace
 
 #include <GameInput.h>
 
+#if defined(GAMEINPUT_API_VERSION) && (GAMEINPUT_API_VERSION == 1)
+using namespace GameInput::v1;
+#endif
+
+
 //======================================================================================
 // GameInput
 //======================================================================================
@@ -111,7 +116,11 @@ public:
         {
             if (mGameInput)
             {
+            #if defined(GAMEINPUT_API_VERSION) && (GAMEINPUT_API_VERSION == 1)
+                if (!mGameInput->UnregisterCallback(mDeviceToken))
+            #else
                 if (!mGameInput->UnregisterCallback(mDeviceToken, UINT64_MAX))
+            #endif
                 {
                     DebugTrace("ERROR: GameInput::UnregisterCallback [keyboard] failed");
                 }

--- a/Src/Mouse.cpp
+++ b/Src/Mouse.cpp
@@ -21,6 +21,10 @@ using Microsoft::WRL::ComPtr;
 
 #include <GameInput.h>
 
+#if defined(GAMEINPUT_API_VERSION) && (GAMEINPUT_API_VERSION == 1)
+using namespace GameInput::v1;
+#endif
+
 //======================================================================================
 // Win32 + GameInput implementation
 //======================================================================================
@@ -121,7 +125,11 @@ public:
         {
             if (mGameInput)
             {
+            #if defined(GAMEINPUT_API_VERSION) && (GAMEINPUT_API_VERSION == 1)
+                if (!mGameInput->UnregisterCallback(mDeviceToken))
+            #else
                 if (!mGameInput->UnregisterCallback(mDeviceToken, UINT64_MAX))
+            #endif
                 {
                     DebugTrace("ERROR: GameInput::UnregisterCallback [mouse] failed");
                 }

--- a/Src/pch.h
+++ b/Src/pch.h
@@ -254,6 +254,15 @@
 #include <OCIdl.h>
 #endif
 
+#if defined(USING_GAMEINPUT) && defined(__MINGW32__)
+namespace GameInput { namespace v1 { interface IGameInput; } }
+template<> inline auto __mingw_uuidof<GameInput::v1::IGameInput>() -> GUID const&
+{
+    static constexpr GUID the_uuid = { 0x40ffb7e4,0x6150,0x407a,0xb4,0x39,0x13,0x2b,0xad,0xc0,0x8d,0x2d };
+    return the_uuid;
+}
+#endif
+
 #ifndef __MINGW32__
 // DirectX Tool Kit for Audio is in all versions of DirectXTK12
 #include <mmreg.h>

--- a/build/vcpkg.json
+++ b/build/vcpkg.json
@@ -1,15 +1,23 @@
 {
-    "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
-    "dependencies": [
-      "directxmath",
-      {
-        "name": "directx-dxc",
-        "host": true
-      },
-      "directx-headers",
-      {
-        "name": "xaudio2redist",
-        "platform": "windows & !arm"
-      }
-    ]
-  }
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "dependencies": [
+    {
+      "name": "directx-dxc",
+      "host": true,
+      "platform": "windows & !xbox"
+    },
+    {
+      "name": "directx-headers",
+      "platform": "windows & !xbox"
+    },
+    "directxmath",
+    {
+      "name": "gameinput",
+      "platform": "windows & x64 & !xbox"
+    },
+    {
+      "name": "xaudio2redist",
+      "platform": "windows & !arm & !xbox"
+    }
+  ]
+}


### PR DESCRIPTION
The original GameInput implementation that is used for the Microsoft GDK is 'verison 0'. Version 1 of the API was released today via NuGet. This PR updates the implementation of GamePad, Keyboard, and Mouse to support both the old and new versions.
