### PR TITLE
GHA and ADO pipeline updates

### DIFF
--- a/.azuredevops/pipelines/DirectXTK12-GitHub-CMake.yml
+++ b/.azuredevops/pipelines/DirectXTK12-GitHub-CMake.yml
@@ -57,12 +57,12 @@ name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
 variables:
   Codeql.Enabled: false
-  VS_GENERATOR: 'Visual Studio 16 2019'
+  VS_GENERATOR: 'Visual Studio 17 2022'
   WIN10_SDK: '10.0.19041.0'
   WIN11_SDK: '10.0.22000.0'
 
 pool:
-  vmImage: windows-2019
+  vmImage: windows-2022
 
 jobs:
   - job: CMAKE_BUILD
@@ -76,7 +76,7 @@ jobs:
         inputs:
           cwd: '$(Build.SourcesDirectory)'
           cmakeArgs: >
-            -G "$(VS_GENERATOR)" -A x64 -B out
+            -G "$(VS_GENERATOR)" -T v142 -A x64 -B out
             -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)
       - task: CMake@1
         displayName: 'CMake (MSVC): Build x64 Debug'
@@ -93,7 +93,7 @@ jobs:
         inputs:
           cwd: '$(Build.SourcesDirectory)'
           cmakeArgs: >
-            -G "$(VS_GENERATOR)" -A Win32 -B out2
+            -G "$(VS_GENERATOR)" -T v142 -A Win32 -B out2
             -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)
       - task: CMake@1
         displayName: 'CMake (MSVC): Build x86 Debug'
@@ -110,7 +110,7 @@ jobs:
         inputs:
           cwd: '$(Build.SourcesDirectory)'
           cmakeArgs: >
-            -G "$(VS_GENERATOR)" -A x64 -B out3
+            -G "$(VS_GENERATOR)" -T v142 -A x64 -B out3
             -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=10.0
       - task: CMake@1
         displayName: 'CMake (UWP): Build x64'
@@ -118,68 +118,51 @@ jobs:
           cwd: '$(Build.SourcesDirectory)'
           cmakeArgs: --build out3 -v
       - task: CMake@1
-        displayName: 'CMake (ClangCl): Config x64'
-        inputs:
-          cwd: '$(Build.SourcesDirectory)'
-          cmakeArgs: >
-            -G "$(VS_GENERATOR)" -A x64 -T clangcl -B out4
-            -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)
-      - task: CMake@1
-        displayName: 'CMake (ClangCl): Build x64 Debug'
-        inputs:
-          cwd: '$(Build.SourcesDirectory)'
-          cmakeArgs: --build out4 -v --config Debug
-      - task: CMake@1
-        displayName: 'CMake (ClangCl): Build x64 Release'
-        inputs:
-          cwd: '$(Build.SourcesDirectory)'
-          cmakeArgs: --build out4 -v --config RelWithDebInfo
-      - task: CMake@1
         displayName: 'CMake (MSVC Spectre): Config x64'
         inputs:
           cwd: '$(Build.SourcesDirectory)'
           cmakeArgs: >
-            -G "$(VS_GENERATOR)" -A x64 -B out5
+            -G "$(VS_GENERATOR)" -T v142 -A x64 -B out4
             -DENABLE_SPECTRE_MITIGATION=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON
             -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)
       - task: CMake@1
         displayName: 'CMake (MSVC Spectre): Build x64 Debug'
         inputs:
           cwd: '$(Build.SourcesDirectory)'
-          cmakeArgs: --build out5 -v --config Debug
+          cmakeArgs: --build out4 -v --config Debug
       - task: CMake@1
         displayName: 'CMake (MSVC Spectre): Build x64 Release'
         inputs:
           cwd: '$(Build.SourcesDirectory)'
-          cmakeArgs: --build out5 -v --config RelWithDebInfo
+          cmakeArgs: --build out4 -v --config RelWithDebInfo
       - task: CMake@1
         displayName: 'CMake (NO_WCHAR_T): Config'
         inputs:
           cwd: '$(Build.SourcesDirectory)'
           cmakeArgs: >
-            -G "$(VS_GENERATOR)" -A x64 -B out6
+            -G "$(VS_GENERATOR)" -T v142 -A x64 -B out5
             -DNO_WCHAR_T=ON
             -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN11_SDK)
       - task: CMake@1
         displayName: 'CMake (NO_WCHAR_T): Build'
         inputs:
           cwd: '$(Build.SourcesDirectory)'
-          cmakeArgs: --build out6 -v --config Debug
+          cmakeArgs: --build out5 -v --config Debug
       - task: CMake@1
         displayName: 'CMake (DLL): Config x64'
         inputs:
           cwd: '$(Build.SourcesDirectory)'
           cmakeArgs: >
-            -G "$(VS_GENERATOR)" -A x64 -B out7
+            -G "$(VS_GENERATOR)" -T v142 -A x64 -B out6
             -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)
             -DBUILD_SHARED_LIBS=ON
       - task: CMake@1
         displayName: 'CMake (DLL): Build x64 Debug'
         inputs:
           cwd: '$(Build.SourcesDirectory)'
-          cmakeArgs: --build out7 -v --config Debug
+          cmakeArgs: --build out6 -v --config Debug
       - task: CMake@1
         displayName: 'CMake (DLL): Build x64 Release'
         inputs:
           cwd: '$(Build.SourcesDirectory)'
-          cmakeArgs: --build out7 -v --config RelWithDebInfo
+          cmakeArgs: --build out6 -v --config RelWithDebInfo

--- a/.azuredevops/pipelines/DirectXTK12-GitHub-CMake.yml
+++ b/.azuredevops/pipelines/DirectXTK12-GitHub-CMake.yml
@@ -118,51 +118,33 @@ jobs:
           cwd: '$(Build.SourcesDirectory)'
           cmakeArgs: --build out3 -v
       - task: CMake@1
-        displayName: 'CMake (MSVC Spectre): Config x64'
-        inputs:
-          cwd: '$(Build.SourcesDirectory)'
-          cmakeArgs: >
-            -G "$(VS_GENERATOR)" -T v142 -A x64 -B out4
-            -DENABLE_SPECTRE_MITIGATION=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON
-            -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)
-      - task: CMake@1
-        displayName: 'CMake (MSVC Spectre): Build x64 Debug'
-        inputs:
-          cwd: '$(Build.SourcesDirectory)'
-          cmakeArgs: --build out4 -v --config Debug
-      - task: CMake@1
-        displayName: 'CMake (MSVC Spectre): Build x64 Release'
-        inputs:
-          cwd: '$(Build.SourcesDirectory)'
-          cmakeArgs: --build out4 -v --config RelWithDebInfo
-      - task: CMake@1
         displayName: 'CMake (NO_WCHAR_T): Config'
         inputs:
           cwd: '$(Build.SourcesDirectory)'
           cmakeArgs: >
