### PR TITLE
Add directx12-agilty to VCPKG tests

### DIFF
--- a/.azuredevops/pipelines/DirectXTK12-GitHub-MinGW.yml
+++ b/.azuredevops/pipelines/DirectXTK12-GitHub-MinGW.yml
@@ -134,6 +134,22 @@ jobs:
         Write-Host "##vso[task.prependpath]$env:BUILD_SOURCESDIRECTORY\gw32\mingw32\bin"
 
       workingDirectory: $(Build.SourcesDirectory)
+  - task: PowerShell@2
+    displayName: Setup for Windows 11 SDK
+    inputs:
+      targetType: inline
+      script: |
+        $sdkroot = Get-ItemProperty -Path 'HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows Kits\Installed Roots' | Select-Object -ExpandProperty KitsRoot10
+        $wsdkarchlib = "{0}lib\$(WIN11_SDK)\um\x86" -f $sdkroot
+        if (Test-Path "$wsdkarchlib") {
+            Write-Host "##vso[task.setvariable variable=WindowsSdkDir;]$sdkroot"
+            Write-Host "##vso[task.setvariable variable=LIB;]$wsdkarchlib"
+        }
+        else {
+            Write-Error -Message "##[error]Can't find Windows SDK ($(WIN11_SDK))" -ErrorAction Stop
+        }
+
+      workingDirectory: $(Build.SourcesDirectory)
   - task: CmdLine@2
     displayName: GCC version
     inputs:
@@ -187,6 +203,22 @@ jobs:
         echo ##vso[task.setvariable variable=VCPKG_DEFAULT_HOST_TRIPLET;]x64-mingw-static
 
       workingDirectory: $(Build.SourcesDirectory)\vcpkg
+  - task: PowerShell@2
+    displayName: Setup for Windows 11 SDK
+    inputs:
+      targetType: inline
+      script: |
+        $sdkroot = Get-ItemProperty -Path 'HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows Kits\Installed Roots' | Select-Object -ExpandProperty KitsRoot10
+        $wsdkarchlib = "{0}lib\$(WIN11_SDK)\um\x64" -f $sdkroot
+        if (Test-Path "$wsdkarchlib") {
+            Write-Host "##vso[task.setvariable variable=WindowsSdkDir;]$sdkroot"
+            Write-Host "##vso[task.setvariable variable=LIB;]$wsdkarchlib"
+        }
+        else {
+            Write-Error -Message "##[error]Can't find Windows SDK ($(WIN11_SDK))" -ErrorAction Stop
+        }
+
+      workingDirectory: $(Build.SourcesDirectory)
   - task: CmdLine@2
     displayName: GCC version
     inputs:

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -398,8 +398,12 @@
     { "name": "x86-Debug-Redist"    , "configurePreset": "x86-Debug-Redist" },
     { "name": "x86-Release-Redist"  , "configurePreset": "x86-Release-Redist" },
 
-    { "name": "x64-Debug-VCPKG"    , "configurePreset": "x64-Debug-VCPKG" },
-    { "name": "x64-Release-VCPKG"  , "configurePreset": "x64-Release-VCPKG" },
+    { "name": "x64-Debug-VCPKG"     , "configurePreset": "x64-Debug-VCPKG" },
+    { "name": "x64-Release-VCPKG"   , "configurePreset": "x64-Release-VCPKG" },
+    { "name": "x86-Debug-VCPKG"     , "configurePreset": "x86-Debug-VCPKG" },
+    { "name": "x86-Release-VCPKG"   , "configurePreset": "x86-Release-VCPKG" },
+    { "name": "arm64-Debug-VCPKG"   , "configurePreset": "arm64-Debug-VCPKG" },
+    { "name": "arm64-Release-VCPKG" , "configurePreset": "arm64-Release-VCPKG" },
 
     { "name": "x64-Debug-Clang"    , "configurePreset": "x64-Debug-Clang" },
     { "name": "x64-Release-Clang"  , "configurePreset": "x64-Release-Clang" },

--- a/build/vcpkg.json
+++ b/build/vcpkg.json
@@ -7,6 +7,10 @@
       "platform": "windows & !xbox"
     },
     {
+      "name": "directx12-agility",
+      "platform": "windows & !xbox"
+    },
+    {
       "name": "directx-headers",
       "platform": "windows & !xbox"
     },


### PR DESCRIPTION
The VCPKG pipelines were already validating the usage of *directx-headers* which covers the library. This makes sure *directx12-agility* is also covered in the test suite build.