### PR TITLE
Add Spectre-mitigated libraries to the NuGet

### DIFF
--- a/.nuget/directxtk12_desktop_2019.nuspec
+++ b/.nuget/directxtk12_desktop_2019.nuspec
@@ -54,14 +54,26 @@ WICTextureLoader - WIC-based image file texture loader</description>
         <file target="native\lib\x86\Debug" src="Bin\Desktop_2019_Win10\Win32\Debug\*.lib" />
         <file target="native\lib\x86\Debug" src="Bin\Desktop_2019_Win10\Win32\Debug\*.pdb" />
 
+        <file target="native\lib\x86\Debug" src="Bin\Desktop_2019_Win10\Win32\DebugSpectre\*.lib" />
+        <file target="native\lib\x86\Debug" src="Bin\Desktop_2019_Win10\Win32\DebugSpectre\*.pdb" />
+
         <file target="native\lib\x86\Release" src="Bin\Desktop_2019_Win10\Win32\Release\*.lib" />
         <file target="native\lib\x86\Release" src="Bin\Desktop_2019_Win10\Win32\Release\*.pdb" />
+
+        <file target="native\lib\x86\Release" src="Bin\Desktop_2019_Win10\Win32\ReleaseSpectre\*.lib" />
+        <file target="native\lib\x86\Release" src="Bin\Desktop_2019_Win10\Win32\ReleaseSpectre\*.pdb" />
 
         <file target="native\lib\x64\Debug" src="Bin\Desktop_2019_Win10\x64\Debug\*.lib" />
         <file target="native\lib\x64\Debug" src="Bin\Desktop_2019_Win10\x64\Debug\*.pdb" />
 
+        <file target="native\lib\x64\Debug" src="Bin\Desktop_2019_Win10\x64\DebugSpectre\*.lib" />
+        <file target="native\lib\x64\Debug" src="Bin\Desktop_2019_Win10\x64\DebugSpectre\*.pdb" />
+
         <file target="native\lib\x64\Release" src="Bin\Desktop_2019_Win10\x64\Release\*.lib" />
         <file target="native\lib\x64\Release" src="Bin\Desktop_2019_Win10\x64\Release\*.pdb" />
+
+        <file target="native\lib\x64\Release" src="Bin\Desktop_2019_Win10\x64\ReleaseSpectre\*.lib" />
+        <file target="native\lib\x64\Release" src="Bin\Desktop_2019_Win10\x64\ReleaseSpectre\*.pdb" />
 
         <file src=".nuget/directxtk12_desktop_2019.targets" target="build\native" />
 

--- a/.nuget/directxtk12_desktop_2019.targets
+++ b/.nuget/directxtk12_desktop_2019.targets
@@ -16,12 +16,14 @@
 
   <PropertyGroup>
     <directxtk12-LibPath>$(MSBuildThisFileDirectory)..\..\native\lib\$(PlatformTarget)\$(NuGetConfiguration)</directxtk12-LibPath>
+    <directxtk12-LibName Condition="'$(SpectreMitigation)'!='' AND '$(SpectreMitigation)'!='false'">DirectXTK12_Spectre</directxtk12-LibName>
+    <directxtk12-LibName Condition="'$(directxtk12-LibName)'==''">DirectXTK12</directxtk12-LibName>
   </PropertyGroup>
 
   <ItemDefinitionGroup>
     <Link>
       <AdditionalLibraryDirectories>$(directxtk12-LibPath);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>DirectXTK12.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(directxtk12-LibName).lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 

--- a/.nuget/directxtk12_desktop_win10.nuspec
+++ b/.nuget/directxtk12_desktop_win10.nuspec
@@ -56,20 +56,38 @@ DirectX Tool Kit for Audio in this package uses XAudio 2.9 which requires Window
         <file target="native\lib\x86\Debug" src="Bin\Desktop_2022_Win10\Win32\Debug\*.lib" />
         <file target="native\lib\x86\Debug" src="Bin\Desktop_2022_Win10\Win32\Debug\*.pdb" />
 
+        <file target="native\lib\x86\Debug" src="Bin\Desktop_2022_Win10\Win32\DebugSpectre\*.lib" />
+        <file target="native\lib\x86\Debug" src="Bin\Desktop_2022_Win10\Win32\DebugSpectre\*.pdb" />
+
         <file target="native\lib\x86\Release" src="Bin\Desktop_2022_Win10\Win32\Release\*.lib" />
         <file target="native\lib\x86\Release" src="Bin\Desktop_2022_Win10\Win32\Release\*.pdb" />
+
+        <file target="native\lib\x86\Release" src="Bin\Desktop_2022_Win10\Win32\ReleaseSpectre\*.lib" />
+        <file target="native\lib\x86\Release" src="Bin\Desktop_2022_Win10\Win32\ReleaseSpectre\*.pdb" />
 
         <file target="native\lib\x64\Debug" src="Bin\Desktop_2022_Win10\x64\Debug\*.lib" />
         <file target="native\lib\x64\Debug" src="Bin\Desktop_2022_Win10\x64\Debug\*.pdb" />
 