-            -G "$(VS_GENERATOR)" -T v142 -A x64 -B out5
+            -G "$(VS_GENERATOR)" -T v142 -A x64 -B out4
             -DNO_WCHAR_T=ON
             -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN11_SDK)
       - task: CMake@1
         displayName: 'CMake (NO_WCHAR_T): Build'
         inputs:
           cwd: '$(Build.SourcesDirectory)'
-          cmakeArgs: --build out5 -v --config Debug
+          cmakeArgs: --build out4 -v --config Debug
       - task: CMake@1
         displayName: 'CMake (DLL): Config x64'
         inputs:
           cwd: '$(Build.SourcesDirectory)'
           cmakeArgs: >
-            -G "$(VS_GENERATOR)" -T v142 -A x64 -B out6
+            -G "$(VS_GENERATOR)" -T v142 -A x64 -B out5
             -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)
             -DBUILD_SHARED_LIBS=ON
       - task: CMake@1
         displayName: 'CMake (DLL): Build x64 Debug'
         inputs:
           cwd: '$(Build.SourcesDirectory)'
-          cmakeArgs: --build out6 -v --config Debug
+          cmakeArgs: --build out5 -v --config Debug
       - task: CMake@1
         displayName: 'CMake (DLL): Build x64 Release'
         inputs:
           cwd: '$(Build.SourcesDirectory)'
-          cmakeArgs: --build out6 -v --config RelWithDebInfo
+          cmakeArgs: --build out5 -v --config RelWithDebInfo

--- a/.azuredevops/pipelines/DirectXTK12-GitHub-GDK-Dev17.yml
+++ b/.azuredevops/pipelines/DirectXTK12-GitHub-GDK-Dev17.yml
@@ -33,7 +33,6 @@ resources:
     - repository: self
       type: git
       ref: refs/heads/main
-      trigger: none
 
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 

--- a/.azuredevops/pipelines/DirectXTK12-GitHub-GDK-Dev17.yml
+++ b/.azuredevops/pipelines/DirectXTK12-GitHub-GDK-Dev17.yml
@@ -46,6 +46,8 @@ variables:
     value: false
   - name: EXTRACTED_FOLDER
     value: '$(ExtractedFolder)'
+  - name: GDK_EDITION
+    value: $(GDKEditionNumber)
   - name: GDKEnableBWOI
     value: true
   - name: URL_FEED
@@ -92,16 +94,13 @@ jobs:
         displayName: 'Secure Supply Chain Analysis'
       - task: NuGetAuthenticate@1
         displayName: 'NuGet Auth'
-      - task: NuGetCommand@2
-        displayName: NuGet install PGDK
+      - task: PowerShell@2
+        displayName: 'NuGet Install GDK'
         inputs:
-          command: custom
-          arguments: install -prerelease Microsoft.GDK.PC.$(GDK_EDITION) -ExcludeVersion -OutputDirectory $(EXTRACTED_FOLDER)
-      - task: NuGetCommand@2
-        displayName: NuGet install GDKX
-        inputs:
-          command: custom
-          arguments: install -prerelease Microsoft.GDK.Xbox.$(GDK_EDITION) -ExcludeVersion -OutputDirectory $(EXTRACTED_FOLDER)
+          targetType: filePath
+          filePath: ./build/RestoreGDK.ps1
+          arguments: -GDKEditionNumber $(GDK_EDITION) -OutputDirectory $(EXTRACTED_FOLDER)
+          failOnStderr: true
       - task: CopyFiles@2
         displayName: Set up Directory.Build.props
         inputs:
@@ -155,16 +154,13 @@ jobs:
         displayName: 'Secure Supply Chain Analysis'
       - task: NuGetAuthenticate@1
         displayName: 'NuGet Auth'
-      - task: NuGetCommand@2
-        displayName: NuGet install PGDK
+      - task: PowerShell@2
+        displayName: 'NuGet Install GDK'
         inputs:
-          command: custom
-          arguments: install -prerelease Microsoft.GDK.PC.$(GDK_EDITION) -ExcludeVersion -OutputDirectory $(EXTRACTED_FOLDER)
-      - task: NuGetCommand@2
-        displayName: NuGet install GDKX
-        inputs:
-          command: custom
-          arguments: install -prerelease Microsoft.GDK.Xbox.$(GDK_EDITION) -ExcludeVersion -OutputDirectory $(EXTRACTED_FOLDER)
+          targetType: filePath
+          filePath: ./build/RestoreGDK.ps1
+          arguments: -GDKEditionNumber $(GDK_EDITION) -OutputDirectory $(EXTRACTED_FOLDER)
+          failOnStderr: true
       - task: CmdLine@2
         displayName: Setup BWOI for GDK command-line
         inputs:
@@ -275,16 +271,13 @@ jobs:
         displayName: 'Secure Supply Chain Analysis'
       - task: NuGetAuthenticate@1
         displayName: 'NuGet Auth'
-      - task: NuGetCommand@2
-        displayName: NuGet install PGDK
+      - task: PowerShell@2
+        displayName: 'NuGet Install GDK'
         inputs:
-          command: custom
-          arguments: install -prerelease Microsoft.GDK.PC.$(GDK_EDITION) -ExcludeVersion -OutputDirectory $(EXTRACTED_FOLDER)
-      - task: NuGetCommand@2
-        displayName: NuGet install GDKX
-        inputs:
-          command: custom
-          arguments: install -prerelease Microsoft.GDK.Xbox.$(GDK_EDITION) -ExcludeVersion -OutputDirectory $(EXTRACTED_FOLDER)
+          targetType: filePath
+          filePath: ./build/RestoreGDK.ps1
+          arguments: -GDKEditionNumber $(GDK_EDITION) -OutputDirectory $(EXTRACTED_FOLDER)
+          failOnStderr: true
       - task: CmdLine@2
         displayName: Setup BWOI for GDK command-line
         inputs:

--- a/.azuredevops/pipelines/DirectXTK12-GitHub-GDK-Dev17.yml
+++ b/.azuredevops/pipelines/DirectXTK12-GitHub-GDK-Dev17.yml
@@ -110,7 +110,6 @@ jobs:
         displayName: Setup BWOI VCTargets
         inputs:
           solution: build/SetupBWOI.targets
-          msbuildVersion: 17.0
           msbuildArchitecture: x64
           msbuildArguments: /p:GDKEditionNumber=$(GDK_EDITION)
       - template: '/.azuredevops/templates/DirectXTK12-build-gdk.yml'

--- a/.azuredevops/pipelines/DirectXTK12-GitHub-GDK.yml
+++ b/.azuredevops/pipelines/DirectXTK12-GitHub-GDK.yml
@@ -69,6 +69,8 @@ variables:
     value: false
   - name: EXTRACTED_FOLDER
     value: '$(ExtractedFolder)'
+  - name: GDK_EDITION
+    value: $(GDKEditionNumber)
   - name: GDKEnableBWOI
     value: true
   - name: URL_FEED
