### PR TITLE
Cleanup of ADO pipeline YAML files

### DIFF
--- a/.azuredevops/pipelines/DirectXTK12-GitHub-CMake-Dev17.yml
+++ b/.azuredevops/pipelines/DirectXTK12-GitHub-CMake-Dev17.yml
@@ -20,7 +20,7 @@ trigger:
     exclude:
     - '*.md'
     - LICENSE
-    - '.github/*'
+    - '.github/**'
     - '.nuget/*'
     - build/*.cmd
     - build/*.json
@@ -37,7 +37,7 @@ pr:
     exclude:
     - '*.md'
     - LICENSE
-    - '.github/*'
+    - '.github/**'
     - '.nuget/*'
     - build/*.cmd
     - build/*.json

--- a/.azuredevops/pipelines/DirectXTK12-GitHub-CMake.yml
+++ b/.azuredevops/pipelines/DirectXTK12-GitHub-CMake.yml
@@ -20,7 +20,7 @@ trigger:
     exclude:
     - '*.md'
     - LICENSE
-    - '.github/*'
+    - '.github/**'
     - '.nuget/*'
     - build/*.cmd
     - build/*.json
@@ -37,7 +37,7 @@ pr:
     exclude:
     - '*.md'
     - LICENSE
-    - '.github/*'
+    - '.github/**'
     - '.nuget/*'
     - build/*.cmd
     - build/*.json

--- a/.azuredevops/pipelines/DirectXTK12-GitHub-Dev17.yml
+++ b/.azuredevops/pipelines/DirectXTK12-GitHub-Dev17.yml
@@ -39,115 +39,77 @@ pool:
 
 jobs:
 - job: DESKTOP_BUILD
-  displayName: 'Win32 Desktop'
+  displayName: 'Windows Desktop'
   timeoutInMinutes: 120
   cancelTimeoutInMinutes: 1
+  strategy:
+    maxParallel: 3
+    matrix:
+      Release_arm64:
+        BuildPlatform: ARM64
+        BuildConfiguration: Release
+      Debug_arm64:
+        BuildPlatform: ARM64
+        BuildConfiguration: Debug
+      Release_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Release
+      Debug_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Debug
+      Release_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Release
+      Debug_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Debug
   steps:
   - checkout: self
     clean: true
     fetchTags: false
   - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2022_Win10.sln 32dbg
+    displayName: Build solution DirectXTK_Desktop_2022_Win10.sln
     inputs:
       solution: DirectXTK_Desktop_2022_Win10.sln
       msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2022_Win10.sln 32rel
-    inputs:
-      solution: DirectXTK_Desktop_2022_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Release
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2022_Win10.sln 64dbg
-    inputs:
-      solution: DirectXTK_Desktop_2022_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2022_Win10.sln 64rel
-    inputs:
-      solution: DirectXTK_Desktop_2022_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Release
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2022_Win10.sln arm64dbg
-    inputs:
-      solution: DirectXTK_Desktop_2022_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2022_Win10.sln arm64rel
-    inputs:
-      solution: DirectXTK_Desktop_2022_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Release
+      platform: '$(BuildPlatform)'
+      configuration: '$(BuildConfiguration)'
       msbuildArchitecture: x64
 
 - job: UWP_BUILD
   displayName: 'Universal Windows Platform (UWP)'
   timeoutInMinutes: 120
   cancelTimeoutInMinutes: 1
+  strategy:
+    maxParallel: 3
+    matrix:
+      Release_arm64:
+        BuildPlatform: ARM64
+        BuildConfiguration: Release
+      Debug_arm64:
+        BuildPlatform: ARM64
+        BuildConfiguration: Debug
+      Release_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Release
+      Debug_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Debug
+      Release_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Release
+      Debug_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Debug
   steps:
   - checkout: self
     clean: true
     fetchTags: false
   - task: VSBuild@1
-    displayName: Build solution DirectXTK_Windows10_2022.sln 32dbg
+    displayName: Build solution DirectXTK_Windows10_2022.sln
     inputs:
       solution: DirectXTK_Windows10_2022.sln
       msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Windows10_2022.sln 32rel
-    inputs:
-      solution: DirectXTK_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Release
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Windows10_2022.sln 64dbg
-    inputs:
-      solution: DirectXTK_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Windows10_2022.sln 64rel
-    inputs:
-      solution: DirectXTK_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Release
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Windows10_2022.sln arm64dbg
-    inputs:
-      solution: DirectXTK_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Windows10_2022.sln arm64rel
-    inputs:
-      solution: DirectXTK_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Release
+      platform: '$(BuildPlatform)'
+      configuration: '$(BuildConfiguration)'
       msbuildArchitecture: x64

--- a/.azuredevops/pipelines/DirectXTK12-GitHub-GDK-Dev17.yml
+++ b/.azuredevops/pipelines/DirectXTK12-GitHub-GDK-Dev17.yml
@@ -21,6 +21,7 @@ pr:
   paths:
     include:
     - '.azuredevops/pipelines/DirectXTK12-GitHub-GDK-Dev17.yml'
+    - '.azuredevops/pipelines/DirectXTK12-build-gdk.yml'
     - CMakeList.txt
     - build/*.in
     - build/*.cmake
@@ -114,66 +115,10 @@ jobs:
       msbuildVersion: 17.0
       msbuildArchitecture: x64
       msbuildArguments: /p:GDKEditionNumber=$(GDK_EDITION)
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_GDK_2022 pcdbg
-    continueOnError: True
-    inputs:
-      solution: DirectXTK_GDK_2022.sln
-      vsVersion: 17.0
-      platform: Gaming.Desktop.x64
-      configuration: Debug
-      msbuildArchitecture: x64
-      msbuildArgs: /p:GDKEditionNumber=$(GDK_EDITION)
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_GDK_2022 pcrel
-    continueOnError: True
-    inputs:
-      solution: DirectXTK_GDK_2022.sln
-      vsVersion: 17.0
-      platform: Gaming.Desktop.x64
-      configuration: Release
-      msbuildArchitecture: x64
-      msbuildArgs: /p:GDKEditionNumber=$(GDK_EDITION)
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_GDK_2022 xbdbg
-    continueOnError: True
-    inputs:
-      solution: DirectXTK_GDK_2022.sln
-      vsVersion: 17.0
-      platform: Gaming.Xbox.XboxOne.x64
-      configuration: Debug
-      msbuildArchitecture: x64
-      msbuildArgs: /p:GDKEditionNumber=$(GDK_EDITION)
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_GDK_2022 xbrel
-    continueOnError: True
-    inputs:
-      solution: DirectXTK_GDK_2022.sln
-      vsVersion: 17.0
-      platform: Gaming.Xbox.XboxOne.x64
-      configuration: Release
-      msbuildArchitecture: x64
-      msbuildArgs: /p:GDKEditionNumber=$(GDK_EDITION)
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_GDK_2022 scardbg
-    continueOnError: True
-    inputs:
-      solution: DirectXTK_GDK_2022.sln
-      vsVersion: 17.0
-      platform: Gaming.Xbox.Scarlett.x64
-      configuration: Debug
-      msbuildArchitecture: x64
-      msbuildArgs: /p:GDKEditionNumber=$(GDK_EDITION)
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_GDK_2022 scarrel
-    continueOnError: True
-    inputs:
-      solution: DirectXTK_GDK_2022.sln
-      vsVersion: 17.0
-      platform: Gaming.Xbox.Scarlett.x64
-      configuration: Release
-      msbuildArchitecture: x64
-      msbuildArgs: /p:GDKEditionNumber=$(GDK_EDITION)
+  - template: '/.azuredevops/templates/DirectXTK12-build-gdk.yml'
+    parameters:
+      msVersion: '17.0'
+      vsYear: 2022
 
 - job: BUILD_GDK_CMAKE_SCAR
   displayName: 'Microsoft Game Development Kit (GDK) using CMake (Scarlett)'

--- a/.azuredevops/pipelines/DirectXTK12-GitHub-GDK.yml
+++ b/.azuredevops/pipelines/DirectXTK12-GitHub-GDK.yml
@@ -136,66 +136,10 @@ jobs:
       msbuildVersion: 16.0
       msbuildArchitecture: x64
       msbuildArguments: /p:GDKEditionNumber=$(GDK_EDITION)
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_GDK_2019 pcdbg
-    continueOnError: True
-    inputs:
-      solution: DirectXTK_GDK_2019.sln
-      vsVersion: 16.0
-      platform: Gaming.Desktop.x64
-      configuration: Debug
-      msbuildArchitecture: x64
-      msbuildArgs: /p:GDKEditionNumber=$(GDK_EDITION)
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_GDK_2019 pcrel
-    continueOnError: True
-    inputs:
-      solution: DirectXTK_GDK_2019.sln
-      vsVersion: 16.0
-      platform: Gaming.Desktop.x64
-      configuration: Release
-      msbuildArchitecture: x64
-      msbuildArgs: /p:GDKEditionNumber=$(GDK_EDITION)
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_GDK_2019 xbdbg
-    continueOnError: True
-    inputs:
-      solution: DirectXTK_GDK_2019.sln
-      vsVersion: 16.0
-      platform: Gaming.Xbox.XboxOne.x64
-      configuration: Debug
-      msbuildArchitecture: x64
-      msbuildArgs: /p:GDKEditionNumber=$(GDK_EDITION)
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_GDK_2019 xbrel
-    continueOnError: True
-    inputs:
-      solution: DirectXTK_GDK_2019.sln
-      vsVersion: 16.0
-      platform: Gaming.Xbox.XboxOne.x64
-      configuration: Release
-      msbuildArchitecture: x64
-      msbuildArgs: /p:GDKEditionNumber=$(GDK_EDITION)
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_GDK_2019 scardbg
-    continueOnError: True
-    inputs:
-      solution: DirectXTK_GDK_2019.sln
-      vsVersion: 16.0
-      platform: Gaming.Xbox.Scarlett.x64
-      configuration: Debug
-      msbuildArchitecture: x64
-      msbuildArgs: /p:GDKEditionNumber=$(GDK_EDITION)
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_GDK_2019 scarrel
-    continueOnError: True
-    inputs:
-      solution: DirectXTK_GDK_2019.sln
-      vsVersion: 16.0
-      platform: Gaming.Xbox.Scarlett.x64
-      configuration: Release
-      msbuildArchitecture: x64
-      msbuildArgs: /p:GDKEditionNumber=$(GDK_EDITION)
+  - template: '/.azuredevops/templates/DirectXTK12-build-gdk.yml'
+    parameters:
+      msVersion: '16.0'
+      vsYear: 2019
 
 - job: BUILD_TEST_XBOXONE
   displayName: 'Test suite for Xbox One'

--- a/.azuredevops/pipelines/DirectXTK12-GitHub-GDK.yml
+++ b/.azuredevops/pipelines/DirectXTK12-GitHub-GDK.yml
@@ -23,7 +23,7 @@ trigger:
     - '*.md'
     - LICENSE
     - CMake*
-    - '.github/*'
+    - '.github/**'
     - '.nuget/*'
     - build/*.cmake
     - build/*.in
@@ -39,7 +39,7 @@ pr:
     - '*.md'
     - LICENSE
     - CMake*
-    - '.github/*'
+    - '.github/**'
     - '.nuget/*'
     - build/*.cmake
     - build/*.in

--- a/.azuredevops/pipelines/DirectXTK12-GitHub-MinGW.yml
+++ b/.azuredevops/pipelines/DirectXTK12-GitHub-MinGW.yml
@@ -20,7 +20,7 @@ trigger:
     exclude:
     - '*.md'
     - LICENSE
-    - '.github/*'
+    - '.github/**'
     - '.nuget/*'
     - build/*.cmd
     - build/OneFuzz*.json
@@ -37,7 +37,7 @@ pr:
     exclude:
     - '*.md'
     - LICENSE
-    - '.github/*'
+    - '.github/**'
     - '.nuget/*'
     - build/*.cmd
     - build/OneFuzz*.json

--- a/.azuredevops/pipelines/DirectXTK12-GitHub-SDK-prerelease.yml
+++ b/.azuredevops/pipelines/DirectXTK12-GitHub-SDK-prerelease.yml
@@ -98,49 +98,7 @@ jobs:
       SourceFolder: build
       Contents: 'Directory.Build.props'
       TargetFolder: $(Build.SourcesDirectory)
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019_Win10.sln 64rel
-    inputs:
-      solution: DirectXTK_Desktop_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019_Win10.sln 32dbg
-    inputs:
-      solution: DirectXTK_Desktop_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019_Win10.sln 32rel
-    inputs:
-      solution: DirectXTK_Desktop_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019_Win10.sln 64dbg
-    inputs:
-      solution: DirectXTK_Desktop_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Debug
-  # VS 2019 for Win32 on ARM64 is out of support.
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2022_Win10.sln arm64dbg
-    inputs:
-      solution: DirectXTK_Desktop_2022_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2022_Win10.sln arm64rel
-    inputs:
-      solution: DirectXTK_Desktop_2022_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Release
+  - template: '/.azuredevops/templates/DirectXTK12-build-win32.yml'
 
 - job: UWP_BUILD
   displayName: 'Universal Windows Platform (UWP)'
@@ -192,34 +150,7 @@ jobs:
       SourceFolder: build
       Contents: 'Directory.Build.props'
       TargetFolder: $(Build.SourcesDirectory)
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Windows10_2022.sln 32dbg
-    inputs:
-      solution: DirectXTK_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Windows10_2022.sln 32rel
-    inputs:
-      solution: DirectXTK_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Windows10_2022.sln 64dbg
-    inputs:
-      solution: DirectXTK_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Windows10_2022.sln 64rel
-    inputs:
-      solution: DirectXTK_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Release
+  - template: '/.azuredevops/templates/DirectXTK12-build-uwp.yml'
 
 - job: UWP_BUILD_ARM64
   displayName: 'Universal Windows Platform (UWP) for ARM64'
@@ -265,17 +196,4 @@ jobs:
       SourceFolder: build
       Contents: 'Directory.Build.props'
       TargetFolder: $(Build.SourcesDirectory)
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Windows10_2022.sln arm64dbg
-    inputs:
-      solution: DirectXTK_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Windows10_2022.sln arm64rel
-    inputs:
-      solution: DirectXTK_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Release
+  - template: '/.azuredevops/templates/DirectXTK12-build-uwp-arm64.yml'

--- a/.azuredevops/pipelines/DirectXTK12-GitHub-SDK-release.yml
+++ b/.azuredevops/pipelines/DirectXTK12-GitHub-SDK-release.yml
@@ -98,49 +98,7 @@ jobs:
       SourceFolder: build
       Contents: 'Directory.Build.props'
       TargetFolder: $(Build.SourcesDirectory)
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019_Win10.sln 64rel
-    inputs:
-      solution: DirectXTK_Desktop_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019_Win10.sln 32dbg
-    inputs:
-      solution: DirectXTK_Desktop_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019_Win10.sln 32rel
-    inputs:
-      solution: DirectXTK_Desktop_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019_Win10.sln 64dbg
-    inputs:
-      solution: DirectXTK_Desktop_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Debug
-  # VS 2019 for Win32 on ARM64 is out of support.
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2022_Win10.sln arm64dbg
-    inputs:
-      solution: DirectXTK_Desktop_2022_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2022_Win10.sln arm64rel
-    inputs:
-      solution: DirectXTK_Desktop_2022_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Release
+  - template: '/.azuredevops/templates/DirectXTK12-build-win32.yml'
 
 - job: UWP_BUILD
   displayName: 'Universal Windows Platform (UWP)'
@@ -192,34 +150,7 @@ jobs:
       SourceFolder: build
       Contents: 'Directory.Build.props'
       TargetFolder: $(Build.SourcesDirectory)
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Windows10_2022.sln 32dbg
-    inputs:
-      solution: DirectXTK_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Windows10_2022.sln 32rel
-    inputs:
-      solution: DirectXTK_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Windows10_2022.sln 64dbg
-    inputs:
-      solution: DirectXTK_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Windows10_2022.sln 64rel
-    inputs:
-      solution: DirectXTK_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Release
+  - template: '/.azuredevops/templates/DirectXTK12-build-uwp.yml'
 
 - job: UWP_BUILD_ARM64
   displayName: 'Universal Windows Platform (UWP) for ARM64'
@@ -265,17 +196,4 @@ jobs:
       SourceFolder: build
       Contents: 'Directory.Build.props'
       TargetFolder: $(Build.SourcesDirectory)
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Windows10_2022.sln arm64dbg
-    inputs:
-      solution: DirectXTK_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Windows10_2022.sln arm64rel
-    inputs:
-      solution: DirectXTK_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Release
+  - template: '/.azuredevops/templates/DirectXTK12-build-uwp-arm64.yml'

--- a/.azuredevops/pipelines/DirectXTK12-GitHub-Test-Dev17.yml
+++ b/.azuredevops/pipelines/DirectXTK12-GitHub-Test-Dev17.yml
@@ -50,11 +50,32 @@ variables:
 
 jobs:
 - job: DESKTOP_BUILD
-  displayName: 'Win32 Desktop for x64/x86'
+  displayName: 'Windows Desktop'
   timeoutInMinutes: 60
   cancelTimeoutInMinutes: 1
   workspace:
     clean: all
+  strategy:
+    maxParallel: 3
+    matrix:
+      Release_arm64:
+        BuildPlatform: ARM64
+        BuildConfiguration: Release
+      Debug_arm64:
+        BuildPlatform: ARM64
+        BuildConfiguration: Debug
+      Release_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Release
+      Debug_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Debug
+      Release_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Release
+      Debug_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Debug
   steps:
   - checkout: self
     clean: true
@@ -79,145 +100,49 @@ jobs:
       includeNuGetOrg: false
       packagesDirectory: ../packages
   - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Desktop_2022_Win10.sln 32dbg
+    displayName: Build solution DirectXTK_Tests_Desktop_2022_Win10.sln
     inputs:
       solution: Tests/DirectXTK_Tests_Desktop_2022_Win10.sln
       vsVersion: 17.0
       msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Debug
+      platform: '$(BuildPlatform)'
+      configuration: '$(BuildConfiguration)'
       msbuildArchitecture: x64
   - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Desktop_2022_Win10.sln 32rel
-    inputs:
-      solution: Tests/DirectXTK_Tests_Desktop_2022_Win10.sln
-      vsVersion: 17.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Release
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Desktop_2022_Win10.sln 64dbg
-    inputs:
-      solution: Tests/DirectXTK_Tests_Desktop_2022_Win10.sln
-      vsVersion: 17.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Desktop_2022_Win10.sln 64rel
-    inputs:
-      solution: Tests/DirectXTK_Tests_Desktop_2022_Win10.sln
-      vsVersion: 17.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Release
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Desktop_2022_AgilitySDK.sln 32dbg
+    displayName: Build solution DirectXTK_Tests_Desktop_2022_AgilitySDK.sln
     inputs:
       solution: Tests/DirectXTK_Tests_Desktop_2022_AgilitySDK.sln
       vsVersion: 17.0
       msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Desktop_2022_AgilitySDK.sln 32rel
-    inputs:
-      solution: Tests/DirectXTK_Tests_Desktop_2022_AgilitySDK.sln
-      vsVersion: 17.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Release
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Desktop_2022_AgilitySDK.sln 64dbg
-    inputs:
-      solution: Tests/DirectXTK_Tests_Desktop_2022_AgilitySDK.sln
-      vsVersion: 17.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Desktop_2022_AgilitySDK.sln 64rel
-    inputs:
-      solution: Tests/DirectXTK_Tests_Desktop_2022_AgilitySDK.sln
-      vsVersion: 17.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Release
+      platform: '$(BuildPlatform)'
+      configuration: '$(BuildConfiguration)'
       msbuildArchitecture: x64
 
-- job: DESKTOP_BUILD_ARM64
-  displayName: 'Win32 Desktop for ARM64'
-  timeoutInMinutes: 60
-  steps:
-  - checkout: self
-    clean: true
-    fetchTags: false
-    fetchDepth: 1
-    path: 's'
-  - checkout: testRepo
-    displayName: Fetch Tests
-    clean: true
-    fetchTags: false
-    fetchDepth: 1
-    path: 's/Tests'
-  - task: NuGetToolInstaller@1
-    displayName: 'Use NuGet'
-  - task: NuGetAuthenticate@1
-    displayName: 'NuGet Auth'
-  - task: NuGetCommand@2
-    displayName: NuGet restore tests
-    inputs:
-      solution: Tests/D3D12Test/packages.config
-      feedRestore: $(GUID_FEED)
-      includeNuGetOrg: false
-      packagesDirectory: ../packages
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Desktop_2022_Win10.sln arm64dbg
-    inputs:
-      solution: Tests/DirectXTK_Tests_Desktop_2022_Win10.sln
-      vsVersion: 17.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Desktop_2022_Win10.sln arm64rel
-    inputs:
-      solution: Tests/DirectXTK_Tests_Desktop_2022_Win10.sln
-      vsVersion: 17.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Release
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Desktop_2022_AgilitySDK.sln arm64dbg
-    inputs:
-      solution: Tests/DirectXTK_Tests_Desktop_2022_AgilitySDK.sln
-      vsVersion: 17.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Desktop_2022_AgilitySDK.sln arm64rel
-    inputs:
-      solution: Tests/DirectXTK_Tests_Desktop_2022_AgilitySDK.sln
-      vsVersion: 17.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Release
-      msbuildArchitecture: x64
-
-- job: UWP_BUILD_X64
-  displayName: 'Universal Windows Platform (UWP) for x64'
+- job: UWP_BUILD
+  displayName: 'Universal Windows Platform (UWP)'
   timeoutInMinutes: 120
   cancelTimeoutInMinutes: 1
+  strategy:
+    maxParallel: 3
+    matrix:
+      Release_arm64:
+        BuildPlatform: ARM64
+        BuildConfiguration: Release
+      Debug_arm64:
+        BuildPlatform: ARM64
+        BuildConfiguration: Debug
+      Release_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Release
+      Debug_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Debug
+      Release_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Release
+      Debug_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Debug
   steps:
   - checkout: self
     clean: true
@@ -242,107 +167,13 @@ jobs:
       includeNuGetOrg: false
       packagesDirectory: ../packages
   - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Windows10.sln 64dbg
+    displayName: Build solution DirectXTK_Tests_Windows10.sln
     inputs:
       solution: Tests/DirectXTK_Tests_Windows10.sln
       vsVersion: 17.0
       msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
-      platform: x64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Windows10.sln 64rel
-    inputs:
-      solution: Tests/DirectXTK_Tests_Windows10.sln
-      vsVersion: 17.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
-      platform: x64
-      configuration: Release
-
-- job: UWP_BUILD_X86
-  displayName: 'Universal Windows Platform (UWP) for x86'
-  timeoutInMinutes: 120
-  steps:
-  - checkout: self
-    clean: true
-    fetchTags: false
-    fetchDepth: 1
-    path: 's'
-  - checkout: testRepo
-    displayName: Fetch Tests
-    clean: true
-    fetchTags: false
-    fetchDepth: 1
-    path: 's/Tests'
-  - task: NuGetToolInstaller@1
-    displayName: 'Use NuGet'
-  - task: NuGetAuthenticate@1
-    displayName: 'NuGet Auth'
-  - task: NuGetCommand@2
-    displayName: NuGet restore tests
-    inputs:
-      solution: Tests/D3D12Test/packages.config
-      feedRestore: $(GUID_FEED)
-      includeNuGetOrg: false
-      packagesDirectory: ../packages
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Windows10.sln 32dbg
-    inputs:
-      solution: Tests/DirectXTK_Tests_Windows10.sln
-      vsVersion: 17.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
-      platform: x86
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Windows10.sln 32rel
-    inputs:
-      solution: Tests/DirectXTK_Tests_Windows10.sln
-      vsVersion: 17.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
-      platform: x86
-      configuration: Release
-
-- job: UWP_BUILD_ARM64
-  displayName: 'Universal Windows Platform (UWP) for ARM64'
-  timeoutInMinutes: 120
-  steps:
-  - checkout: self
-    clean: true
-    fetchTags: false
-    fetchDepth: 1
-    path: 's'
-  - checkout: testRepo
-    displayName: Fetch Tests
-    clean: true
-    fetchTags: false
-    fetchDepth: 1
-    path: 's/Tests'
-  - task: NuGetToolInstaller@1
-    displayName: 'Use NuGet'
-  - task: NuGetAuthenticate@1
-    displayName: 'NuGet Auth'
-  - task: NuGetCommand@2
-    displayName: NuGet restore tests
-    inputs:
-      solution: Tests/D3D12Test/packages.config
-      feedRestore: $(GUID_FEED)
-      includeNuGetOrg: false
-      packagesDirectory: ../packages
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Windows10.sln arm64dbg
-    inputs:
-      solution: Tests/DirectXTK_Tests_Windows10.sln
-      vsVersion: 17.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
-      platform: ARM64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Windows10.sln arm64rel
-    inputs:
-      solution: Tests/DirectXTK_Tests_Windows10.sln
-      vsVersion: 17.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
-      platform: ARM64
-      configuration: Release
+      platform: '$(BuildPlatform)'
+      configuration: '$(BuildConfiguration)'
 
 - job: CMAKE_BUILD_X64
   displayName: 'CMake for X64 BUILD_TESTING=ON'

--- a/.azuredevops/pipelines/DirectXTK12-GitHub-Test.yml
+++ b/.azuredevops/pipelines/DirectXTK12-GitHub-Test.yml
@@ -49,11 +49,26 @@ variables:
 
 jobs:
 - job: DESKTOP_BUILD
-  displayName: 'Win32 Desktop for x64/x86'
+  displayName: 'Windows Desktop'
   timeoutInMinutes: 120
   cancelTimeoutInMinutes: 1
   workspace:
     clean: all
+  strategy:
+    maxParallel: 2
+    matrix:
+      Release_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Release
+      Debug_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Debug
+      Release_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Release
+      Debug_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Debug
   steps:
   - checkout: self
     clean: true
@@ -78,69 +93,21 @@ jobs:
       includeNuGetOrg: false
       packagesDirectory: ../packages
   - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Desktop_2019_Win10.sln 32dbg
+    displayName: Build solution DirectXTK_Tests_Desktop_2019_Win10.sln
     inputs:
       solution: Tests/DirectXTK_Tests_Desktop_2019_Win10.sln
       vsVersion: 16.0
       msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Debug
+      platform: '$(BuildPlatform)'
+      configuration: '$(BuildConfiguration)'
   - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Desktop_2019_Win10.sln 32rel
-    inputs:
-      solution: Tests/DirectXTK_Tests_Desktop_2019_Win10.sln
-      vsVersion: 16.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Desktop_2019_Win10.sln 64dbg
-    inputs:
-      solution: Tests/DirectXTK_Tests_Desktop_2019_Win10.sln
-      vsVersion: 16.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Desktop_2019_Win10.sln 64rel
-    inputs:
-      solution: Tests/DirectXTK_Tests_Desktop_2019_Win10.sln
-      vsVersion: 16.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Desktop_2019_AgilitySDK.sln 32dbg
+    displayName: Build solution DirectXTK_Tests_Desktop_2019_AgilitySDK.sln
     inputs:
       solution: Tests/DirectXTK_Tests_Desktop_2019_AgilitySDK.sln
       vsVersion: 16.0
       msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Desktop_2019_AgilitySDK.sln 32rel
-    inputs:
-      solution: Tests/DirectXTK_Tests_Desktop_2019_AgilitySDK.sln
-      vsVersion: 16.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Desktop_2019_AgilitySDK.sln 64dbg
-    inputs:
-      solution: Tests/DirectXTK_Tests_Desktop_2019_AgilitySDK.sln
-      vsVersion: 16.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Desktop_2019_AgilitySDK.sln 64rel
-    inputs:
-      solution: Tests/DirectXTK_Tests_Desktop_2019_AgilitySDK.sln
-      vsVersion: 16.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Release
+      platform: '$(BuildPlatform)'
+      configuration: '$(BuildConfiguration)'
 
 - job: CMAKE_BUILD_X64
   displayName: 'CMake for X64 BUILD_TESTING=ON'

--- a/.azuredevops/pipelines/DirectXTK12-GitHub.yml
+++ b/.azuredevops/pipelines/DirectXTK12-GitHub.yml
@@ -39,38 +39,33 @@ pool:
 
 jobs:
 - job: DESKTOP_BUILD
-  displayName: 'Win32 Desktop'
+  displayName: 'Windows Desktop'
   timeoutInMinutes: 120
   cancelTimeoutInMinutes: 1
+  strategy:
+    maxParallel: 2
+    matrix:
+      Release_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Release
+      Debug_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Debug
+      Release_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Release
+      Debug_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Debug
   steps:
   - checkout: self
     clean: true
     fetchTags: false
   - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019_Win10.sln 32dbg
+    displayName: Build solution DirectXTK_Desktop_2019_Win10.sln
     inputs:
       solution: DirectXTK_Desktop_2019_Win10.sln
       msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019_Win10.sln 32rel
-    inputs:
-      solution: DirectXTK_Desktop_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019_Win10.sln 64dbg
-    inputs:
-      solution: DirectXTK_Desktop_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019_Win10.sln 64rel
-    inputs:
-      solution: DirectXTK_Desktop_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Release
+      platform: '$(BuildPlatform)'
+      configuration: '$(BuildConfiguration)'
+ 

--- a/.azuredevops/templates/DirectXTK12-build-gdk.yml
+++ b/.azuredevops/templates/DirectXTK12-build-gdk.yml
@@ -1,0 +1,80 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# https://go.microsoft.com/fwlink/?LinkID=615561
+
+# Template used by GitHub-GDK-* pipelines
+
+parameters:
+- name: msVersion
+  type: string
+  values:
+    - '${{ parameters.msVersion }}'
+    - '17.0'
+- name: vsYear
+  type: number
+  values:
+    - 2019
+    - 2022
+
+steps:
+- task: VSBuild@1
+  displayName: Build solution DirectXTK_GDK_${{ parameters.vsYear }} pcdbg
+  continueOnError: True
+  inputs:
+    solution: DirectXTK_GDK_${{ parameters.vsYear }}.sln
+    vsVersion: ${{ parameters.msVersion }}
+    platform: Gaming.Desktop.x64
+    configuration: Debug
+    msbuildArchitecture: x64
+    msbuildArgs: /p:GDKEditionNumber=$(GDK_EDITION)
+- task: VSBuild@1
+  displayName: Build solution DirectXTK_GDK_${{ parameters.vsYear }} pcrel
+  continueOnError: True
+  inputs:
+    solution: DirectXTK_GDK_${{ parameters.vsYear }}.sln
+    vsVersion: ${{ parameters.msVersion }}
+    platform: Gaming.Desktop.x64
+    configuration: Release
+    msbuildArchitecture: x64
+    msbuildArgs: /p:GDKEditionNumber=$(GDK_EDITION)
+- task: VSBuild@1
+  displayName: Build solution DirectXTK_GDK_${{ parameters.vsYear }} xbdbg
+  continueOnError: True
+  inputs:
+    solution: DirectXTK_GDK_${{ parameters.vsYear }}.sln
+    vsVersion: ${{ parameters.msVersion }}
+    platform: Gaming.Xbox.XboxOne.x64
+    configuration: Debug
+    msbuildArchitecture: x64
+    msbuildArgs: /p:GDKEditionNumber=$(GDK_EDITION)
+- task: VSBuild@1
+  displayName: Build solution DirectXTK_GDK_${{ parameters.vsYear }} xbrel
+  continueOnError: True
+  inputs:
+    solution: DirectXTK_GDK_${{ parameters.vsYear }}.sln
+    vsVersion: ${{ parameters.msVersion }}
+    platform: Gaming.Xbox.XboxOne.x64
+    configuration: Release
+    msbuildArchitecture: x64
+    msbuildArgs: /p:GDKEditionNumber=$(GDK_EDITION)
+- task: VSBuild@1
+  displayName: Build solution DirectXTK_GDK_${{ parameters.vsYear }} scardbg
+  continueOnError: True
+  inputs:
+    solution: DirectXTK_GDK_${{ parameters.vsYear }}.sln
+    vsVersion: ${{ parameters.msVersion }}
+    platform: Gaming.Xbox.Scarlett.x64
+    configuration: Debug
+    msbuildArchitecture: x64
+    msbuildArgs: /p:GDKEditionNumber=$(GDK_EDITION)
+- task: VSBuild@1
+  displayName: Build solution DirectXTK_GDK_${{ parameters.vsYear }} scarrel
+  continueOnError: True
+  inputs:
+    solution: DirectXTK_GDK_${{ parameters.vsYear }}.sln
+    vsVersion: ${{ parameters.msVersion }}
+    platform: Gaming.Xbox.Scarlett.x64
+    configuration: Release
+    msbuildArchitecture: x64
+    msbuildArgs: /p:GDKEditionNumber=$(GDK_EDITION)

--- a/.azuredevops/templates/DirectXTK12-build-gdk.yml
+++ b/.azuredevops/templates/DirectXTK12-build-gdk.yml
@@ -9,7 +9,7 @@ parameters:
 - name: msVersion
   type: string
   values:
-    - '${{ parameters.msVersion }}'
+    - '16.0'
     - '17.0'
 - name: vsYear
   type: number

--- a/.azuredevops/templates/DirectXTK12-build-uwp-arm64.yml
+++ b/.azuredevops/templates/DirectXTK12-build-uwp-arm64.yml
@@ -1,0 +1,22 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# http://go.microsoft.com/fwlink/?LinkID=615561
+
+# Template used by SDK-release and SDK-prerelease pipelines
+
+steps:
+- task: VSBuild@1
+  displayName: Build solution DirectXTK_Windows10_2022.sln arm64dbg
+  inputs:
+    solution: DirectXTK_Windows10_2022.sln
+    msbuildArgs: /p:PreferredToolArchitecture=x64
+    platform: ARM64
+    configuration: Debug
+- task: VSBuild@1
+  displayName: Build solution DirectXTK_Windows10_2022.sln arm64rel
+  inputs:
+    solution: DirectXTK_Windows10_2022.sln
+    msbuildArgs: /p:PreferredToolArchitecture=x64
+    platform: ARM64
+    configuration: Release

--- a/.azuredevops/templates/DirectXTK12-build-uwp.yml
+++ b/.azuredevops/templates/DirectXTK12-build-uwp.yml
@@ -1,0 +1,36 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# http://go.microsoft.com/fwlink/?LinkID=615561
+
+# Template used by SDK-release and SDK-prerelease pipelines
+
+steps:
+- task: VSBuild@1
+  displayName: Build solution DirectXTK_Windows10_2022.sln 32dbg
+  inputs:
+    solution: DirectXTK_Windows10_2022.sln
+    msbuildArgs: /p:PreferredToolArchitecture=x64
+    platform: x86
+    configuration: Debug
+- task: VSBuild@1
+  displayName: Build solution DirectXTK_Windows10_2022.sln 32rel
+  inputs:
+    solution: DirectXTK_Windows10_2022.sln
+    msbuildArgs: /p:PreferredToolArchitecture=x64
+    platform: x86
+    configuration: Release
+- task: VSBuild@1
+  displayName: Build solution DirectXTK_Windows10_2022.sln 64dbg
+  inputs:
+    solution: DirectXTK_Windows10_2022.sln
+    msbuildArgs: /p:PreferredToolArchitecture=x64
+    platform: x64
+    configuration: Debug
+- task: VSBuild@1
+  displayName: Build solution DirectXTK_Windows10_2022.sln 64rel
+  inputs:
+    solution: DirectXTK_Windows10_2022.sln
+    msbuildArgs: /p:PreferredToolArchitecture=x64
+    platform: x64
+    configuration: Release

--- a/.azuredevops/templates/DirectXTK12-build-win32.yml
+++ b/.azuredevops/templates/DirectXTK12-build-win32.yml
@@ -1,0 +1,51 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# http://go.microsoft.com/fwlink/?LinkID=615561
+
+# Template used by SDK-release and SDK-prerelease pipelines
+
+steps:
+- task: VSBuild@1
+  displayName: Build solution DirectXTK_Desktop_2019_Win10.sln 64rel
+  inputs:
+    solution: DirectXTK_Desktop_2019_Win10.sln
+    msbuildArgs: /p:PreferredToolArchitecture=x64
+    platform: x64
+    configuration: Release
+- task: VSBuild@1
+  displayName: Build solution DirectXTK_Desktop_2019_Win10.sln 32dbg
+  inputs:
+    solution: DirectXTK_Desktop_2019_Win10.sln
+    msbuildArgs: /p:PreferredToolArchitecture=x64
+    platform: x86
+    configuration: Debug
+- task: VSBuild@1
+  displayName: Build solution DirectXTK_Desktop_2019_Win10.sln 32rel
+  inputs:
+    solution: DirectXTK_Desktop_2019_Win10.sln
+    msbuildArgs: /p:PreferredToolArchitecture=x64
+    platform: x86
+    configuration: Release
+- task: VSBuild@1
+  displayName: Build solution DirectXTK_Desktop_2019_Win10.sln 64dbg
+  inputs:
+    solution: DirectXTK_Desktop_2019_Win10.sln
+    msbuildArgs: /p:PreferredToolArchitecture=x64
+    platform: x64
+    configuration: Debug
+# VS 2019 for Win32 on ARM64 is out of support.
+- task: VSBuild@1
+  displayName: Build solution DirectXTK_Desktop_2022_Win10.sln arm64dbg
+  inputs:
+    solution: DirectXTK_Desktop_2022_Win10.sln
+    msbuildArgs: /p:PreferredToolArchitecture=x64
+    platform: ARM64
+    configuration: Debug
+- task: VSBuild@1
+  displayName: Build solution DirectXTK_Desktop_2022_Win10.sln arm64rel
+  inputs:
+    solution: DirectXTK_Desktop_2022_Win10.sln
+    msbuildArgs: /p:PreferredToolArchitecture=x64
+    platform: ARM64
+    configuration: Release

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,12 +8,23 @@ name: "CodeQL"
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.azuredevops/**'
+      - '.nuget/*'
+      - build/*.cmd
+      - build/*.json
+      - build/*.props
+      - build/*.ps1
+      - build/*.targets
+      - build/*.xvd
   pull_request:
     branches: [ "main" ]
     paths-ignore:
       - '*.md'
       - LICENSE
-      - '.azuredevops/*'
+      - '.azuredevops/**'
       - '.nuget/*'
       - build/*.cmd
       - build/*.json

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,12 +8,23 @@ name: 'CMake (Windows)'
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.azuredevops/**'
+      - '.nuget/*'
+      - build/*.cmd
+      - build/*.json
+      - build/*.props
+      - build/*.ps1
+      - build/*.targets
+      - build/*.xvd
   pull_request:
     branches: [ "main" ]
     paths-ignore:
       - '*.md'
       - LICENSE
-      - '.azuredevops/*'
+      - '.azuredevops/**'
       - '.nuget/*'
       - build/*.cmd
       - build/*.json

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -8,12 +8,18 @@ name: MSBuild
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.azuredevops/**'
+      - '.nuget/*'
+      - build/*
   pull_request:
     branches: [ "main" ]
     paths-ignore:
       - '*.md'
       - LICENSE
-      - '.azuredevops/*'
+      - '.azuredevops/**'
       - '.nuget/*'
       - build/*
 

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -8,12 +8,23 @@ name: Microsoft C++ Code Analysis
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.azuredevops/**'
+      - '.nuget/*'
+      - build/*.cmd
+      - build/*.json
+      - build/*.props
+      - build/*.ps1
+      - build/*.targets
+      - build/*.xvd
   pull_request:
     branches: [ "main" ]
     paths-ignore:
       - '*.md'
       - LICENSE
-      - '.azuredevops/*'
+      - '.azuredevops/**'
       - '.nuget/*'
       - build/*.cmd
       - build/*.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,23 @@ name: 'CTest (Windows)'
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.azuredevops/**'
+      - '.nuget/*'
+      - build/*.cmd
+      - build/*.json
+      - build/*.props
+      - build/*.ps1
+      - build/*.targets
+      - build/*.xvd
   pull_request:
     branches: [ "main" ]
     paths-ignore:
       - '*.md'
       - LICENSE
-      - '.azuredevops/*'
+      - '.azuredevops/**'
       - '.nuget/*'
       - build/*.cmd
       - build/*.json

--- a/.github/workflows/uwp.yml
+++ b/.github/workflows/uwp.yml
@@ -8,12 +8,23 @@ name: 'CMake (UWP)'
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.azuredevops/**'
+      - '.nuget/*'
+      - build/*.cmd
+      - build/*.json
+      - build/*.props
+      - build/*.ps1
+      - build/*.targets
+      - build/*.xvd
   pull_request:
     branches: [ "main" ]
     paths-ignore:
       - '*.md'
       - LICENSE
-      - '.azuredevops/*'
+      - '.azuredevops/**'
       - '.nuget/*'
       - build/*.cmd
       - build/*.json

--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -8,12 +8,21 @@ name: 'CMake (Windows using VCPKG)'
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.azuredevops/**'
+      - build/*.cmd
+      - build/*.props
+      - build/*.ps1
+      - build/*.targets
+      - build/*.xvd
   pull_request:
     branches: [ "main" ]
     paths-ignore:
       - '*.md'
       - LICENSE
-      - '.azuredevops/*'
+      - '.azuredevops/**'
       - build/*.cmd
       - build/*.props
       - build/*.ps1

--- a/build/copysourcetree.flt
+++ b/build/copysourcetree.flt
@@ -1,0 +1,7 @@
+.azuredevops\
+.git\
+.github\
+.nuget\
+.vs\
+build\
+wiki\

--- a/build/copysourcetree.ps1
+++ b/build/copysourcetree.ps1
@@ -8,20 +8,44 @@ Licensed under the MIT License.
 Copies the source tree excluding various .git and control files.
 
 .DESCRIPTION
-This script is used to extract a 'clean' source tree for deplying tests.
+This script is used to extract a minimal source tree for testing.
 
 .PARAMETER FilePath
 Indicates the root of the tree to copy to.
 
 .PARAMETER Overwrite
-Indicates overwrite of existing content.
+Indicates overwrite of existing content if present.
+
+.PARAMETER Clean
+Delete content in the target directory before copying.
+
+.EXAMPLE
+copysourcetree.ps1 -Destination D:\temp\abc
+
+.EXAMPLE
+Remove-Item D:\temp\abc -Recurse -force -ErrorAction SilentlyContinue | Out-Null
+New-Item -Path D:\Temp -Name "abc" -ItemType Directory -ErrorAction SilentlyContinue | Out-Null
+.\build\copysourcetree.ps1 -Destination D:\temp\abc
+robocopy /mir D:\temp\abc \\durfs\durango\TestContent\samples\nightly_dist_directxtk
+
+Update internal test share.
 #>
 
 param(
     [Parameter(Mandatory)]
     [string]$Destination,
-    [switch]$Overwrite
+    [switch]$Quiet,
+    [switch]$Overwrite,
+    [switch]$Clean
 )
+
+$xcopyFlags = "/Y/S"
+if($Quiet) {
+    $xcopyFlags += "/Q"
+}
+else {
+    $xcopyFlags += "/F"
+}
 
 function Copy-Source {
 
@@ -48,7 +72,7 @@ function Copy-Source {
 
     $filters | ForEach-Object {
         $files = Join-Path -Path $Path -ChildPath $_
-        xcopy /Y/S/Q /EXCLUDE:$excludefile $files $Destination
+        xcopy $xcopyFlags /EXCLUDE:$excludefile $files $Destination
         if ($LastExitCode -ne 0) {
             Write-Error "Failed copying source files" -ErrorAction Stop
         }
@@ -59,17 +83,26 @@ if (-Not (Test-Path $Destination)) {
     Write-Error "ERROR: -Destination folder does not exist" -ErrorAction Stop
 }
 
-$targetreadme = Join-Path -Path $Destination -ChildPath "README.md"
+$destdir = Join-Path $Destination -ChildPath "DirectXTK12"
+
+$targetreadme = Join-Path -Path $destdir -ChildPath "README.md"
 
 if ((Test-Path $targetreadme) -And (-Not $Overwrite)) {
     Write-Error "ERROR: Destination folder contains files. Use -Overwrite to proceed anyhow." -ErrorAction Stop
 }
+
+if($Clean) {
+    Write-Host "Clean..."
+    Remove-Item $destdir -Recurse -force -ErrorAction SilentlyContinue | Out-Null
+}
+
+New-Item -Path $Destination -Name "DirectXTK12" -ItemType Directory -ErrorAction SilentlyContinue | Out-Null
 
 $sourcedir = Split-Path -Path $PSScriptRoot -Parent
 
 $readme = Join-Path -Path $sourcedir -ChildPath "README.md"
 $license = Join-Path -Path $sourcedir -ChildPath "LICENSE"
 
-Copy-Item $readme -Destination $Destination
-Copy-Item $license -Destination $Destination
-Copy-Source -Path $sourcedir -Destination $Destination
+Copy-Item $readme -Destination $destdir
+Copy-Item $license -Destination $destdir
+Copy-Source -Path $sourcedir -Destination $destdir

--- a/build/copysourcetree.ps1
+++ b/build/copysourcetree.ps1
@@ -1,0 +1,75 @@
+<#
+
+.NOTES
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT License.
+
+.SYNOPSIS
+Copies the source tree excluding various .git and control files.
+
+.DESCRIPTION
+This script is used to extract a 'clean' source tree for deplying tests.
+
+.PARAMETER FilePath
+Indicates the root of the tree to copy to.
+
+.PARAMETER Overwrite
+Indicates overwrite of existing content.
+#>
+
+param(
+    [Parameter(Mandatory)]
+    [string]$Destination,
+    [switch]$Overwrite
+)
+
+function Copy-Source {
+
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path,
+        [Parameter(Mandatory)]
+        [string]$Destination
+        )
+
+    $filters = @("*.cpp",
+        "*.h", "*.inl", "*.inc",
+        "*.cmd",
+        "*.hlsl", "*.hlsli", "*.fx", "*.fxh",
+        "*.sln", "*.vcxproj", "*.vcxproj.filters",
+        "*.config", "*.mgc", "*.appxmanifest", "*.manifest",
+        "*.spritefont", "*.bmp", "*.dds", "*.png", "*.jpg", "*.tif", "*.tiff",
+        "*.sdkmesh*", "*.cmo", "*._obj", "*.mtl", "*.vbo",
+        "*.wav", "*.xwb" )
+
+    $excludefile = Split-Path -Path $PSScriptRoot -Parent
+    $excludefile = Join-Path $excludefile -Child "build"
+    $excludefile = Join-Path $excludefile -Child "copysourcetree.flt"
+
+    $filters | ForEach-Object {
+        $files = Join-Path -Path $Path -ChildPath $_
+        xcopy /Y/S/Q /EXCLUDE:$excludefile $files $Destination
+        if ($LastExitCode -ne 0) {
+            Write-Error "Failed copying source files" -ErrorAction Stop
+        }
+    }
+}
+
+if (-Not (Test-Path $Destination)) {
+    Write-Error "ERROR: -Destination folder does not exist" -ErrorAction Stop
+}
+
+$targetreadme = Join-Path -Path $Destination -ChildPath "README.md"
+
+if ((Test-Path $targetreadme) -And (-Not $Overwrite)) {
+    Write-Error "ERROR: Destination folder contains files. Use -Overwrite to proceed anyhow." -ErrorAction Stop
+}
+
+$sourcedir = Split-Path -Path $PSScriptRoot -Parent
+
+$readme = Join-Path -Path $sourcedir -ChildPath "README.md"
+$license = Join-Path -Path $sourcedir -ChildPath "LICENSE"
+
+Copy-Item $readme -Destination $Destination
+Copy-Item $license -Destination $Destination
+Copy-Source -Path $sourcedir -Destination $Destination


### PR DESCRIPTION
This PR adds the use of strategy and templates to the existing ADO pipelines.

* For the basic builds using Visual Studio MSBuild with minimal job setup, I made use of `strategy` `matrix` to simplify the pipelines for GitHub, GitHub-Dev17, GitHub-Test, and GitHub-Dev17.

* For the Windows SDK NuGet pipelines which have substantial package sizes as part of job setup, I made use of `template` for SDK-release and SDK-prerelease pipelines to share implementation.
> Also updated pipeline trigger path filters: GHA should ignore everything under ``.azuredevops``, and ADO should ignore everything under ``.github``.