+        <file target="native\lib\x64\Debug" src="Bin\Desktop_2022_Win10\x64\DebugSpectre\*.lib" />
+        <file target="native\lib\x64\Debug" src="Bin\Desktop_2022_Win10\x64\DebugSpectre\*.pdb" />
+
         <file target="native\lib\x64\Release" src="Bin\Desktop_2022_Win10\x64\Release\*.lib" />
         <file target="native\lib\x64\Release" src="Bin\Desktop_2022_Win10\x64\Release\*.pdb" />
+
+        <file target="native\lib\x64\Release" src="Bin\Desktop_2022_Win10\x64\ReleaseSpectre\*.lib" />
+        <file target="native\lib\x64\Release" src="Bin\Desktop_2022_Win10\x64\ReleaseSpectre\*.pdb" />
 
         <file target="native\lib\ARM64\Debug" src="Bin\Desktop_2022_Win10\ARM64\Debug\*.lib" />
         <file target="native\lib\ARM64\Debug" src="Bin\Desktop_2022_Win10\ARM64\Debug\*.pdb" />
 
+        <file target="native\lib\ARM64\Debug" src="Bin\Desktop_2022_Win10\ARM64\DebugSpectre\*.lib" />
+        <file target="native\lib\ARM64\Debug" src="Bin\Desktop_2022_Win10\ARM64\DebugSpectre\*.pdb" />
+
         <file target="native\lib\ARM64\Release" src="Bin\Desktop_2022_Win10\ARM64\Release\*.lib" />
         <file target="native\lib\ARM64\Release" src="Bin\Desktop_2022_Win10\ARM64\Release\*.pdb" />
+
+        <file target="native\lib\ARM64\Release" src="Bin\Desktop_2022_Win10\ARM64\ReleaseSpectre\*.lib" />
+        <file target="native\lib\ARM64\Release" src="Bin\Desktop_2022_Win10\ARM64\ReleaseSpectre\*.pdb" />
 
         <file src=".nuget/directxtk12_desktop_win10.targets" target="build\native" />
 

--- a/.nuget/directxtk12_desktop_win10.targets
+++ b/.nuget/directxtk12_desktop_win10.targets
@@ -16,12 +16,14 @@
 
   <PropertyGroup>
     <directxtk12-LibPath>$(MSBuildThisFileDirectory)..\..\native\lib\$(PlatformTarget)\$(NuGetConfiguration)</directxtk12-LibPath>
+    <directxtk12-LibName Condition="'$(SpectreMitigation)'!='' AND '$(SpectreMitigation)'!='false'">DirectXTK12_Spectre</directxtk12-LibName>
+    <directxtk12-LibName Condition="'$(directxtk12-LibName)'==''">DirectXTK12</directxtk12-LibName>
   </PropertyGroup>
 
   <ItemDefinitionGroup>
     <Link>
       <AdditionalLibraryDirectories>$(directxtk12-LibPath);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>DirectXTK12.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(directxtk12-LibName).lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 

--- a/DirectXTK_Desktop_2019_Win10.vcxproj
+++ b/DirectXTK_Desktop_2019_Win10.vcxproj
@@ -290,6 +290,11 @@
     <IntDir>Bin\Desktop_2019_Win10\$(Platform)\$(Configuration)\</IntDir>
     <TargetName>DirectXTK12</TargetName>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(SpectreMitigation)'!='' AND '$(SpectreMitigation)'!='false'">
+    <OutDir>Bin\Desktop_2019_Win10\$(Platform)\$(Configuration)Spectre\</OutDir>
+    <IntDir>Bin\Desktop_2019_Win10\$(Platform)\$(Configuration)Spectre\</IntDir>
+    <TargetName>DirectXTK12_Spectre</TargetName>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>

--- a/DirectXTK_Desktop_2022_Win10.vcxproj
+++ b/DirectXTK_Desktop_2022_Win10.vcxproj
@@ -290,6 +290,11 @@
     <IntDir>Bin\Desktop_2022_Win10\$(Platform)\$(Configuration)\</IntDir>
     <TargetName>DirectXTK12</TargetName>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(SpectreMitigation)'!='' AND '$(SpectreMitigation)'!='false'">
+    <OutDir>Bin\Desktop_2022_Win10\$(Platform)\$(Configuration)Spectre\</OutDir>
+    <IntDir>Bin\Desktop_2022_Win10\$(Platform)\$(Configuration)Spectre\</IntDir>
+    <TargetName>DirectXTK12_Spectre</TargetName>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>


### PR DESCRIPTION
Customers using the BinSkim Microsoft security tool will get flagged when using static C++ libraries not built using /Qspectre. This adds the alternative flavor of the libraries to the directxtex_desktop_2019 and directxtex_desktop_win10 versions of the NuGet package. The targets automatically selects the Spectre version when building with SpectreMitigations enabled.

> The new packages are 67 MB and 101 MB in size, compared to the old ones which were 32 MB and 48 MB.