### PR TITLE
Upgrade to CMake 3.21

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-cmake_minimum_required (VERSION 3.20)
+cmake_minimum_required (VERSION 3.21)
 
 set(DIRECTXTK12_VERSION 1.6.3)
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": 2,
+  "version": 3,
   "configurePresets": [
     {
       "name": "base",
@@ -8,7 +8,7 @@
       "generator": "Ninja",
       "hidden": true,
       "binaryDir": "${sourceDir}/out/build/${presetName}",
-      "cacheVariables": { "CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/${presetName}" }
+      "installDir": "${sourceDir}/out/install/${presetName}"
     },
 
     {
@@ -164,12 +164,7 @@
     },
     {
       "name": "VCPKG",
-      "cacheVariables": {
-        "CMAKE_TOOLCHAIN_FILE": {
-          "value": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
-          "type": "FILEPATH"
-        }
-      },
+      "toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
       "hidden": true
     },
     {

--- a/Inc/DescriptorHeap.h
+++ b/Inc/DescriptorHeap.h
@@ -23,6 +23,7 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <stdexcept>
 
 #include <wrl/client.h>

--- a/Inc/GraphicsMemory.h
+++ b/Inc/GraphicsMemory.h
@@ -230,6 +230,9 @@ namespace DirectX
             DIRECTX_TOOLKIT_API GraphicsMemoryStatistics __cdecl GetStatistics();
             DIRECTX_TOOLKIT_API void __cdecl ResetStatistics();
 
+            // Properties
+            DIRECTX_TOOLKIT_API ID3D12Device* __cdecl GetDevice() const noexcept;
+
             // Singleton
             // Should only use nullptr for single GPU scenarios; mGPU requires a specific device
             DIRECTX_TOOLKIT_API static GraphicsMemory& __cdecl Get(_In_opt_ ID3D12Device* device = nullptr);

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ FOR SECURITY ADVISORIES, see [GitHub](https://github.com/microsoft/DirectXTK12/s
 
 For a full change history, see [CHANGELOG.md](https://github.com/microsoft/DirectXTK12/blob/main/CHANGELOG.md).
 
+* The CMake projects require 3.21 or later. VS 2019 users will need to install a standalone version of CMake 3.21 or later and add it to their PATH.
+
 * In the June 2024 release, the defaulted parameter `initialState` for the ``CreateUploadBuffer`` function in _BufferHelpers_ was removed. Per the DirectX 12 validation layer, the only valid initial state for an upload buffer is ``D3D12_RESOURCE_STATE_GENERIC_READ``.
 
 * Starting with the February 2023 release, the Mouse class implementation of relative mouse movement was updated to accumulate changes between calls to ``GetState``. By default, each time you call ``GetState`` the deltas are reset which works for scenarios where you use relative movement but only call the method once per frame. If you call it more than once per frame, then add an explicit call to ``EndOfInputFrame`` to use an explicit reset model instead.

--- a/Src/GraphicsMemory.cpp
+++ b/Src/GraphicsMemory.cpp
@@ -210,9 +210,7 @@ namespace
             stats.totalPages = totalPageCount;
         }
 
-    #if !(defined(_XBOX_ONE) && defined(_TITLE)) && !defined(_GAMING_XBOX)
         ID3D12Device* GetDevice() const noexcept { return mDevice.Get(); }
-    #endif
 
     private:
         ComPtr<ID3D12Device> mDevice;
@@ -330,6 +328,8 @@ public:
         m_peakPages = 0;
     }
 
+    ID3D12Device* GetDevice() const noexcept { return mDeviceAllocator ? mDeviceAllocator->GetDevice() : nullptr; }
+
     GraphicsMemory* mOwner;
 #if (defined(_XBOX_ONE) && defined(_TITLE)) || defined(_GAMING_XBOX)
     static GraphicsMemory::Impl* s_graphicsMemory;
@@ -413,6 +413,14 @@ GraphicsMemoryStatistics GraphicsMemory::GetStatistics()
 void GraphicsMemory::ResetStatistics()
 {
     pImpl->ResetStatistics();
+}
+
+ID3D12Device* GraphicsMemory::GetDevice() const noexcept
+{
+    if (!pImpl)
+        return nullptr;
+
+    return pImpl->GetDevice();
 }
 
 #if (defined(_XBOX_ONE) && defined(_TITLE)) || defined(_GAMING_XBOX)

--- a/Src/LoaderHelpers.h
+++ b/Src/LoaderHelpers.h
@@ -16,6 +16,10 @@
 #include "DDSTextureLoader.h"
 #include "PlatformHelpers.h"
 
+#include <algorithm>
+#include <memory>
+#include <new>
+#include <tuple>
 
 namespace DirectX
 {

--- a/Src/LoaderHelpers.h
+++ b/Src/LoaderHelpers.h
@@ -17,6 +17,8 @@
 #include "PlatformHelpers.h"
 
 #include <algorithm>
+#include <cfloat>
+#include <cmath>
 #include <memory>
 #include <new>
 #include <tuple>

--- a/Src/PlatformHelpers.h
+++ b/Src/PlatformHelpers.h
@@ -14,6 +14,7 @@
 #pragma warning(disable : 4324)
 #endif
 
+#include <cstdio>
 #include <exception>
 #include <memory>
 


### PR DESCRIPTION
CMake 3.21 comes with VS 2022.

> VS 2019 users will need to install a standalone version of a CMake newer than the 3.20 that comes with it.