@@ -113,16 +115,13 @@ jobs:
         displayName: 'Secure Supply Chain Analysis'
       - task: NuGetAuthenticate@1
         displayName: 'NuGet Auth'
-      - task: NuGetCommand@2
-        displayName: NuGet install PGDK
+      - task: PowerShell@2
+        displayName: 'NuGet Install GDK'
         inputs:
-          command: custom
-          arguments: install -prerelease Microsoft.GDK.PC.$(GDK_EDITION) -ExcludeVersion -OutputDirectory $(EXTRACTED_FOLDER)
-      - task: NuGetCommand@2
-        displayName: NuGet install GDKX
-        inputs:
-          command: custom
-          arguments: install -prerelease Microsoft.GDK.Xbox.$(GDK_EDITION) -ExcludeVersion -OutputDirectory $(EXTRACTED_FOLDER)
+          targetType: filePath
+          filePath: ./build/RestoreGDK.ps1
+          arguments: -GDKEditionNumber $(GDK_EDITION) -OutputDirectory $(EXTRACTED_FOLDER)
+          failOnStderr: true
       - task: CopyFiles@2
         displayName: Set up Directory.Build.props
         inputs:
@@ -183,16 +182,13 @@ jobs:
         displayName: 'Secure Supply Chain Analysis'
       - task: NuGetAuthenticate@1
         displayName: 'NuGet Auth'
-      - task: NuGetCommand@2
-        displayName: NuGet install PGDK
+      - task: PowerShell@2
+        displayName: 'NuGet Install GDK'
         inputs:
-          command: custom
-          arguments: install -prerelease Microsoft.GDK.PC.$(GDK_EDITION) -ExcludeVersion -OutputDirectory $(EXTRACTED_FOLDER)
-      - task: NuGetCommand@2
-        displayName: NuGet install GDKX
-        inputs:
-          command: custom
-          arguments: install -prerelease Microsoft.GDK.Xbox.$(GDK_EDITION) -ExcludeVersion -OutputDirectory $(EXTRACTED_FOLDER)
+          targetType: filePath
+          filePath: ./build/RestoreGDK.ps1
+          arguments: -GDKEditionNumber $(GDK_EDITION) -OutputDirectory $(EXTRACTED_FOLDER)
+          failOnStderr: true
       - task: NuGetCommand@2
         displayName: NuGet restore
         inputs:
@@ -276,16 +272,13 @@ jobs:
         displayName: 'Secure Supply Chain Analysis'
       - task: NuGetAuthenticate@1
         displayName: 'NuGet Auth'
-      - task: NuGetCommand@2
-        displayName: NuGet install PGDK
+      - task: PowerShell@2
+        displayName: 'NuGet Install GDK'
         inputs:
-          command: custom
-          arguments: install -prerelease Microsoft.GDK.PC.$(GDK_EDITION) -ExcludeVersion -OutputDirectory $(EXTRACTED_FOLDER)
-      - task: NuGetCommand@2
-        displayName: NuGet install GDKX
-        inputs:
-          command: custom
-          arguments: install -prerelease Microsoft.GDK.Xbox.$(GDK_EDITION) -ExcludeVersion -OutputDirectory $(EXTRACTED_FOLDER)
+          targetType: filePath
+          filePath: ./build/RestoreGDK.ps1
+          arguments: -GDKEditionNumber $(GDK_EDITION) -OutputDirectory $(EXTRACTED_FOLDER)
+          failOnStderr: true
       - task: NuGetCommand@2
         displayName: NuGet restore
         inputs:

--- a/.azuredevops/pipelines/DirectXTK12-GitHub-GDK.yml
+++ b/.azuredevops/pipelines/DirectXTK12-GitHub-GDK.yml
@@ -61,7 +61,7 @@ resources:
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
 pool:
-  vmImage: windows-2019
+  vmImage: windows-2022
 
 variables:
   - group: dxtk-shared-variables
@@ -132,12 +132,11 @@ jobs:
         displayName: Setup BWOI VCTargets
         inputs:
           solution: build/SetupBWOI.targets
-          msbuildVersion: 16.0
           msbuildArchitecture: x64
           msbuildArguments: /p:GDKEditionNumber=$(GDK_EDITION)
       - template: '/.azuredevops/templates/DirectXTK12-build-gdk.yml'
         parameters:
-          msVersion: '16.0'
+          msVersion: '17.0'
           vsYear: 2019
 
   - job: BUILD_TEST_XBOXONE

--- a/.azuredevops/pipelines/DirectXTK12-GitHub-Test-Dev17.yml
+++ b/.azuredevops/pipelines/DirectXTK12-GitHub-Test-Dev17.yml
@@ -102,7 +102,6 @@ jobs:
         displayName: Build solution DirectXTK_Tests_Desktop_2022_Win10.sln
         inputs:
           solution: Tests/DirectXTK_Tests_Desktop_2022_Win10.sln
-          vsVersion: 17.0
           msbuildArgs: /p:PreferredToolArchitecture=x64
           platform: '$(BuildPlatform)'
           configuration: '$(BuildConfiguration)'
@@ -111,7 +110,6 @@ jobs:
         displayName: Build solution DirectXTK_Tests_Desktop_2022_AgilitySDK.sln
         inputs:
           solution: Tests/DirectXTK_Tests_Desktop_2022_AgilitySDK.sln
-          vsVersion: 17.0
           msbuildArgs: /p:PreferredToolArchitecture=x64
           platform: '$(BuildPlatform)'
           configuration: '$(BuildConfiguration)'
@@ -169,7 +167,6 @@ jobs:
         displayName: Build solution DirectXTK_Tests_Windows10.sln
         inputs:
           solution: Tests/DirectXTK_Tests_Windows10.sln
-          vsVersion: 17.0
           msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
           platform: '$(BuildPlatform)'
           configuration: '$(BuildConfiguration)'

--- a/.azuredevops/pipelines/DirectXTK12-GitHub-Test.yml
+++ b/.azuredevops/pipelines/DirectXTK12-GitHub-Test.yml
@@ -36,14 +36,12 @@ resources:
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
 pool:
-  vmImage: windows-2019
+  vmImage: windows-2022
 
 variables:
   - group: dxtk-shared-variables
   - name: Codeql.Enabled
     value: false
-  - name: VC_PATH
-    value: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC'
   - name: GUID_FEED
     value: $(ADOFeedGUID)
 
@@ -96,7 +94,6 @@ jobs:
         displayName: Build solution DirectXTK_Tests_Desktop_2019_Win10.sln
         inputs:
           solution: Tests/DirectXTK_Tests_Desktop_2019_Win10.sln
-          vsVersion: 16.0
           msbuildArgs: /p:PreferredToolArchitecture=x64
           platform: '$(BuildPlatform)'
           configuration: '$(BuildConfiguration)'
@@ -104,89 +101,6 @@ jobs:
         displayName: Build solution DirectXTK_Tests_Desktop_2019_AgilitySDK.sln
         inputs:
           solution: Tests/DirectXTK_Tests_Desktop_2019_AgilitySDK.sln
