### PR TITLE
Add overflow check to XWB reader

### DIFF
--- a/Audio/WaveBankReader.cpp
+++ b/Audio/WaveBankReader.cpp
@@ -37,6 +37,7 @@ namespace
     constexpr size_t DVD_BLOCK_SIZE = DVD_SECTOR_SIZE * 16;
 
     constexpr size_t ALIGNMENT_MIN = 4;
+    constexpr size_t ALIGNMENT_MAX = 0xFFFF;
     constexpr size_t ALIGNMENT_DVD = DVD_SECTOR_SIZE;
 
     constexpr size_t MAX_DATA_SEGMENT_SIZE = 0xFFFFFFFF;
@@ -608,7 +609,7 @@ HRESULT WaveBankReader::Impl::Open(const wchar_t* szFileName) noexcept(false)
         if (m_data.dwAlignment % DVD_SECTOR_SIZE)
             return E_FAIL;
     }
-    else if (m_data.dwAlignment < ALIGNMENT_MIN)
+    else if ((m_data.dwAlignment < ALIGNMENT_MIN) || (m_data.dwAlignment > ALIGNMENT_MAX))
     {
         return E_FAIL;
     }

--- a/Audio/WaveBankReader.cpp
+++ b/Audio/WaveBankReader.cpp
@@ -635,7 +635,14 @@ HRESULT WaveBankReader::Impl::Open(const wchar_t* szFileName) noexcept(false)
     }
 
     const DWORD metadataBytes = m_header.Segments[HEADER::SEGIDX_ENTRYMETADATA].dwLength;
-    if (metadataBytes != (m_data.dwEntryCount * m_data.dwEntryMetaDataElementSize))
+
+    uint64_t expectedSize = uint64_t(m_data.dwEntryCount) * m_data.dwEntryMetaDataElementSize;
+    if (expectedSize > MAX_DATA_SEGMENT_SIZE)
+    {
+        return HRESULT_FROM_WIN32(ERROR_ARITHMETIC_OVERFLOW);
+    }
+
+    if (metadataBytes != static_cast<DWORD>(expectedSize))
     {
         return E_FAIL;
     }
@@ -644,7 +651,13 @@ HRESULT WaveBankReader::Impl::Open(const wchar_t* szFileName) noexcept(false)
     const DWORD namesBytes = m_header.Segments[HEADER::SEGIDX_ENTRYNAMES].dwLength;
     if (namesBytes > 0)
     {
-        if (namesBytes >= (m_data.dwEntryNameElementSize * m_data.dwEntryCount))
+        expectedSize = uint64_t(m_data.dwEntryCount) * m_data.dwEntryNameElementSize;
+        if (expectedSize > UINT32_MAX)
+        {
+            return E_FAIL;
+        }
+
+        if (namesBytes >= static_cast<DWORD>(expectedSize))
         {
             std::unique_ptr<char[]> temp(new (std::nothrow) char[namesBytes]);
             if (!temp)


### PR DESCRIPTION
The XACT-style WaveBank format is fairly specialized and is almost certainly being created by *xwbtool* but there were a few places where a bad header could cause undetected overflows.