### PR TITLE
Update MinGW GitHub action to cover more compiler versions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -329,6 +329,17 @@ When reviewing documentation, do the following:
 - Read the documentation on the wiki located in [this git repository](https://github.com/microsoft/DirectXTK12.wiki.git).
 - Report any specific gaps in the documentation compared to the public interface.
 
+## Code Change Rules
+
+- Make precise, surgical changes that **fully** address the request. Don't modify unrelated code, but ensure changes are complete and correct.
+- Don't fix pre-existing issues unrelated to your task. However, if you discover bugs directly caused by or tightly coupled to the code you're changing, fix those too.
+- Update documentation if it is directly related to the changes you are making.
+- Always validate that your changes don't break existing behavior.
+- Only run linters, builds and tests that already exist. Do not add new linting, building or testing tools unless necessary.
+- Use the smallest targeted test, build, or lint command that covers the changed behavior.
+- Prefer ecosystem tools (package managers, scaffolding, refactoring tools, linters) over manual changes.
+- Only comment code that needs clarification. Do not comment otherwise.
+
 ## Release Process
 
 The release process is documented in the [release skill](.github/skills/release/SKILL.md). Invoke the `release` skill for step-by-step guidance when performing a release.

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -38,8 +38,6 @@ permissions:
 
 jobs:
   build:
-    runs-on: windows-2022
-
     strategy:
       fail-fast: false
 
@@ -47,6 +45,9 @@ jobs:
         build_type: [x64-Debug-MinGW, x64-Release-MinGW]
         shared: ['OFF', 'ON']
         gameinput: ['OFF', 'ON']
+        os: [windows-2022, windows-2025]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -107,4 +107,4 @@ jobs:
 
       - name: 'Build'
         working-directory: ${{ github.workspace }}
-        run: cmake --build out\build\${{ matrix.build_type }}
+        run: cmake --build out/build/${{ matrix.build_type }}

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ FOR SECURITY ADVISORIES, see [GitHub](https://github.com/microsoft/DirectXTK12/s
 
 For a full change history, see [CHANGELOG.md](https://github.com/microsoft/DirectXTK12/blob/main/CHANGELOG.md).
 
+* The _directxtk12_desktop_win10_ and _directxtk12_uwp_ NuGet packages are deprecated. The best way to integrate the latest DirectX Tool Kit into your C++ project is using [vcpkg](https://github.com/microsoft/vcpkg/tree/master/ports/directxtk12).
+
 * The CMake projects require 3.21 or later.
 
 * In the June 2024 release, the defaulted parameter `initialState` for the ``CreateUploadBuffer`` function in _BufferHelpers_ was removed. Per the DirectX 12 validation layer, the only valid initial state for an upload buffer is ``D3D12_RESOURCE_STATE_GENERIC_READ``.
@@ -172,4 +174,6 @@ Thanks to Roberto Sonnino for his help with the CMO format and the VS Starter Ki
 
 Thanks to Richie Meyer for their contribution of Xbox PIX custom memory and type allocation tracking events support.
 
-Thanks to Andrew Farrier and Scott Matloff for their on-going help with code reviews.
+Thanks to Andrew Farrier, Jon Martin, and Scott Matloff for their help with code reviews.
+
+Thanks to Shawn Hargreaves and Nada Ouf for their continued support for this library.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Copyright (c) Microsoft Corporation.
 
 This package contains the "DirectX Tool Kit", a collection of helper classes for writing Direct3D 12 C++ code for Win32 desktop applications for Windows 11 and Windows 10, game titles for Xbox Series X\|S and Xbox One, and Universal Windows Platform (UWP) apps for Windows 11 and Windows 10.
 
-This code is designed to build with Visual Studio 2022, Visual Studio 2026, clang for Windows v12 or later, or MinGW 12.2. Use of the Windows 10 May 2020 Update SDK ([19041](https://walbourn.github.io/windows-10-may-2020-update-sdk/)) or later is required for Visual Studio.
+This code is designed to build with Visual Studio 2022, Visual Studio 2026, clang for Windows v12 or later, or MinGW. Use of the Windows 10 May 2020 Update SDK ([19041](https://walbourn.github.io/windows-10-may-2020-update-sdk/)) or later is required for Visual Studio.
 
 These components are designed to work without requiring any content from the legacy DirectX SDK. For details, see [Where is the DirectX SDK?](https://aka.ms/dxsdk).
 


### PR DESCRIPTION
Added a second case to the MinGW GHA to test a different version of the compiler: current 14.2 and 15.2.

> Includes some readme and copilot instructions edits as well.