-          vsVersion: 16.0
           msbuildArgs: /p:PreferredToolArchitecture=x64
           platform: '$(BuildPlatform)'
           configuration: '$(BuildConfiguration)'
-
-  - job: CMAKE_BUILD_X64
-    displayName: 'CMake for X64 BUILD_TESTING=ON'
-    timeoutInMinutes: 60
-    workspace:
-      clean: all
-    steps:
-      - checkout: self
-        clean: true
-        fetchTags: false
-        fetchDepth: 1
-        path: 's'
-      - checkout: testRepo
-        displayName: Fetch Tests
-        clean: true
-        fetchTags: false
-        fetchDepth: 1
-        path: 's/Tests'
-      - task: CmdLine@2
-        displayName: Setup environment for CMake to use VS
-        inputs:
-          script: |
-            call "$(VC_PATH)\Auxiliary\Build\vcvars64.bat"
-            echo ##vso[task.setvariable variable=WindowsSdkVerBinPath;]%WindowsSdkVerBinPath%
-            echo ##vso[task.prependpath]%VSINSTALLDIR%Common7\IDE\CommonExtensions\Microsoft\CMake\Ninja
-            echo ##vso[task.prependpath]%VCINSTALLDIR%Tools\Llvm\x64\bin
-            echo ##vso[task.prependpath]%WindowsSdkBinPath%x64
-            echo ##vso[task.prependpath]%WindowsSdkVerBinPath%x64
-            echo ##vso[task.prependpath]%VCToolsInstallDir%bin\Hostx64\x64
-            echo ##vso[task.setvariable variable=EXTERNAL_INCLUDE;]%EXTERNAL_INCLUDE%
-            echo ##vso[task.setvariable variable=INCLUDE;]%INCLUDE%
-            echo ##vso[task.setvariable variable=LIB;]%LIB%
-
-      - task: CMake@1
-        displayName: CMake (MSVC; x64-Debug) Config
-        inputs:
-          cwd: $(Build.SourcesDirectory)
-          cmakeArgs: --preset=x64-Debug
-      - task: CMake@1
-        displayName: CMake (MSVC; x64-Debug) Build
-        inputs:
-          cwd: $(Build.SourcesDirectory)
-          cmakeArgs: --build out/build/x64-Debug -v
-      - task: DeleteFiles@1
-        inputs:
-          Contents: 'out'
-      - task: CMake@1
-        displayName: CMake (MSVC; x64-Release) Config
-        inputs:
-          cwd: $(Build.SourcesDirectory)
-          cmakeArgs: --preset=x64-Release
-      - task: CMake@1
-        displayName: CMake (MSVC; x64-Release) Build
-        inputs:
-          cwd: $(Build.SourcesDirectory)
-          cmakeArgs: --build out/build/x64-Release -v
-      - task: DeleteFiles@1
-        inputs:
-          Contents: 'out'
-      - task: CMake@1
-        displayName: CMake (clang/LLVM; x64-Debug) Config
-        inputs:
-          cwd: $(Build.SourcesDirectory)
-          cmakeArgs: --preset=x64-Debug-Clang
-      - task: CMake@1
-        displayName: CMake (clang/LLVM; x64-Debug) Build
-        inputs:
-          cwd: $(Build.SourcesDirectory)
-          cmakeArgs: --build out/build/x64-Debug-Clang -v
-      - task: DeleteFiles@1
-        inputs:
-          Contents: 'out'
-      - task: CMake@1
-        displayName: CMake (clang/LLVM; x64-Release) Config
-        inputs:
-          cwd: $(Build.SourcesDirectory)
-          cmakeArgs: --preset=x64-Release-Clang
-      - task: CMake@1
-        displayName: CMake (clang/LLVM; x64-Release) Build
-        inputs:
-          cwd: $(Build.SourcesDirectory)
-          cmakeArgs: --build out/build/x64-Release-Clang -v

--- a/.azuredevops/pipelines/DirectXTK12-GitHub.yml
+++ b/.azuredevops/pipelines/DirectXTK12-GitHub.yml
@@ -35,7 +35,7 @@ variables:
   Codeql.Enabled: false
 
 pool:
-  vmImage: windows-2019
+  vmImage: windows-2022
 
 jobs:
   - job: DESKTOP_BUILD

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -84,24 +84,24 @@ When creating documentation:
 
 ### Document Only What Exists
 
-* Only document features, patterns, and decisions that are explicitly present in the source code.
-* Only include configurations and requirements that are clearly specified.
-* Do not make assumptions about implementation details.
+- Only document features, patterns, and decisions that are explicitly present in the source code.
+- Only include configurations and requirements that are clearly specified.
+- Do not make assumptions about implementation details.
 
 ### Handle Missing Information
 
-* Ask the user questions to gather missing information.
-* Document gaps in current implementation or specifications.
-* List open questions that need to be addressed.
+- Ask the user questions to gather missing information.
+- Document gaps in current implementation or specifications.
+- List open questions that need to be addressed.
 
 ### Source Material
 
-* Always cite the specific source file and line numbers for documented features.
-* Link directly to relevant source code when possible.
-* Indicate when information comes from requirements vs. implementation.
+- Always cite the specific source file and line numbers for documented features.
+- Link directly to relevant source code when possible.
+- Indicate when information comes from requirements vs. implementation.
 
 ### Verification Process
 
