### PR TITLE
Use an absolute path for CompileShaders.cmd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,7 +318,7 @@ if(NOT USE_PREBUILT_SHADERS)
         MAIN_DEPENDENCY "${PROJECT_SOURCE_DIR}/Src/Shaders/CompileShaders.cmd"
         DEPENDS ${SHADER_SOURCES}
         COMMENT "Generating HLSL shaders..."
-        COMMAND ${CMAKE_COMMAND} -E env CompileShadersOutput="${COMPILED_SHADERS}" $<$<BOOL:${DIRECTX_DXC_TOOL}>:DirectXShaderCompiler=${DIRECTX_DXC_TOOL}> $<$<BOOL:${DIRECTX_FXC_TOOL}>:LegacyShaderCompiler=${DIRECTX_FXC_TOOL}> CompileShaders.cmd ARGS ${ShaderOpts} > "${COMPILED_SHADERS}/compileshaders.log"
+        COMMAND ${CMAKE_COMMAND} -E env CompileShadersOutput="${COMPILED_SHADERS}" $<$<BOOL:${DIRECTX_DXC_TOOL}>:DirectXShaderCompiler=${DIRECTX_DXC_TOOL}> $<$<BOOL:${DIRECTX_FXC_TOOL}>:LegacyShaderCompiler=${DIRECTX_FXC_TOOL}> "${PROJECT_SOURCE_DIR}/Src/Shaders/CompileShaders.cmd" ARGS ${ShaderOpts} > "${COMPILED_SHADERS}/compileshaders.log"
         WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/Src/Shaders"
         USES_TERMINAL)
 endif()


### PR DESCRIPTION
[Created by Copilot on behalf of @bghgary]

Same change as [microsoft/DirectXTK#660](https://github.com/microsoft/DirectXTK/pull/660), suggested by @walbourn there.

The shader build step names the script as a bare `CompileShaders.cmd`, which only resolves because Windows falls back to searching the current directory when looking up an executable. That fallback is disabled whenever [`NoDefaultCurrentDirectoryInExePath`](https://learn.microsoft.com/en-us/windows/win32/api/processenv/nf-processenv-needcurrentdirectoryforexepatha) is present in the environment — its presence alone is enough, the value is irrelevant — so any hardened build or automation environment fails with `Generating HLSL shaders...` followed by `no such file or directory`.

`WORKING_DIRECTORY` already points at `Src/Shaders`, so naming the script by absolute path keeps the same intent without relying on current-directory lookup.

Verified on Windows with the `Visual Studio 17 2022` generator, building the `DirectXTK12` target:

| | variable set | variable unset |
|---|---|---|
| before | fails: `no such file or directory`, `error MSB8066` | builds |
| after | builds | builds |

The shader step regenerated all 192 `.inc` files in each passing case, and produced none in the failing case.
