### PR TITLE
Update ADO pipeline for MinGW validation

### DIFF
--- a/build/DirectXTK12-GitHub-MinGW.yml
+++ b/build/DirectXTK12-GitHub-MinGW.yml
@@ -201,3 +201,32 @@ jobs:
     inputs:
       cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out
+  - task: CMake@1
+    displayName: CMake (MinGW-W64) as Shared Lib
+    inputs:
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: >
+        -B out2 -DCMAKE_BUILD_TYPE="Debug" -DDIRECTX_ARCH=x64 -DBUILD_XAUDIO_REDIST=ON
+        -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
+        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-mingw-static
+        -DVCPKG_HOST_TRIPLET=x64-mingw-static -DDIRECTX_DXC_PATH="$(DIRECTX_DXC_DIR)"
+        -DBUILD_SHARED_LIBS=ON
+  - task: CMake@1
+    displayName: CMake (MinGW-W64) Build as Shared Lib
+    inputs:
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: --build out2
+  - task: CMake@1
+    displayName: CMake (MinGW-W64) w/ GameInput
+    inputs:
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: >
+        -B out3 -DCMAKE_BUILD_TYPE="Debug" -DDIRECTX_ARCH=x64 -DBUILD_XAUDIO_REDIST=ON -DBUILD_GAMEINPUT=ON
+        -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
+        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-mingw-static
+        -DVCPKG_HOST_TRIPLET=x64-mingw-static -DDIRECTX_DXC_PATH="$(DIRECTX_DXC_DIR)"
+  - task: CMake@1
+    displayName: CMake (MinGW-W64) Build w/ GameInput
+    inputs:
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: --build out3


### PR DESCRIPTION
* Retired support for Windows 7 and Windows 8.0
* CMake project updates including support for BUILD_SHARED_LIBS (i.e. DLL vs. static library)