### PR TITLE
Fix dxc and fxc paths for non-Visual Studio builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,11 +293,13 @@ if(NOT USE_PREBUILT_SHADERS)
     elseif(BUILD_DXIL_SHADERS)
         find_program(DIRECTX_DXC_TOOL DXC.EXE
           HINTS "C:/Program Files (x86)/Windows Kits/10/bin/${CMAKE_SYSTEM_VERSION}/${DIRECTX_HOST_ARCH}"
+                "C:/Program Files (x86)/Windows Kits/10/bin/${CMAKE_SYSTEM_VERSION}.0/${DIRECTX_HOST_ARCH}"
                 "C:/Program Files (x86)/Windows Kits/10/bin/${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}/${DIRECTX_HOST_ARCH}")
         message(STATUS "Using DirectXShaderCompiler found in ${DIRECTX_DXC_TOOL}")
     else()
         find_program(DIRECTX_FXC_TOOL FXC.EXE
           HINTS "C:/Program Files (x86)/Windows Kits/10/bin/${CMAKE_SYSTEM_VERSION}/${DIRECTX_HOST_ARCH}"
+                "C:/Program Files (x86)/Windows Kits/10/bin/${CMAKE_SYSTEM_VERSION}.0/${DIRECTX_HOST_ARCH}"
                 "C:/Program Files (x86)/Windows Kits/10/bin/${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}/${DIRECTX_HOST_ARCH}")
         message(STATUS "Using LegacyShaderCompiler found in ${DIRECTX_FXC_TOOL}")
     endif()


### PR DESCRIPTION
Derived from https://github.com/microsoft/DirectXTex/pull/670.

Non-Visual Studio generators (e.g., Ninja) can now locate `dxc` and `fxc` without modifying environment variables.