### PR TITLE
Ensure projects using NuGet packages select correct input implementation

### DIFF
--- a/.nuget/directxtk12_desktop_2019.targets
+++ b/.nuget/directxtk12_desktop_2019.targets
@@ -29,7 +29,7 @@
 
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>HAS_DIRECTXTK12;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>HAS_DIRECTXTK12;USING_WINDOWS_GAMING_INPUT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>

--- a/.nuget/directxtk12_desktop_win10.targets
+++ b/.nuget/directxtk12_desktop_win10.targets
@@ -29,7 +29,7 @@
 
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>HAS_DIRECTXTK12;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>HAS_DIRECTXTK12;USING_WINDOWS_GAMING_INPUT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>

--- a/.nuget/directxtk12_uwp.targets
+++ b/.nuget/directxtk12_uwp.targets
@@ -27,7 +27,7 @@
 
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>HAS_DIRECTXTK12;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>HAS_DIRECTXTK12;USING_WINDOWS_GAMING_INPUT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>


### PR DESCRIPTION
The NuGet packages were relying on matching build settings to pick the 'correct' version of the input implementation. This ensures the consuming project builds consistently.