### PR TITLE
GameInput implementation updates for for GAMEINPUT_API_VERSION = 2

### DIFF
--- a/Inc/GamePad.h
+++ b/Inc/GamePad.h
@@ -331,15 +331,16 @@ namespace DirectX
         DIRECTX_TOOLKIT_API void __cdecl RegisterEvents(void* ctrlChanged) noexcept;
 
         // Underlying device access
+    #if defined(GAMEINPUT_API_VERSION) && (GAMEINPUT_API_VERSION == 1)
+        using GameInputDevice_t = GameInput::v1::IGameInputDevice;
+    #elif defined(GAMEINPUT_API_VERSION) && (GAMEINPUT_API_VERSION == 2)
+        using GameInputDevice_t = GameInput::v2::IGameInputDevice;
+    #else
+        using GameInputDevice_t = ::IGameInputDevice;
+    #endif
+
         _Success_(return)
-            DIRECTX_TOOLKIT_API
-            bool __cdecl GetDevice(int player,
-            #if defined(GAMEINPUT_API_VERSION) && (GAMEINPUT_API_VERSION == 1)
-                _Outptr_ GameInput::v1::IGameInputDevice * *device
-            #else
-                _Outptr_ IGameInputDevice * *device
-            #endif
-            ) noexcept;
+            DIRECTX_TOOLKIT_API bool __cdecl GetDevice(int player, _Outptr_ GameInputDevice_t * *device) noexcept;
     #elif defined(USING_WINDOWS_GAMING_INPUT) || defined(_XBOX_ONE)
         DIRECTX_TOOLKIT_API void __cdecl RegisterEvents(void* ctrlChanged, void* userChanged) noexcept;
     #endif

--- a/Src/GamePad.cpp
+++ b/Src/GamePad.cpp
@@ -86,6 +86,8 @@ namespace
 
 #if defined(GAMEINPUT_API_VERSION) && (GAMEINPUT_API_VERSION == 1)
 using namespace GameInput::v1;
+#elif defined(GAMEINPUT_API_VERSION) && (GAMEINPUT_API_VERSION == 2)
+using namespace GameInput::v2;
 #endif
 
 //======================================================================================
@@ -145,11 +147,11 @@ public:
         {
             if (mGameInput)
             {
-            #if defined(GAMEINPUT_API_VERSION) && (GAMEINPUT_API_VERSION == 1)
+            #if defined(GAMEINPUT_API_VERSION) && (GAMEINPUT_API_VERSION >= 1)
                 if (!mGameInput->UnregisterCallback(mDeviceToken))
-                #else
+            #else
                 if (!mGameInput->UnregisterCallback(mDeviceToken, UINT64_MAX))
-                #endif
+            #endif
                 {
                     DebugTrace("ERROR: GameInput::UnregisterCallback [gamepad] failed");
                 }
@@ -197,7 +199,7 @@ public:
             if (reading->GetGamepadState(&pad))
             {
                 state.connected = true;
-            #if defined(GAMEINPUT_API_VERSION) && (GAMEINPUT_API_VERSION == 1)
+            #if defined(GAMEINPUT_API_VERSION) && (GAMEINPUT_API_VERSION >= 1)
                 state.packet = reading->GetTimestamp();
             #else
                 state.packet = reading->GetSequenceNumber(GameInputKindGamepad);
@@ -245,7 +247,7 @@ public:
             {
                 if (device->GetDeviceStatus() & GameInputDeviceConnected)
                 {
-                #if defined(GAMEINPUT_API_VERSION) && (GAMEINPUT_API_VERSION == 1)
+                #if defined(GAMEINPUT_API_VERSION) && (GAMEINPUT_API_VERSION >= 1)
                     const GameInputDeviceInfo* deviceInfo = nullptr;
                     device->GetDeviceInfo(&deviceInfo);
                 #else
@@ -425,7 +427,7 @@ void GamePad::RegisterEvents(HANDLE ctrlChanged) noexcept
 }
 
 _Success_(return)
-bool GamePad::GetDevice(int player, _Outptr_ IGameInputDevice * *device) noexcept
+bool GamePad::GetDevice(int player, _Outptr_ GameInputDevice_t * *device) noexcept
 {
     return pImpl->GetDevice(player, device);
 }

--- a/Src/Keyboard.cpp
+++ b/Src/Keyboard.cpp
@@ -55,6 +55,8 @@ namespace
 
 #if defined(GAMEINPUT_API_VERSION) && (GAMEINPUT_API_VERSION == 1)
 using namespace GameInput::v1;
+#elif defined(GAMEINPUT_API_VERSION) && (GAMEINPUT_API_VERSION == 2)
+using namespace GameInput::v2;
 #endif
 
 
@@ -116,11 +118,11 @@ public:
         {
             if (mGameInput)
             {
-            #if defined(GAMEINPUT_API_VERSION) && (GAMEINPUT_API_VERSION == 1)
+            #if defined(GAMEINPUT_API_VERSION) && (GAMEINPUT_API_VERSION >= 1)
                 if (!mGameInput->UnregisterCallback(mDeviceToken))
-                #else
+            #else
                 if (!mGameInput->UnregisterCallback(mDeviceToken, UINT64_MAX))
-                #endif
+            #endif
                 {
                     DebugTrace("ERROR: GameInput::UnregisterCallback [keyboard] failed");
                 }

--- a/Src/Mouse.cpp
+++ b/Src/Mouse.cpp
@@ -23,6 +23,8 @@ using Microsoft::WRL::ComPtr;
 
 #if defined(GAMEINPUT_API_VERSION) && (GAMEINPUT_API_VERSION == 1)
 using namespace GameInput::v1;
+#elif defined(GAMEINPUT_API_VERSION) && (GAMEINPUT_API_VERSION == 2)
+using namespace GameInput::v2;
 #endif
 
 //======================================================================================
@@ -125,11 +127,11 @@ public:
         {
             if (mGameInput)
             {
-            #if defined(GAMEINPUT_API_VERSION) && (GAMEINPUT_API_VERSION == 1)
+            #if defined(GAMEINPUT_API_VERSION) && (GAMEINPUT_API_VERSION >= 1)
                 if (!mGameInput->UnregisterCallback(mDeviceToken))
-                #else
+            #else
                 if (!mGameInput->UnregisterCallback(mDeviceToken, UINT64_MAX))
-                #endif
+            #endif
                 {
                     DebugTrace("ERROR: GameInput::UnregisterCallback [mouse] failed");
                 }


### PR DESCRIPTION
The original GameInput implementation that is used for the Microsoft GDK is 'version 0'. Version 1 support was added in #310. This PR adds support for v2 released today.