-* Review each documented item against source code whenever related to the task.
-* Remove any speculative content.
-* Ensure all documentation is verifiable against the current state of the codebase.
+- Review each documented item against source code whenever related to the task.
+- Remove any speculative content.
+- Ensure all documentation is verifiable against the current state of the codebase.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -13,7 +13,8 @@ These instructions define how GitHub Copilot should assist with this project. Th
 
 - See the tutorial at [Getting Started](https://github.com/microsoft/DirectXTK12/wiki/Getting-Started).
 - The recommended way to integrate DirectX Tool Kit for DirectX 12 into your project is by using VCPKG. See [d3d12game_vcpkg](https://github.com/walbourn/directx-vs-templates/tree/main/d3d12game_vcpkg) which includes a template and details in the `README.md` file for integrating this library.
-- You can make use of the nuget.org packages directxtk12_desktop_2019, directxtk12_desktop_win10, or directxtk12_uwp.
+- You can make use of the nuget.org packages **directxtk12_desktop_2019**, **directxtk12_desktop_win10**, or **directxtk12_uwp**.
+- If you are new to DirectX, you may want to start with [DirectX Tool Kit for DirectX 11](https://github.com/microsoft/DirectXTK/wiki/Getting-Started) to learn many important concepts for Direct3D programming, HLSL shaders, and the code patterns used in this project with a more 'noobie friendly' API.
 
 ## General Guidelines
 
@@ -28,7 +29,7 @@ These instructions define how GitHub Copilot should assist with this project. Th
 
 ## File Structure
 
-```
+```txt
 .azuredevops/
 .github/
 build/

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,77 @@
+# GitHub Copilot Instructions
+
+These instructions define how GitHub Copilot should assist with this project. The goal is to ensure consistent, high-quality code generation aligned with our conventions, stack, and best practices.
+
+## Context
+
+- **Project Type**: Graphics Library / DirectX / Direct3D 12 / Game Audio
+- **Language**: C++
+- **Framework / Libraries**: STL / CMake / CTest
+- **Architecture**: Modular / RAII / OOP
+
+## Getting Started
+
+- See the tutorial at [Getting Started](https://github.com/microsoft/DirectXTK12/wiki/Getting-Started).
+- The recommended way to integrate DirectX Tool Kit for DirectX 12 into your project is by using VCPKG. See [d3d12game_vcpkg](https://github.com/walbourn/directx-vs-templates/tree/main/d3d12game_vcpkg) which includes a template and details in the `README.md` file for integrating this library.
+- You can make use of the nuget.org packages directxtk12_desktop_2019, directxtk12_desktop_win10, or directxtk12_uwp.
+
+## General Guidelines
+
+- **Code Style**: The project uses an .editorconfig file to enforce coding standards. Follow the rules defined in `.editorconfig` for indentation, line endings, and other formatting. Additional information can be found on the wiki at [Implementation](https://github.com/microsoft/DirectXTK12/wiki/Implementation). The code requires C++11/C++14 features.
+- **Documentation**: The project provides documentation in the form of wiki pages available at [Documentation](https://github.com/microsoft/DirectXTK12/wiki/). The audio, input, and math implementations are identical to the DirectX Tool Kit for DirectX 11.
+- **Error Handling**: Use C++ exceptions for error handling and uses RAII smart pointers to ensure resources are properly managed. For some functions that return HRESULT error codes, they are marked `noexcept`, use `std::nothrow` for memory allocation, and should not throw exceptions.
+- **Testing**: Unit tests for this project are implemented in this repository [Test Suite](https://github.com/walbourn/directxtk12test/) and can be run using CTest per the instructions at [Test Documentation](https://github.com/walbourn/directxtk12test/wiki).
+- **Security**: This project uses secure coding practices from the Microsoft Secure Coding Guidelines, and is subject to the `SECURITY.md` file in the root of the repository. Functions that read input from image file, geomeotry files, and audio files are subject to OneFuzz testing to ensure they are secure against malformed files.
+- **Dependencies**: The project uses CMake and VCPKG for managing dependencies, making optional use of DirectXMath, DirectX-Headers, DirectX 12 Agility SDK, GameInput, and XAudio2Redist. The project can be built without these dependencies, relying on the Windows SDK for core functionality.
+- **Continuous Integration**: This project implements GitHub Actions for continuous integration, ensuring that all code changes are tested and validated before merging. This includes building the project for a number of configurations and toolsets, running a subset of unit tests, and static code analysis including GitHub super-linter, CodeQL, and MSVC Code Analysis.
+- **Code of Conduct**: The project adheres to the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). All contributors are expected to follow this code of conduct in all interactions related to the project.
+
+## File Structure
+
+```
+.azuredevops/
+.github/
+build/
+Audio/
+Inc/
+Src/
+  Shaders/
+Tests/
+```
+
+The `Inc` folder is for public header files, while the `Src` folder contains the implementation header and source files. The `Audio` folder contains DirectX Tool Kit for Audio implementation files.
+
+Note that DirectX Tool Kit for DirectX 12 utilizes the MakeSpriteFont C# tool and the XWBTool C++ Audio tool from DirectX Tool Kit for DirectX 11. See [MakeSpriteFont](https://github.com/microsoft/DirectXTK/tree/main/MakeSpriteFont) and [XWBTool](https://github.com/microsoft/DirectXTK/tree/main/XWBTool).
+
+## Patterns
+
+### Patterns to Follow
+
+- Use RAII for all resource ownership (memory, file handles, etc.).
+- Many classes utilize the pImpl idiom to hide implementation details, and to enable optimized memory alignment in the implementation.
+- Use `std::unique_ptr` for exclusive ownership and `std::shared_ptr` for shared ownership.
+- Use `Microsoft::WRL::ComPtr` for COM object management.
+- Make use of anonymous namespaces to limit scope of functions and variables.
+- Make use of `assert` for debugging checks, but be sure to validate input parameters in release builds.
+- Make use of the `DebugTrace` helper to log diagnostic messages, particularly at the point of throwing an exception.
+
+### Patterns to Avoid
+
+- Don’t use raw pointers for ownership.
+- Avoid macros for constants—prefer `constexpr` or `inline` `const`.
+- Don’t put implementation logic in header files unless using templates, although the SimpleMath library does use an .inl file for performance.
+- Avoid using `using namespace` in header files to prevent polluting the global namespace.
+
+## References
+
+- [C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines)
+- [Microsoft Secure Coding Guidelines](https://learn.microsoft.com/en-us/security/develop/secure-coding-guidelines)
+- [CMake Documentation](https://cmake.org/documentation/)
+- [VCPK Documentation](https://learn.microsoft.com/vcpkg/)
+- [DirectX Tool Kit for DirectX 12 Wiki](https://github.com/microsoft/DirectXTK12/wiki/)
+- [DirectX Tool Kit for Audio Wiki](https://github.com/Microsoft/DirectXTK/wiki/Audio)
+- [Games for Windows and the DirectX SDK blog - December 2013](https://walbourn.github.io/directx-tool-kit-for-audio/)
+- [Games for Windows and the DirectX SDK blog - July 2016](https://walbourn.github.io/directx-tool-kit-for-directx-12/)
+- [Games for Windows and the DirectX SDK blog - May 2020](https://walbourn.github.io/directx-tool-kit-for-audio-updates-and-a-direct3d-9-footnote/)
+- [Games for Windows and the DirectX SDK blog - September 2021](https://walbourn.github.io/latest-news-on-directx-tool-kit/)
+- [Games for Windows and the DirectX SDK blog - October 2021](https://walbourn.github.io/directx-tool-kit-vertex-skinning-update/)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,6 +5,7 @@ These instructions define how GitHub Copilot should assist with this project. Th
 ## Context
 
 - **Project Type**: Graphics Library / DirectX / Direct3D 12 / Game Audio
+- **Project Name**: DirectX Tool Kit for DirectX 12
 - **Language**: C++
 - **Framework / Libraries**: STL / CMake / CTest
 - **Architecture**: Modular / RAII / OOP
@@ -24,7 +25,7 @@ These instructions define how GitHub Copilot should assist with this project. Th
 - **Documentation**: The project provides documentation in the form of wiki pages available at [Documentation](https://github.com/microsoft/DirectXTK12/wiki/). The audio, input, and math implementations are identical to the DirectX Tool Kit for DirectX 11.
 - **Error Handling**: Use C++ exceptions for error handling and uses RAII smart pointers to ensure resources are properly managed. For some functions that return HRESULT error codes, they are marked `noexcept`, use `std::nothrow` for memory allocation, and should not throw exceptions.
 - **Testing**: Unit tests for this project are implemented in this repository [Test Suite](https://github.com/walbourn/directxtk12test/) and can be run using CTest per the instructions at [Test Documentation](https://github.com/walbourn/directxtk12test/wiki).
-- **Security**: This project uses secure coding practices from the Microsoft Secure Coding Guidelines, and is subject to the `SECURITY.md` file in the root of the repository. Functions that read input from image file, geomeotry files, and audio files are subject to OneFuzz testing to ensure they are secure against malformed files.
+- **Security**: This project uses secure coding practices from the Microsoft Secure Coding Guidelines, and is subject to the `SECURITY.md` file in the root of the repository. Functions that read input from image file, geometry files, and audio files are subject to OneFuzz testing to ensure they are secure against malformed files.
 - **Dependencies**: The project uses CMake and VCPKG for managing dependencies, making optional use of DirectXMath, DirectX-Headers, DirectX 12 Agility SDK, GameInput, and XAudio2Redist. The project can be built without these dependencies, relying on the Windows SDK for core functionality.
 - **Continuous Integration**: This project implements GitHub Actions for continuous integration, ensuring that all code changes are tested and validated before merging. This includes building the project for a number of configurations and toolsets, running a subset of unit tests, and static code analysis including GitHub super-linter, CodeQL, and MSVC Code Analysis.
 - **Code of Conduct**: The project adheres to the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). All contributors are expected to follow this code of conduct in all interactions related to the project.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,9 +12,11 @@ These instructions define how GitHub Copilot should assist with this project. Th
 ## Getting Started
 
 - See the tutorial at [Getting Started](https://github.com/microsoft/DirectXTK12/wiki/Getting-Started).
-- The recommended way to integrate DirectX Tool Kit for DirectX 12 into your project is by using VCPKG. See [d3d12game_vcpkg](https://github.com/walbourn/directx-vs-templates/tree/main/d3d12game_vcpkg) which includes a template and details in the `README.md` file for integrating this library.
+- The recommended way to integrate *DirectX Tool Kit for DirectX 12* into your project is by using the *vcpkg* Package Manager. See [d3d12game_vcpkg](https://github.com/walbourn/directx-vs-templates/tree/main/d3d12game_vcpkg) for a template which uses VCPKG.
 - You can make use of the nuget.org packages **directxtk12_desktop_2019**, **directxtk12_desktop_win10**, or **directxtk12_uwp**.
-- If you are new to DirectX, you may want to start with [DirectX Tool Kit for DirectX 11](https://github.com/microsoft/DirectXTK/wiki/Getting-Started) to learn many important concepts for Direct3D programming, HLSL shaders, and the code patterns used in this project with a more 'noobie friendly' API.
+- You can also use the library source code directly in your project or as a git submodule.
+
+> If you are new to DirectX, you may want to start with [DirectX Tool Kit for DirectX 11](https://github.com/microsoft/DirectXTK/wiki/Getting-Started) to learn many important concepts for Direct3D programming, HLSL shaders, and the code patterns used in this project with a more 'noobie friendly' API.
 
 ## General Guidelines
 
@@ -30,19 +32,17 @@ These instructions define how GitHub Copilot should assist with this project. Th
 ## File Structure
 
 ```txt
-.azuredevops/
-.github/
-build/
-Audio/
-Inc/
-Src/
-  Shaders/
-Tests/
+.azuredevops/ # Azure DevOps pipeline configuration and policy files.
+.github/      # GitHub Actions workflow files and linter configuration files.
+build/        # Miscellaneous build files and scripts.
+Audio/        # DirectX Tool Kit for Audio implementation files.
+Inc/          # Public header files.
+Src/          # Implementation header and source files.
+  Shaders/    # HLSL shader files.
+Tests/        # Tests are designed to be cloned from a separate repository at this location.
 ```
 
-The `Inc` folder is for public header files, while the `Src` folder contains the implementation header and source files. The `Audio` folder contains DirectX Tool Kit for Audio implementation files.
-
-Note that DirectX Tool Kit for DirectX 12 utilizes the MakeSpriteFont C# tool and the XWBTool C++ Audio tool from DirectX Tool Kit for DirectX 11. See [MakeSpriteFont](https://github.com/microsoft/DirectXTK/tree/main/MakeSpriteFont) and [XWBTool](https://github.com/microsoft/DirectXTK/tree/main/XWBTool).
+> Note that *DirectX Tool Kit for DirectX 12* utilizes the `MakeSpriteFont` C# tool and the `XWBTool` C++ Audio tool hosted in the *DirectX Tool Kit for DirectX 11* repository. See [MakeSpriteFont](https://github.com/microsoft/DirectXTK/tree/main/MakeSpriteFont) and [XWBTool](https://github.com/microsoft/DirectXTK/tree/main/XWBTool).
 
 ## Patterns
 
@@ -76,3 +76,31 @@ Note that DirectX Tool Kit for DirectX 12 utilizes the MakeSpriteFont C# tool an
 - [Games for Windows and the DirectX SDK blog - May 2020](https://walbourn.github.io/directx-tool-kit-for-audio-updates-and-a-direct3d-9-footnote/)
 - [Games for Windows and the DirectX SDK blog - September 2021](https://walbourn.github.io/latest-news-on-directx-tool-kit/)
 - [Games for Windows and the DirectX SDK blog - October 2021](https://walbourn.github.io/directx-tool-kit-vertex-skinning-update/)
+
+## No speculation
+
+When creating documentation:
+
+### Document Only What Exists
+
+* Only document features, patterns, and decisions that are explicitly present in the source code.
+* Only include configurations and requirements that are clearly specified.
+* Do not make assumptions about implementation details.
+
+### Handle Missing Information
+
+* Ask the user questions to gather missing information.
+* Document gaps in current implementation or specifications.
+* List open questions that need to be addressed.
+
+### Source Material
+
+* Always cite the specific source file and line numbers for documented features.
+* Link directly to relevant source code when possible.
+* Indicate when information comes from requirements vs. implementation.
+
+### Verification Process
+
+* Review each documented item against source code whenever related to the task.
+* Remove any speculative content.
+* Ensure all documentation is verifiable against the current state of the codebase.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -35,6 +35,7 @@ These instructions define how GitHub Copilot should assist with this project. Th
 ```txt
 .azuredevops/ # Azure DevOps pipeline configuration and policy files.
 .github/      # GitHub Actions workflow files and linter configuration files.
+.nuget/       # NuGet package configuration files.
 build/        # Miscellaneous build files and scripts.
 Audio/        # DirectX Tool Kit for Audio implementation files.
 Inc/          # Public header files.

--- a/.github/linters/actionlint.yml
+++ b/.github/linters/actionlint.yml
@@ -1,0 +1,4 @@
+self-hosted-runner:
+  # Workaround until linter is updated
+  labels:
+    - windows-11-arm

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -3,7 +3,7 @@
 #
 # http://go.microsoft.com/fwlink/?LinkID=615561
 
-name: 'BVTs (x64)'
+name: 'CMake (Windows on ARM64)'
 
 on:
   push:
@@ -38,43 +38,40 @@ permissions:
 
 jobs:
   build:
-    runs-on: windows-2022
-    timeout-minutes: 20
+    runs-on: windows-11-arm
 
     strategy:
       fail-fast: false
 
       matrix:
-        toolver: ['14.29', '14']
-        build_type: [x64-Release]
-        arch: [amd64]
+        build_type: [arm64-Debug, arm64-Release, arm64-Debug-UWP, arm64-Release-UWP]
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Clone test repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          repository: walbourn/directxtk12test
-          path: Tests
-          ref: main
 
       - name: 'Install Ninja'
         run: choco install ninja
 
       - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
         with:
-          arch: ${{ matrix.arch }}
-          toolset: ${{ matrix.toolver }}
+          arch: arm64
 
       - name: 'Configure CMake'
         working-directory: ${{ github.workspace }}
-        run: cmake --preset=${{ matrix.build_type }} -DBUILD_TESTING=ON -DBUILD_BVT=ON
+        run: cmake --preset=${{ matrix.build_type }}
 
       - name: 'Build'
         working-directory: ${{ github.workspace }}
         run: cmake --build out\build\${{ matrix.build_type }}
 
-      - name: 'Run BVTs'
+      - name: 'Clean up'
         working-directory: ${{ github.workspace }}
-        run: ctest --preset=${{ matrix.build_type }} --output-on-failure
+        run: Remove-Item -Path out -Recurse -Force
+
+      - name: 'Configure CMake (DLL)'
+        working-directory: ${{ github.workspace }}
+        run: cmake --preset=${{ matrix.build_type }} -DBUILD_SHARED_LIBS=ON
+
+      - name: 'Build (DLL)'
+        working-directory: ${{ github.workspace }}
+        run: cmake --build out\build\${{ matrix.build_type }}

--- a/.github/workflows/arm64bvt.yml
+++ b/.github/workflows/arm64bvt.yml
@@ -3,7 +3,7 @@
 #
 # http://go.microsoft.com/fwlink/?LinkID=615561
 
-name: 'BVTs (x64)'
+name: 'CTest (BVTs)'
 
 on:
   push:
@@ -38,16 +38,14 @@ permissions:
 
 jobs:
   build:
-    runs-on: windows-2022
+    runs-on: windows-11-arm
     timeout-minutes: 20
 
     strategy:
       fail-fast: false
 
       matrix:
-        toolver: ['14.29', '14']
-        build_type: [x64-Release]
-        arch: [amd64]
+        build_type: [arm64-Release]
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -64,8 +62,7 @@ jobs:
 
       - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
         with:
-          arch: ${{ matrix.arch }}
-          toolset: ${{ matrix.toolver }}
+          arch: arm64
 
       - name: 'Configure CMake'
         working-directory: ${{ github.workspace }}

--- a/build/RestoreGDK.proj
+++ b/build/RestoreGDK.proj
@@ -1,0 +1,20 @@
+<!-- First update the GDKEditionNumber property in gdkedition.props -->
+
+<!-- nuget restore restoregdk.proj -packagesDirectory <outputdirectory> -->
+
+<Project Sdk="Microsoft.NET.Sdk">
+    <Import Project="gdkedition.props" />
+    <PropertyGroup>
+        <EditionYearMonth>$(GDKEditionNumber.Substring(0,2))$(GDKEditionNumber.Substring(2,2))</EditionYearMonth>
+        <EditionQFE>$(GDKEditionNumber.Substring(4,2).TrimStart('0'))</EditionQFE>
+        <EditionQFE Condition="'$(EditionQFE)'==''">0</EditionQFE>
+    </PropertyGroup>
+    <PropertyGroup>
+        <TargetFramework>net472</TargetFramework>
+        <Platforms>x64</Platforms>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.GDK.PC" Version="$(EditionYearMonth).$(EditionQFE).*" />
+        <PackageReference Include="Microsoft.GDK.Xbox" Version="$(EditionYearMonth).$(EditionQFE).*" />
+    </ItemGroup>
+</Project>

--- a/build/RestoreGDK.ps1
+++ b/build/RestoreGDK.ps1
@@ -1,0 +1,159 @@
+<#
+
+.SYNOPSIS
+Download and extract GDK NuGet based on edition number
+
+.DESCRIPTION
+This script determines the NuGet package id to use based on the provided GDK edition number. It makes use of MSBuild PackageReference floating version numbers to do the restore operation.
+
+.PARAMETER GDKEditionNumber
+The GDK edition number in the form of YYMMQQ.
+
+.PARAMETER OutputDirectory
+Directory to write the packages into. Path should not already contain the packages.
+
+#>
+
+param(
+    [Parameter(
+        Mandatory,
+        Position = 0
+    )]
+    [string]$GDKEditionNumber,
+    [Parameter(
+        Mandatory,
+        Position = 1
+    )]
+    [string]$OutputDirectory
+)
+
+# Validate output directory
+if ([string]::IsNullOrEmpty($OutputDirectory)) {
+    Write-Error "##[error]Output Directory is required" -ErrorAction Stop
+}
+
+# Parse edition number
+if (-not ($GDKEditionNumber -match '^([0-9][0-9])([0-9][0-9])([0-9][0-9])$')) {
+    Write-Error "##[error]This script requires a valid GDK edition number!" -ErrorAction Stop
+}
+
+$year = $Matches.1
+$month = [int]$Matches.2
+$qfe = [int]$Matches.3
+
+if ($year -lt 21)
+{
+    Write-Error "##[error]Edition year not supported: 20$year" -ErrorAction Stop
+}
+
+if (($month -lt 1) -or ($month -gt 12))
+{
+    Write-Error "##[error]Edition month not supported: $month" -ErrorAction Stop
+}
+
+if ($qfe -gt 0) {
+    Write-Host ("##[debug]GDKEditionNumber = $GDKEditionNumber ({0} 20{1} QFE {2})" -f (Get-Culture).DateTimeFormat.GetMonthName($month), $year, $qfe)
+}
+else {
+    Write-Host ("##[debug]GDKEditionNumber = $GDKEditionNumber ({0} 20{1})" -f (Get-Culture).DateTimeFormat.GetMonthName($month), $year)
+}
+
+# Verify NuGet tool is available
+$nuget = Get-Command nuget.exe -ErrorAction SilentlyContinue
+if (-Not $nuget) {
+    Write-Error "##[error]Missing required nuget.exe tool" -ErrorAction Stop
+}
+
+# Determine NuGet package ID
+if ($GDKEditionNumber -ge 241000) {
+    $PGDK_ID = "Microsoft.GDK.PC"
+    $GDKX_ID = "Microsoft.GDK.Xbox"
+}
+else {
+    Write-Error "##[error]Script supports October 2024 or later" -ErrorAction Stop
+}
+
+# Check that the package isn't already present
+$PGDK_DIR = [IO.Path]::Combine($OutputDirectory, $PGDK_ID)
+if (Test-Path $PGDK_DIR) {
+    Write-Error "##[error]PC Package ID already exists!" -ErrorAction Stop
+}
+
+$GDKX_DIR = [IO.Path]::Combine($OutputDirectory, $GDKX_ID)
+if (Test-Path $GDKX_DIR) {
+    Write-Error "##[error]Xbox Package ID already exists!" -ErrorAction Stop
+}
+
+# Restore Nuget packages using floating versions
+$propsfile = [IO.Path]::Combine( $PSScriptRoot , "gdkedition.props")
+$props = Get-Content -Path $propsfile
+$props = $props -replace '<GDKEditionNumber>.+</GDKEditionNumber>', ("<GDKEditionNumber>{0}</GDKEditionNumber>" -f $GDKEditionNumber)
+Set-Content -Path $propsfile -Value $props
+
+$nugetArgs = "restore RestoreGDK.proj -PackageSaveMode nuspec -packagesDirectory `"{0}`"" -f $OutputDirectory.TrimEnd('\')
+Write-Host "##[command]nuget $nugetArgs"
+$nugetrun = Start-Process -PassThru -Wait -FilePath $nuget.Path -WorkingDirectory $PSScriptRoot -ArgumentList $nugetArgs -NoNewWindow
+if ($nugetrun.ExitCode -gt 0) {
+    Write-Error "##[error]nuget restore failed" -ErrorAction Stop
+}
+
+# Verify expected output of restore
+if (-Not (Test-Path $PGDK_DIR)) {
+    Write-Error "##[error]Missing PC package after restore!" -ErrorAction Stop
+}
+
+if (-Not (Test-Path $GDKX_DIR)) {
+    Write-Error "##[error]Missing Xbox package after restore!" -ErrorAction Stop
+}
+
+# Reduce path depth removing version folder
+$PGDK_VER = Get-ChildItem $PGDK_DIR
+if ($PGDK_VER.Count -ne 1) {
+    Write-Error "##[error]Expected a single directory for the version!" -ErrorAction Stop
+}
+
+$content = Get-ChildItem $PGDK_VER.Fullname
+ForEach-Object -InputObject $content { Move-Item $_.Fullname -Destination $PGDK_DIR }
+Remove-Item $PGDK_VER.Fullname
+
+$GDKX_VER = Get-ChildItem $GDKX_DIR
+if ($GDKX_VER.Count -ne 1) {
+    Write-Error "##[error]Expected a single directory for the version!" -ErrorAction Stop
+}
+
+$content = Get-ChildItem $GDKX_VER.Fullname
+ForEach-Object -InputObject $content { Move-Item $_.Fullname -Destination $GDKX_DIR }
+Remove-Item $GDKX_VER.Fullname
+
+Write-Host ("##[debug]PC Package ID: {0}  Version: {1}" -f $PGDK_ID, $PGDK_VER)
+Write-Host ("##[debug]Xbox Package ID: {0}  Version: {1}" -f $GDKX_ID, $GDKX_VER)
+
+# Read the nuspec files
+$PGDK_NUSPEC = New-Object xml
+$PGDK_NUSPEC.PreserveWhitespace = $true
+$PGDK_NUSPEC.Load([IO.Path]::Combine($PGDK_DIR, $PGDK_ID + ".nuspec"))
+
+$GDKX_NUSPEC = New-Object xml
+$GDKX_NUSPEC.PreserveWhitespace = $true
+$GDKX_NUSPEC.Load([IO.Path]::Combine($GDKX_DIR, $GDKX_ID + ".nuspec"))
+
+# Log results
+Write-Host "##[group]PC Nuget Package nuspec"
+Write-host $PGDK_NUSPEC.outerxml
+Write-Host "##[endgroup]"
+
+Write-Host "##[group]Xbox Nuget Package nuspec"
+Write-host $GDKX_NUSPEC.outerxml
+Write-Host "##[endgroup]"
+
+$id = $PGDK_NUSPEC.package.metadata.id
+Write-Host "##vso[task.setvariable variable=PCNuGetPackage;]$id"
+
+$id = $GDKX_NUSPEC.package.metadata.id
+Write-Host "##vso[task.setvariable variable=XboxNuGetPackage;]$id"
+
+$ver = $PGDK_NUSPEC.package.metadata.version
+Write-Host "##vso[task.setvariable variable=PCNuGetPackageVersion;]$ver"
+
+$ver = $GDKX_NUSPEC.package.metadata.version
+Write-Host "##vso[task.setvariable variable=XboxNuGetPackageVersion;]$ver"

--- a/build/SetupBWOI.cmd
+++ b/build/SetupBWOI.cmd
@@ -13,7 +13,7 @@ goto needconsole
 set GXDKEDITION=%2
 echo GXDKEDITION: %GXDKEDITION%
 
-set PCNUGET=%1\Microsoft.GDK.PC.%GXDKEDITION%\
+set PCNUGET=%1\Microsoft.GDK.PC\
 if NOT EXIST %PCNUGET% goto missingpcnuget
 
 set GRDKLatest=%PCNUGET%native\%GXDKEDITION%\GRDK\
@@ -21,7 +21,7 @@ echo GRDKLatest: %GRDKLatest%
 
 if %3.==PC. goto grdkonly
 
-set XBOXNUGET=%1\Microsoft.gdk.xbox.%GXDKEDITION%\
+set XBOXNUGET=%1\Microsoft.gdk.xbox\
 if NOT EXIST %XBOXNUGET% goto missingxboxnuget
 
 set GXDKLatest=%XBOXNUGET%native\%GXDKEDITION%\GXDK\
@@ -68,9 +68,9 @@ echo Usage: This script requires the target type of PC, Scarlett, or XboxOne in 
 exit /b 1
 
 :missingpcnuget
-echo ERROR - Cannot find Microsoft.GDK.PC.<edition> installed at '%1'
+echo ERROR - Cannot find Microsoft.GDK.PC installed at '%1'
 exit /b 1
 
 :missingxboxnuget
-echo ERROR - Cannot find Microsoft.GDK.Xbox.<edition> installed at '%1'
+echo ERROR - Cannot find Microsoft.GDK.Xbox installed at '%1'
 exit /b 1

--- a/build/gdkedition.props
+++ b/build/gdkedition.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <GDKEditionNumber>000000</GDKEditionNumber>
+    </PropertyGroup>
+</Project>


### PR DESCRIPTION
* GitHub Actions using Windows on ARM64 native

* Updated Azure pipelines to stop using the windows-2019 image while still testing the v142 platform toolset.

* Some minor updates for the GDK pipelines for the package renaming as of October 2024.